### PR TITLE
Establish ADR and developer-experience foundation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Outcome
+
+What observable result does this change deliver?
+
+## Verification
+
+- [ ] Relevant local checks pass
+- [ ] Public examples compile or execute
+- [ ] Security, accessibility and no-JavaScript behavior were considered
+- [ ] Documentation is updated with the implementation
+
+## Architecture decision
+
+- Related ADR: <!-- link, or write "Not required" and explain why -->
+- Why a new or updated ADR is or is not required:
+
+## Compatibility
+
+Describe effects on public APIs, protocols, generated code, server adapters, browser behavior and documented compatibility promises.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Documentation
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+      - "scripts/validate-adrs.sh"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+      - "scripts/validate-adrs.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-adrs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Validate architecture decisions
+        run: ./scripts/validate-adrs.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Woge
+
+Woge is early in development. Prefer small changes that prove one behavior and leave a clear path for the next vertical slice.
+
+## Architecture decisions
+
+Create or update an ADR when a change affects one of these contracts:
+
+- public Kotlin API;
+- browser or server protocol;
+- module or dependency boundaries;
+- security defaults or trust boundaries;
+- supported server, browser or build platforms;
+- compatibility promises.
+
+Small local implementation choices do not need an ADR. If a pull request intentionally does not require one, explain why in the pull-request template.
+
+Read the [ADR lifecycle](docs/adr/README.md) before proposing a decision. Do not edit the decision of an accepted ADR as though history changed; supersede it with a new ADR.
+
+## Documentation
+
+Public behavior needs documentation in the same change. Write for a web developer who may be new to Kotlin and follow the [documentation style guide](docs/documentation/style-guide.md).
+
+Examples must be complete enough to compile once the corresponding modules exist. Canonical examples will be tested and reused by tutorials instead of copied into several files.
+
+## Local checks
+
+The repository scaffold will eventually expose one Gradle verification task. Until then, validate the current documentation foundation with:
+
+```shell
+./scripts/validate-adrs.sh
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Woge
+
+Woge is an HTML-first Kotlin framework for typed, server-driven and progressively enhanced web applications.
+
+The project is in its architecture and product-validation phase. It is not ready for application use yet.
+
+## Direction
+
+- HTML, CSS, links, forms, HTTP, URLs and browser APIs remain visible.
+- Spring Boot is the primary host integration; Spring MVC, Spring WebFlux and Ktor use the same framework-neutral core.
+- JavaScript enhances a working web application instead of becoming a prerequisite for core workflows.
+- Kotlin types, generated descriptors and compiler diagnostics replace avoidable strings and runtime magic.
+- Accessibility and security are part of normal component and action behavior.
+- Plain CSS is always supported. Tailwind and the component distribution model are still being evaluated.
+
+## Project documentation
+
+- [Documentation index](docs/README.md)
+- [Architecture decisions](docs/adr/README.md)
+- [Documentation style guide](docs/documentation/style-guide.md)
+- [AI-assisted developer-experience criteria](docs/ai-dx/evaluation.md)
+- [Contributing](CONTRIBUTING.md)
+- [Roadmap](https://github.com/users/christian-draeger/projects/1)
+
+## License
+
+Woge is licensed under the [Apache License 2.0](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ The documentation grows with executable product slices. Pages describing unimple
 
 - [Project direction](../README.md)
 - [Architecture decision records](adr/README.md)
+- [Reference application](product/reference-application.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Woge documentation
+
+The documentation grows with executable product slices. Pages describing unimplemented behavior must say so clearly.
+
+## Start here
+
+- [Project direction](../README.md)
+- [Architecture decision records](adr/README.md)
+- [Documentation style guide](documentation/style-guide.md)
+- [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
+
+## Planned documentation layers
+
+1. **Quick start:** build one useful page with Spring Boot.
+2. **Mental model:** relate Woge pages, regions, actions and patches to HTML and HTTP.
+3. **Task guides:** solve forms, validation, streaming, live updates, styling and deployment.
+4. **API reference:** list exact types, defaults and compatibility constraints.
+5. **Internals:** explain protocols, generated code and adapter implementation.
+
+Only the architecture and quality foundations exist today. The quick start begins with the walking skeleton.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,32 @@
+# ADR NNNN: Short decision title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Decision owners: GitHub handles or team
+- Related issues: Links to evidence and implementation work
+
+## Context
+
+What problem requires a durable decision? State constraints and evidence, not only a preferred solution.
+
+## Decision
+
+What will Woge do? Be specific about boundaries and defaults.
+
+## Alternatives considered
+
+- **Alternative:** Why it was not selected.
+
+## Consequences
+
+### Positive
+
+- What becomes easier or safer.
+
+### Negative
+
+- Cost, limitation or follow-up work introduced by the decision.
+
+## Follow-up
+
+- Link implementation and verification work.

--- a/docs/adr/0001-web-native-product-boundary.md
+++ b/docs/adr/0001-web-native-product-boundary.md
@@ -1,0 +1,41 @@
+# ADR 0001: Keep Woge web-native and progressively enhanced
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#1](https://github.com/christian-draeger/woge/issues/1), [#5](https://github.com/christian-draeger/woge/issues/5), [#11](https://github.com/christian-draeger/woge/issues/11), [#75](https://github.com/christian-draeger/woge/issues/75)
+
+## Context
+
+Woge should give Kotlin developers typed, reactive server-driven applications without asking web developers to replace their knowledge of HTML, CSS, HTTP and browser behavior with a mobile UI mental model. Reactive convenience must not make basic navigation and mutations dependent on a large client runtime.
+
+## Decision
+
+Woge uses standards-shaped HTML, ordinary URLs, links and forms as its baseline. The server owns authoritative application state. A small browser runtime may enhance eligible interactions with streamed patches, but core workflows retain a useful no-JavaScript path.
+
+Application code can use normal classes, CSS, custom properties, data and ARIA attributes, custom elements and JavaScript modules. Woge will not introduce a virtual DOM, mandatory hydration graph or Kotlin replacement for CSS.
+
+## Alternatives considered
+
+- **Client-rendered SPA core:** rejected because it makes JavaScript, hydration and a client state model foundational.
+- **Compose-style universal UI model:** rejected because it hides browser semantics and conflicts with the intended web-developer mental model.
+- **Server-only pages without enhancement:** rejected because it does not meet the reactive interaction and streaming goals.
+
+## Consequences
+
+### Positive
+
+- Browser behavior remains inspectable and interoperable.
+- Accessibility, caching, navigation and forms can build on platform semantics.
+- Enhancement can fail back to a normal web request.
+
+### Negative
+
+- Native and enhanced paths both need conformance tests.
+- Some SPA-style local interactions require an explicit optional escape hatch.
+- Patch ownership and preservation rules must be specified carefully.
+
+## Follow-up
+
+- Define browser support and progressive enhancement in [#11](https://github.com/christian-draeger/woge/issues/11).
+- Prove styling and complex-application escape hatches in [#75](https://github.com/christian-draeger/woge/issues/75).

--- a/docs/adr/0002-framework-neutral-host-boundary.md
+++ b/docs/adr/0002-framework-neutral-host-boundary.md
@@ -1,0 +1,46 @@
+# ADR 0002: Put server frameworks behind Woge host adapters
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#9](https://github.com/christian-draeger/woge/issues/9), [#63](https://github.com/christian-draeger/woge/issues/63), [#64](https://github.com/christian-draeger/woge/issues/64), [#65](https://github.com/christian-draeger/woge/issues/65)
+
+## Context
+
+Spring Boot is the primary integration target, while Ktor remains important for Kotlin-native server applications and as proof that Woge does not depend on one host. Spring MVC, Spring WebFlux and Ktor expose different request, response, streaming and cancellation types.
+
+A generic clone of their HTTP APIs would either leak framework concepts or reduce all adapters to a weak lowest common denominator.
+
+## Decision
+
+The Woge core, protocol and application model own no Spring, Reactor, Servlet or Ktor types. Narrow host ports model Woge use cases such as page execution, action execution and live-update subscriptions. Adapters translate real framework requests, security context and lifecycle into those ports.
+
+Public portable APIs use Woge-owned types and Kotlin coroutine constructs where appropriate. Spring MVC, Spring WebFlux and Ktor must pass a shared adapter technology compatibility kit. Spring Boot is the primary quick-start and production documentation path; Ktor is a first-class alternative.
+
+Concrete port names and signatures remain provisional until exercised by the walking skeleton.
+
+## Alternatives considered
+
+- **Ktor types in the core:** rejected because Spring support would become a translation layer over another framework.
+- **Spring types in the core:** rejected for the symmetrical reason and because application components should remain portable.
+- **Universal HTTP request/response facade:** rejected because it would recreate framework APIs and obscure useful host capabilities.
+- **Separate Woge programming model per host:** rejected because component and protocol semantics would drift.
+
+## Consequences
+
+### Positive
+
+- Application and component code can run unchanged on each supported host.
+- Framework-specific lifecycle and security integration stay idiomatic inside adapters.
+- The shared TCK makes portability measurable.
+
+### Negative
+
+- Woge must maintain multiple adapters and real-server fixtures early.
+- Capabilities that cannot be expressed portably need explicit host escape hatches.
+- Streaming and cancellation differences must be documented instead of hidden.
+
+## Follow-up
+
+- Validate Spring MVC and WebFlux behavior in [#64](https://github.com/christian-draeger/woge/issues/64).
+- Implement the host SPI and adapter TCK in [#18](https://github.com/christian-draeger/woge/issues/18) and [#65](https://github.com/christian-draeger/woge/issues/65).

--- a/docs/adr/0003-web-first-documentation-and-ai-dx.md
+++ b/docs/adr/0003-web-first-documentation-and-ai-dx.md
@@ -1,0 +1,43 @@
+# ADR 0003: Use web-first documentation and compiler-guided AI DX
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#70](https://github.com/christian-draeger/woge/issues/70), [#71](https://github.com/christian-draeger/woge/issues/71), [#72](https://github.com/christian-draeger/woge/issues/72), [#74](https://github.com/christian-draeger/woge/issues/74)
+
+## Context
+
+The primary audience includes web developers who understand browser and HTTP concepts but have limited Kotlin experience. Coding models are also expected to create Woge applications reliably. Separate human and AI APIs would duplicate concepts and make correctness harder to evaluate.
+
+## Decision
+
+Documentation starts from familiar web concepts and introduces Kotlin syntax only when the current task needs it. Examples are canonical source files compiled or executed in CI, not copied snippets that can drift.
+
+Woge has one public application API for humans and coding models. It favors small orthogonal concepts, explicit types, deterministic generation and defaults, complete examples, and actionable source-located diagnostics. AI-assisted output must pass the same compiler, browser, accessibility and security checks as human-authored output.
+
+AI DX is evaluated with versioned, model-neutral tasks and measurable outcomes. Vendor-specific prompt conventions do not enter the public API.
+
+## Alternatives considered
+
+- **Kotlin-first reference documentation only:** rejected because it assumes knowledge the target audience may not have.
+- **Separate AI-facing DSL or metadata API:** rejected because it creates a second product contract and may weaken type safety.
+- **Documentation-only AI claims:** rejected because reliability requires compile, test and repair measurements.
+
+## Consequences
+
+### Positive
+
+- Web developers can transfer existing knowledge directly.
+- Compiler feedback supports both learning and automated repair.
+- Canonical examples expose documentation drift in CI.
+
+### Negative
+
+- Documentation and negative compile fixtures are implementation work, not a release afterthought.
+- Diagnostics and generated naming need compatibility discipline.
+- Model-based evaluation can vary, so deterministic checks remain the release gate.
+
+## Follow-up
+
+- Apply the writing rules in the [documentation style guide](../documentation/style-guide.md).
+- Define and baseline the evaluation in the [AI-DX criteria](../ai-dx/evaluation.md).

--- a/docs/adr/0004-project-operations-reference-application.md
+++ b/docs/adr/0004-project-operations-reference-application.md
@@ -1,0 +1,53 @@
+# ADR 0004: Use one project operations dashboard as the reference application
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#1](https://github.com/christian-draeger/woge/issues/1), [#2](https://github.com/christian-draeger/woge/issues/2), [#24](https://github.com/christian-draeger/woge/issues/24), [#75](https://github.com/christian-draeger/woge/issues/75), [#85](https://github.com/christian-draeger/woge/issues/85)
+
+## Context
+
+Woge needs one stable reference journey that exposes interactions between streaming, actions, concurrency, accessibility, styling and server adapters. Separate toy examples would make each feature look simpler while hiding integration failures and duplicating application code.
+
+The domain should be understandable without specialist knowledge and should grow from the walking skeleton into a polished, data-rich application.
+
+## Decision
+
+Woge uses a **project operations dashboard** as its primary reference application. One project page has an immediate semantic shell and three independently loaded regions:
+
+1. project summary metrics;
+2. a filterable task table;
+3. recent project activity.
+
+The core mutation journey creates a task with server validation and changes a task status. A successful mutation updates the task table and summary through typed region references. An authorized SSE event appends project activity and announces the update accessibly.
+
+The same application model runs on Spring MVC, Spring WebFlux and Ktor. Spring Boot is the primary quick-start host. Styling begins with plain CSS; the optional Tailwind path and richer component system enhance the same markup and behavior later.
+
+Implementation is staged by milestone. M1 proves the shell and deferred regions, M2 adds actions and live updates, M3 hardens behavior, and M4 adds the complete themed UI. Later stages must not replace the earlier journey with a different application.
+
+## Alternatives considered
+
+- **Commerce storefront:** useful for carts and optimistic updates, but pricing and checkout introduce unrelated domain and security complexity too early.
+- **AI assistant:** demonstrates streaming well, but does not naturally cover ordinary forms, tables and no-JavaScript CRUD.
+- **Independent feature demos:** make isolated documentation easy, but do not prove that the architecture composes into a real application.
+- **Administration CRUD only:** covers forms and tables but provides a weaker natural story for deferred metrics and live activity.
+
+## Consequences
+
+### Positive
+
+- Every milestone improves one recognizable application and shared test fixture.
+- The domain covers both simple HTML flows and complex frontend composition.
+- Hand-written, Woge, Spring and Ktor implementations can be compared directly.
+
+### Negative
+
+- The sample needs explicit fixture data and deterministic timing controls.
+- Access control, uploads and optimistic islands require later extensions to the core journey.
+- Documentation must distinguish currently implemented stages from the final reference design.
+
+## Follow-up
+
+- Maintain the journey and measurements in the [reference application specification](../product/reference-application.md).
+- Build the hand-written baseline in [#2](https://github.com/christian-draeger/woge/issues/2).
+- Deliver the first multi-host slice in [#24](https://github.com/christian-draeger/woge/issues/24).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0001](0001-web-native-product-boundary.md) | Accepted | Keep Woge web-native and progressively enhanced |
 | [0002](0002-framework-neutral-host-boundary.md) | Accepted | Put server frameworks behind Woge host adapters |
 | [0003](0003-web-first-documentation-and-ai-dx.md) | Accepted | Use web-first documentation and compiler-guided AI DX |
+| [0004](0004-project-operations-reference-application.md) | Accepted | Use one project operations dashboard as the reference application |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,32 @@
+# Architecture decision records
+
+ADRs preserve why Woge made a consequential choice, which alternatives were considered and what the choice costs. They complement tutorials and API reference; they do not replace them.
+
+## Lifecycle
+
+1. Copy [`0000-template.md`](0000-template.md) to the next free four-digit number and a short lowercase slug.
+2. Start with `Proposed`. Link the issue or pull request that supplies evidence.
+3. Record concrete alternatives and consequences before changing the status.
+4. Use one of: `Proposed`, `Accepted`, `Rejected`, `Deprecated`, or `Superseded`.
+5. Never rewrite an accepted decision to hide history. Add a new ADR and mark the old one `Superseded`, with links in both directions.
+6. Add every ADR to the index below.
+
+An ADR is required for changes to public APIs, protocols, module boundaries, security defaults, supported platforms or compatibility promises. A narrow implementation detail with no effect on those contracts is exempt.
+
+## Validation
+
+Run:
+
+```shell
+./scripts/validate-adrs.sh
+```
+
+The check validates filenames, required sections, metadata, duplicate numbers, index entries and local Markdown links.
+
+## Index
+
+| ADR | Status | Decision |
+| --- | --- | --- |
+| [0001](0001-web-native-product-boundary.md) | Accepted | Keep Woge web-native and progressively enhanced |
+| [0002](0002-framework-neutral-host-boundary.md) | Accepted | Put server frameworks behind Woge host adapters |
+| [0003](0003-web-first-documentation-and-ai-dx.md) | Accepted | Use web-first documentation and compiler-guided AI DX |

--- a/docs/ai-dx/evaluation.md
+++ b/docs/ai-dx/evaluation.md
@@ -1,0 +1,55 @@
+# AI-assisted developer-experience criteria
+
+AI friendliness in Woge means that a coding model can discover the normal API, produce a small correct application, and repair mistakes using compiler and test feedback. It does not mean adding an AI-specific framework layer.
+
+## Design criteria
+
+Public APIs should provide:
+
+- small concepts with one clear responsibility;
+- strong input, output and reference types;
+- deterministic generated names and source;
+- one obvious default form before advanced variants;
+- complete, compile-verified examples;
+- source-located errors that state the violated rule, received shape and a valid shape;
+- stable, searchable diagnostic identifiers where practical;
+- explicit security, accessibility and no-JavaScript behavior.
+
+Avoid magic strings, hidden global state, ambiguous overloads and several spellings for the same operation unless evidence justifies them.
+
+## Evaluation tasks
+
+The initial corpus will ask a participant to:
+
+1. serve a standards-compliant page with Spring Boot;
+2. add a typed route and ordinary link;
+3. submit and validate a typed form action;
+4. stream a deferred region;
+5. update two typed regions from one action;
+6. add an authorized live update;
+7. diagnose and repair deliberately invalid component and action signatures;
+8. style a responsive screen with ordinary CSS and with the optional Tailwind path.
+
+Each task starts from the same published consumer scaffold and public documentation. Hidden repository context or maintainer-only prompts are not allowed.
+
+## Measurements
+
+Record:
+
+- whether the clean consumer project compiles;
+- whether unit, adapter and browser tests pass;
+- unsafe or inaccessible behavior introduced;
+- invented APIs or dependencies;
+- number of compile-and-repair iterations;
+- unnecessary application code and duplicated concepts;
+- whether normal HTML and HTTP behavior remains intact.
+
+Human-authored and AI-assisted solutions have the same correctness gates. Model runs are evidence collected at milestones, not nondeterministic pull-request CI requirements.
+
+## Evaluation policy
+
+- Keep tasks and expected observable outcomes under version control.
+- Use more than one model family when practical, but never shape the public API around a vendor prompt format.
+- Convert repeated failure patterns into API, diagnostic or documentation issues.
+- Rerun the corpus before MVP API freeze and each compatibility release.
+- Publish limitations and methodology with results.

--- a/docs/documentation/style-guide.md
+++ b/docs/documentation/style-guide.md
@@ -1,0 +1,56 @@
+# Documentation style guide
+
+Woge documentation is written first for a web developer who knows HTML, CSS, JavaScript, URLs, requests and browser developer tools but may be opening a Kotlin project for the first time.
+
+## Start from the web
+
+- Say `form`, `link`, `HTTP response`, `HTML attribute` and `CSS class` when those are the real concepts.
+- Explain what Woge adds and what the browser already does.
+- Do not use mobile, Compose or virtual-DOM terminology as the default analogy.
+- Show the no-JavaScript behavior before explaining enhancement when both exist.
+- Keep ordinary HTML, CSS and JavaScript escape hatches visible.
+
+## Introduce Kotlin just in time
+
+Explain only syntax required by the current example. A page guide may briefly introduce a function, lambda and named argument; it should not detour into a complete language tutorial.
+
+When a Kotlin feature provides the safety being discussed, name the benefit in plain language:
+
+| Kotlin/Woge term | Web-oriented explanation |
+| --- | --- |
+| `data class` | A typed request or form value with named fields |
+| `suspend fun` | A function that can wait for work without owning a thread while it waits |
+| `Flow<T>` | A sequence of values that can arrive over time |
+| generated descriptor | A compiler-checked reference replacing a string URL, action or DOM target |
+| sealed result | A fixed set of outcomes the compiler requires the caller to handle |
+
+Link to deeper Kotlin material after the reader has completed the web task.
+
+## Structure a guide
+
+1. State the visible result.
+2. Show the smallest complete example with imports and host setup available nearby.
+3. Explain the web request and response behavior.
+4. Explain the Kotlin/Woge pieces introduced by the example.
+5. Show failure, accessibility and security behavior where relevant.
+6. Point to one next task and the exact API reference.
+
+Prefer one concept per example. Add an advanced composition only after the simple path works.
+
+## Keep examples trustworthy
+
+- Store each canonical example as executable source and include it in CI.
+- Do not maintain almost-identical snippets in several pages.
+- Include imports when ambiguity would make copying fail.
+- State the supported Woge and host versions.
+- Mark proposed or unimplemented APIs explicitly.
+- Show compiler errors using their real diagnostic text after diagnostics exist.
+
+## Writing rules
+
+- Lead with what the developer achieves.
+- Use short sentences and concrete nouns.
+- Define a Woge-specific term on first use.
+- Prefer a runnable example over a feature inventory.
+- Do not describe defaults as magic; name the convention and override point.
+- Do not claim simplicity by hiding network, security or browser behavior.

--- a/docs/product/reference-application.md
+++ b/docs/product/reference-application.md
@@ -1,0 +1,109 @@
+# Project operations reference application
+
+This document defines the product fixture used to evaluate Woge. It describes observable web behavior, not a proposed framework API.
+
+## User journey
+
+A user opens `/projects/{project}` and receives an immediate page shell containing:
+
+- a skip link, site navigation and one page heading;
+- project identity and ordinary navigation URLs;
+- semantic loading placeholders for three deferred regions;
+- a native link to the task-creation path.
+
+The server completes these regions independently:
+
+| Region | Content | Behavior to prove |
+| --- | --- | --- |
+| Project summary | Open, completed and overdue task counts | Fast deferred replacement |
+| Task table | Tasks, status, owner and due date | Slower data-rich replacement and later filtering |
+| Recent activity | Ordered project events | Deferred append and later SSE reuse |
+
+The deliberately slower task table may arrive after a region declared later. Tests control completion order instead of relying on sleeps.
+
+## Mutations and validation
+
+The first complete mutation flow supports:
+
+1. creating a task with a title, optional owner and optional due date;
+2. rejecting a blank title with a field error, summary and predictable focus;
+3. changing a task between open and completed;
+4. updating both project summary and task table after a successful mutation;
+5. appending an activity item and issuing a polite announcement.
+
+Native forms use normal names, methods and action URLs. Without JavaScript, successful mutations use Post/Redirect/Get and validation renders a useful HTML response. Enhanced requests may receive patches, but server validation and authorization remain authoritative.
+
+## Live update
+
+An authorized SSE subscription emits a new project activity event. Reconnection uses an event ID, and a duplicate or stale event cannot apply the same visible update twice. Without JavaScript, the activity page remains available through ordinary navigation and refresh.
+
+## Host matrix
+
+The application and component source is shared across:
+
+- Spring Boot with Spring MVC;
+- Spring Boot with Spring WebFlux;
+- Ktor.
+
+Only host bootstrap and framework integration may differ. Adapter tests assert equivalent status, headers, HTML, patch semantics, errors and cancellation where the host exposes it.
+
+## UI growth path
+
+The same page later expands to prove complex frontend work:
+
+- responsive application navigation;
+- task filtering, sorting and pagination in the URL;
+- dense but accessible form layouts;
+- dialog or drawer enhancement with a normal page fallback;
+- loading, empty, validation, partial-error and stale states;
+- light, dark, high-contrast and reduced-motion behavior;
+- replaceable plain-CSS and Tailwind themes.
+
+CSS classes never identify patch targets. UI behavior must not require Kotlin/JS, Kotlin/Wasm, hydration or a virtual DOM.
+
+## Measurements
+
+Record results against the hand-written Spring baseline before setting release budgets.
+
+### Developer experience
+
+- time from a clean consumer scaffold to the first rendered page;
+- time to add the first deferred region and typed action;
+- number of application-owned string URLs, action IDs and patch selectors;
+- number of files and lines needed for host-specific glue;
+- compile-error repair success for a web developer new to Kotlin and for the AI-DX corpus.
+
+### Web performance
+
+- time to first response byte and first shell byte;
+- time of each deferred patch relative to request start;
+- enhanced action round-trip and patch-apply time;
+- compressed base runtime and generated CSS size;
+- server render allocations and throughput under a documented fixture.
+
+### Reliability and compatibility
+
+- adapter TCK pass rate for all three hosts;
+- stable-browser and no-JavaScript journey pass rate;
+- stale or duplicate patch rejection rate in deterministic race fixtures;
+- disconnect cancellation and SSE reconnect behavior;
+- reproducibility of generated source and production assets.
+
+### Accessibility and security
+
+- keyboard-complete journey and predictable focus restoration;
+- automated violations plus a documented manual screen-reader review;
+- equivalent CSRF, validation and authorization behavior in native and enhanced requests;
+- strict-CSP and patch-injection fixture pass rate.
+
+Exact thresholds belong to the performance-budget decision after baseline data exists. A metric without a recorded environment, fixture and comparison is not accepted as evidence.
+
+## Milestone slices
+
+| Milestone | Reference result |
+| --- | --- |
+| M0 | Domain, baseline and measurement method are fixed |
+| M1 | Immediate shell and three deferred regions run on every host |
+| M2 | Typed forms, validation, multi-region updates and SSE complete the CRUD journey |
+| M3 | Security, accessibility, cancellation, browser and production behavior are hardened |
+| M4 | Navigation, themes and the accessible component catalog produce a polished complex application |

--- a/scripts/validate-adrs.sh
+++ b/scripts/validate-adrs.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -u
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+adr_directory="$repository_root/docs/adr"
+index_file="$adr_directory/README.md"
+failure_count=0
+
+fail() {
+  printf 'ADR validation: %s\n' "$1" >&2
+  failure_count=$((failure_count + 1))
+}
+
+if [[ ! -d "$adr_directory" ]]; then
+  printf 'ADR validation: missing docs/adr directory\n' >&2
+  exit 1
+fi
+
+if [[ ! -f "$index_file" ]]; then
+  printf 'ADR validation: missing docs/adr/README.md\n' >&2
+  exit 1
+fi
+
+duplicate_numbers=$(
+  find "$adr_directory" -maxdepth 1 -type f -name '[0-9][0-9][0-9][0-9]-*.md' \
+    | sed -E 's#^.*/([0-9]{4})-.*#\1#' \
+    | sort \
+    | uniq -d
+)
+
+if [[ -n "$duplicate_numbers" ]]; then
+  fail "duplicate ADR numbers: $(printf '%s' "$duplicate_numbers" | tr '\n' ' ')"
+fi
+
+while IFS= read -r adr_file; do
+  filename=$(basename "$adr_file")
+
+  if [[ ! "$filename" =~ ^[0-9]{4}-[a-z0-9]+(-[a-z0-9]+)*\.md$ ]]; then
+    fail "$filename does not match NNNN-lowercase-slug.md"
+    continue
+  fi
+
+  if [[ "$filename" == "0000-template.md" ]]; then
+    continue
+  fi
+
+  number=${filename:0:4}
+  required_patterns=(
+    "# ADR $number: "
+    "- Status: "
+    "- Date: "
+    "- Decision owners: "
+    "- Related issues: "
+    "## Context"
+    "## Decision"
+    "## Alternatives considered"
+    "## Consequences"
+    "## Follow-up"
+  )
+
+  for pattern in "${required_patterns[@]}"; do
+    if ! grep -Fq -- "$pattern" "$adr_file"; then
+      fail "$filename is missing '$pattern'"
+    fi
+  done
+
+  status=$(sed -nE 's/^- Status: (.*)$/\1/p' "$adr_file")
+  case "$status" in
+    Proposed|Accepted|Rejected|Deprecated|Superseded) ;;
+    *) fail "$filename has invalid status '$status'" ;;
+  esac
+
+  date_value=$(sed -nE 's/^- Date: (.*)$/\1/p' "$adr_file")
+  if [[ ! "$date_value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    fail "$filename has invalid date '$date_value'"
+  fi
+
+  if [[ "$status" == "Superseded" ]] && ! grep -Fq -- "- Superseded by:" "$adr_file"; then
+    fail "$filename is superseded but has no '- Superseded by:' link"
+  fi
+
+  if ! grep -Fq -- "($filename)" "$index_file"; then
+    fail "$filename is missing from docs/adr/README.md"
+  fi
+
+  while IFS= read -r linked_file; do
+    [[ -z "$linked_file" ]] && continue
+    if [[ ! -f "$(dirname "$adr_file")/$linked_file" ]]; then
+      fail "$filename links to missing local file '$linked_file'"
+    fi
+  done < <(sed -nE 's/.*\]\(([^:)#]+\.md)(#[^)]*)?\).*/\1/p' "$adr_file")
+done < <(find "$adr_directory" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | sort)
+
+if (( failure_count > 0 )); then
+  printf 'ADR validation failed with %d problem(s).\n' "$failure_count" >&2
+  exit 1
+fi
+
+printf 'ADR validation passed.\n'


### PR DESCRIPTION
## Outcome

Establish the decision and documentation foundation before public Woge APIs are implemented.

- adds the ADR lifecycle, template, index and four accepted foundation decisions
- fixes one project-operations reference journey across M0–M4
- records measurable DX, performance, reliability, accessibility and security evidence
- records the web-first documentation style and Kotlin learning bridge
- defines measurable, model-neutral AI-assisted developer-experience criteria
- validates ADR structure and local links locally and in GitHub Actions
- adds contribution guidance and a pull-request decision checklist

## Verification

- `bash -n scripts/validate-adrs.sh`
- `./scripts/validate-adrs.sh`
- negative validator fixture rejects an unsupported ADR status
- `git diff --check`

## Architecture decisions

- ADR 0001: web-native and progressively enhanced product boundary
- ADR 0002: framework-neutral host boundary with Spring Boot as the primary path
- ADR 0003: web-first documentation and compiler-guided AI DX
- ADR 0004: one project operations dashboard as the cross-milestone reference application

## Compatibility

Documentation and process foundation only. No public library API or runtime behavior exists yet.

Progresses #1, #70, #63, #71, and #72.