### PR TITLE
Validate the Spring MVC and WebFlux support model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Architecture decision records](adr/README.md)
 - [Reference application](product/reference-application.md)
 - [Hand-written Spring HTML baseline](../spikes/spring-html-htmx-baseline/evidence.md)
+- [Spring MVC and WebFlux support model](architecture/spring-support-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
 

--- a/docs/adr/0002-framework-neutral-host-boundary.md
+++ b/docs/adr/0002-framework-neutral-host-boundary.md
@@ -42,5 +42,5 @@ Concrete port names and signatures remain provisional until exercised by the wal
 
 ## Follow-up
 
-- Validate Spring MVC and WebFlux behavior in [#64](https://github.com/christian-draeger/woge/issues/64).
+- Apply the verified [Spring MVC and WebFlux support model](../architecture/spring-support-model.md).
 - Implement the host SPI and adapter TCK in [#18](https://github.com/christian-draeger/woge/issues/18) and [#65](https://github.com/christian-draeger/woge/issues/65).

--- a/docs/architecture/spring-support-model.md
+++ b/docs/architecture/spring-support-model.md
@@ -1,0 +1,97 @@
+# Spring MVC and WebFlux support model
+
+This M0 report records the evidence and support decision for issue
+[#64](https://github.com/christian-draeger/woge/issues/64). The executable fixture is the
+[hand-written Spring baseline](../../spikes/spring-html-htmx-baseline/README.md).
+
+## Decision
+
+Spring MVC and Spring WebFlux are both first-class Woge server adapters. They provide equivalent Woge page, action, patch and live-update semantics, but Woge does not promise identical threading or resource-use characteristics.
+
+The adapters remain separate modules. A shared Spring Boot starter owns common configuration and selects exactly one adapter from the Spring web application type. An application containing both stacks must choose explicitly rather than depending on classpath order.
+
+Portable application code owns no Servlet, Reactor, Spring Security, `SseEmitter`, `ServerWebExchange` or Spring session type. Each adapter snapshots the required request context into Woge-owned values and maps Woge outcomes back to its host response lifecycle.
+
+## Executable evidence
+
+Both baseline applications now provide:
+
+- a full semantic HTML response;
+- three delayed HTML-region responses;
+- native and enhanced form actions;
+- equivalent validation and redirect behavior;
+- a finite `text/event-stream` response with two ordered events;
+- a 404 response for an unknown project before streaming begins.
+
+MVC implements the stream with `SseEmitter`, an `AsyncTaskExecutor` and lifecycle callbacks. WebFlux returns a cold Kotlin `Flow<ServerSentEvent<String>>`. Their HTTP contract tests assert the same status, media type, event order and data.
+
+The spike also found two differences before tests normalized them:
+
+1. MVC accepted form-body values as individual `@RequestParam` arguments. WebFlux required a model object for equivalent form decoding.
+2. A `Flow` returned from a view-oriented WebFlux `@Controller` required an explicit `@ResponseBody` boundary, while MVC has a dedicated result handler for `SseEmitter`.
+
+## Support matrix
+
+| Concern | Spring MVC adapter | Spring WebFlux adapter | Woge contract |
+| --- | --- | --- | --- |
+| Full HTML and fragments | view rendering on Servlet request | reactive view rendering | byte-equivalent semantics, headers and escaping |
+| Waiting for application work | blocking work may use the request or configured worker thread | suspending work must not block the event loop | application outcome is portable; execution policy is adapter configuration |
+| Streaming writes | Servlet async response; each write is blocking on a worker | non-blocking response pipeline; SSE values flush individually | ordered frames and terminal outcome are portable |
+| Disconnect | detected when a write fails; heartbeat required for idle streams | subscriber cancellation propagates to the coroutine/Flow | cancellation signal reaches Woge execution; detection latency may differ |
+| Error before commit | normal Spring exception/status mapping | normal reactive exception/status mapping | typed Woge failure maps to the same HTTP contract |
+| Error after commit | terminate async response and diagnose | terminate publisher/connection and diagnose | no second status response; emit safe structured diagnostics |
+| Form decoding | Servlet parameter binding | form model/request-data binding | one Woge command decoder defines empty, missing and invalid values |
+| Locale and request context | often backed by thread-local/request objects | backed by reactive/coroutine context and exchange | immutable Woge snapshot at adapter ingress |
+| Session | `HttpSession` integration | `WebSession` integration | optional host capability; never a portable mutable session map |
+| Security | Servlet filter-chain context | reactive security context | authenticated principal/capabilities translated at ingress; domain authorization remains application-owned |
+| Blocking persistence | idiomatic for MVC | must run on an explicitly configured blocking dispatcher | supported, visible and measurable; never silently block a WebFlux event loop |
+
+Spring documents that MVC streaming releases the original Servlet request thread but performs individual writes on another thread, while WebFlux uses non-blocking I/O. It also documents that Servlet disconnects are discovered through failed writes and therefore need periodic heartbeats. See the [Spring MVC asynchronous request documentation](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-ann-async.html).
+
+For WebFlux, reactive multi-value responses are streamed rather than collected, and event-stream values are flushed individually. See [WebFlux controller return values](https://docs.spring.io/spring-framework/reference/web/webflux/controller/ann-methods/return-types.html) and [Spring coroutine support](https://docs.spring.io/spring-framework/reference/languages/kotlin/coroutines.html).
+
+## Port implications
+
+The future host SPI needs capabilities, not a generic HTTP facade:
+
+- **Page execution:** immutable request context in, streamed HTML/patch output out.
+- **Action execution:** typed command plus request context in, redirect/full-page/patch outcome out.
+- **Live subscription:** request context plus resume cursor in, cancellable flow of patch events out.
+- **Response metadata:** status, safe headers, cookies and cache directives represented by Woge-owned types.
+- **Cancellation:** a structured execution scope cancelled by adapter disconnect, timeout or shutdown.
+- **Host escape hatch:** explicit adapter-local access outside portable application/component APIs.
+
+The request snapshot should contain only stable values needed by portable code: method and canonical route data, locale, authenticated principal/capabilities, CSRF result, request correlation ID and negotiated enhancement capabilities. Raw framework requests and security contexts remain adapter-local.
+
+## Spring Boot module recommendation
+
+- `woge-host-spi`: Woge-owned ports and values only;
+- `woge-spring-mvc`: Servlet/MVC transport and lifecycle translation;
+- `woge-spring-webflux`: WebFlux/coroutine transport and lifecycle translation;
+- `woge-spring-boot-autoconfigure`: shared properties and conditional adapter selection;
+- `woge-spring-boot-starter`: primary consumer dependency with no application-facing framework fork.
+
+The starter should fail fast for ambiguous dual-stack configuration. Blocking-persistence support must require an explicit bounded executor/dispatcher with observable saturation rather than an undocumented global offload.
+
+## Required adapter-TCK scenarios
+
+Issue [#65](https://github.com/christian-draeger/woge/issues/65) must cover:
+
+- shell, fragment, native action and enhanced action parity;
+- empty, missing and malformed form fields;
+- ordered SSE events and per-event flush on a real server;
+- 404/error behavior before response commit;
+- safe termination and diagnostics after response commit;
+- disconnect and timeout cancellation, including heartbeat detection latency;
+- locale, principal, CSRF and correlation-context propagation;
+- blocking-work isolation and bounded-executor saturation;
+- graceful shutdown of active streams.
+
+## Known limitations of the M0 fixture
+
+- Mock-server tests verify SSE encoding and completion but not real proxy buffering or per-event wall-clock visibility.
+- No real Spring Security, session store or database is installed; their ownership is evaluated at the boundary only.
+- The MVC fixture uses the auto-configured task executor and is not a production sizing recommendation.
+- Heartbeats, resume cursors and long-lived authorization checks remain M2 work.
+
+These limitations are implementation/TCK work, not unresolved reasons to choose one Spring stack over the other.

--- a/spikes/spring-html-htmx-baseline/evidence.md
+++ b/spikes/spring-html-htmx-baseline/evidence.md
@@ -8,11 +8,11 @@ Recorded on 2026-09-03 for the source in this directory. Run `./measure.sh` to r
 | --- | ---: |
 | Shared Kotlin fixture | 116 |
 | Shared HTML templates and CSS | 274 |
-| Spring MVC host Kotlin | 163 |
-| Spring WebFlux host Kotlin | 177 |
-| Total | 730 |
+| Spring MVC host Kotlin | 208 |
+| Spring WebFlux host Kotlin | 206 |
+| Total | 804 |
 
-The application contains 25 occurrences of the application-owned `/projects/` route prefix across host code and templates. The templates contain two htmx target-selector occurrences and two unique selectors: `#task-create` and `#project-summary`.
+The application contains 27 occurrences of the application-owned `/projects/` route prefix across host code and templates. The templates contain two htmx target-selector occurrences and two unique selectors: `#task-create` and `#project-summary`.
 
 These are occurrence counts, not a claim that every string has a distinct semantic meaning. They measure how many places a route or patch-target refactor can touch in this small journey.
 
@@ -24,16 +24,18 @@ These are occurrence counts, not a claim that every string has a distinct semant
 | Form binding | form bodies can be read with individual `@RequestParam` arguments | form bodies require a model object; `@RequestParam` only covered query parameters in this spike |
 | Empty required title | arrived as an empty string | initially failed with 400 before validation until an explicit form object supplied a default |
 | Cancellation potential | blocking work needs explicit interruption/cooperation | coroutine cancellation can propagate through suspending work |
+| SSE shape | `SseEmitter` plus executor, timeout and completion callbacks | a cold `Flow<ServerSentEvent<String>>` |
+| Response-body declaration | `SseEmitter` has a dedicated MVC result handler | `Flow` on a view controller needs an explicit `@ResponseBody` boundary |
 | Template and domain reuse | shared | shared |
 
-The HTTP tests now require both hosts to return the same shell, full-page fallback, 422 validation response, redirect behavior and htmx multi-region response. Cancellation behavior is not yet asserted because the baseline has no cancellable data source.
+The HTTP tests now require both hosts to return the same shell, full-page fallback, 422 validation response, redirect behavior, htmx multi-region response and finite SSE event sequence. Cancellation behavior is not yet asserted against a real disconnected socket.
 
 ## Streaming and enhancement gaps
 
 - The immediate shell starts three independent htmx requests. It does not stream the shell and region patches through one response.
 - A slow MVC region occupies a servlet thread. The equivalent WebFlux delay suspends, but both controllers duplicate the same routes and rendering decisions.
 - htmx out-of-band swaps solve multi-region updates with string IDs and response-template conventions. Neither the compiler nor Spring verifies that the targets exist.
-- SSE, reconnect IDs, stale-event rejection and live authorization are intentionally absent from this M0 baseline.
+- The finite SSE fixture proves host mechanics only. Reconnect IDs, stale-event rejection, heartbeats and live authorization remain absent.
 - htmx is loaded from a CDN for the shortest realistic setup. Production would need a local asset, dependency update policy and CSP decision.
 - There is no client build, hydration, virtual DOM or Kotlin browser runtime.
 

--- a/spikes/spring-html-htmx-baseline/spring-mvc/src/main/kotlin/dev/woge/baseline/mvc/ProjectController.kt
+++ b/spikes/spring-html-htmx-baseline/spring-mvc/src/main/kotlin/dev/woge/baseline/mvc/ProjectController.kt
@@ -6,8 +6,10 @@ import dev.woge.baseline.shared.ProjectIdentity
 import dev.woge.baseline.shared.ProjectSnapshot
 import dev.woge.baseline.shared.ReferenceProjectStore
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.task.AsyncTaskExecutor
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,13 +17,16 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import org.springframework.web.server.ResponseStatusException
+import java.io.IOException
 import java.time.LocalDate
 
 @Controller
 class ProjectController(
     private val store: ReferenceProjectStore,
     private val delays: BaselineDelays,
+    private val taskExecutor: AsyncTaskExecutor,
 ) {
     @GetMapping("/projects/{project}")
     fun project(
@@ -56,6 +61,48 @@ class ProjectController(
         model.addAttribute("snapshot", requireSnapshot(project))
         model.addAttribute("oob", false)
         return "fragments/activity"
+    }
+
+    @GetMapping(
+        "/projects/{project}/activity/stream",
+        produces = [MediaType.TEXT_EVENT_STREAM_VALUE],
+    )
+    fun activityStream(@PathVariable project: String): SseEmitter {
+        val latestActivity = requireSnapshot(project).activity.first()
+        val emitter = SseEmitter(5_000L)
+        val task = taskExecutor.submit {
+            try {
+                pause(delays.activityMillis)
+                emitter.send(
+                    SseEmitter.event()
+                        .id("stream-ready")
+                        .name("status")
+                        .data("Activity stream ready", MediaType.TEXT_PLAIN),
+                )
+                pause(delays.activityMillis)
+                emitter.send(
+                    SseEmitter.event()
+                        .id("activity-${latestActivity.id}")
+                        .name("activity")
+                        .data(latestActivity.description, MediaType.TEXT_PLAIN),
+                )
+                emitter.complete()
+            } catch (cancelled: InterruptedException) {
+                Thread.currentThread().interrupt()
+                emitter.complete()
+            } catch (_: IOException) {
+                // The Servlet container owns the async error dispatch after a failed write.
+            }
+        }
+        emitter.onTimeout {
+            task.cancel(true)
+            emitter.complete()
+        }
+        emitter.onError { task.cancel(true) }
+        emitter.onCompletion {
+            if (!task.isDone) task.cancel(true)
+        }
+        return emitter
     }
 
     @PostMapping("/projects/{project}/tasks")

--- a/spikes/spring-html-htmx-baseline/spring-mvc/src/test/kotlin/dev/woge/baseline/mvc/MvcReferenceJourneyTest.kt
+++ b/spikes/spring-html-htmx-baseline/spring-mvc/src/test/kotlin/dev/woge/baseline/mvc/MvcReferenceJourneyTest.kt
@@ -7,6 +7,9 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content as mvcContent
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status as mvcStatus
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 
@@ -88,5 +91,24 @@ class MvcReferenceJourneyTest {
             status { is3xxRedirection() }
             redirectedUrl("/projects/woge?full=true")
         }
+    }
+
+    @Test
+    fun `activity stream flushes finite SSE events and rejects unknown projects before streaming`() {
+        val pending = mvc.get("/projects/woge/activity/stream") {
+            accept = MediaType.TEXT_EVENT_STREAM
+        }.andExpect {
+            request { asyncStarted() }
+        }.andReturn()
+
+        mvc.perform(asyncDispatch(pending))
+            .andExpect(mvcStatus().isOk)
+            .andExpect(mvcContent().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
+            .andExpect(mvcContent().string(containsString("id:stream-ready")))
+            .andExpect(mvcContent().string(containsString("event:activity")))
+            .andExpect(mvcContent().string(containsString("Reference project created")))
+
+        mvc.get("/projects/missing/activity/stream")
+            .andExpect { status { isNotFound() } }
     }
 }

--- a/spikes/spring-html-htmx-baseline/spring-webflux/src/main/kotlin/dev/woge/baseline/webflux/ProjectController.kt
+++ b/spikes/spring-html-htmx-baseline/spring-webflux/src/main/kotlin/dev/woge/baseline/webflux/ProjectController.kt
@@ -6,8 +6,12 @@ import dev.woge.baseline.shared.ProjectIdentity
 import dev.woge.baseline.shared.ProjectSnapshot
 import dev.woge.baseline.shared.ReferenceProjectStore
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.codec.ServerSentEvent
 import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
 
@@ -58,6 +63,31 @@ class ProjectController(
         model.addAttribute("snapshot", requireSnapshot(project))
         model.addAttribute("oob", false)
         return "fragments/activity"
+    }
+
+    @GetMapping(
+        "/projects/{project}/activity/stream",
+        produces = [MediaType.TEXT_EVENT_STREAM_VALUE],
+    )
+    @ResponseBody
+    fun activityStream(@PathVariable project: String): Flow<ServerSentEvent<String>> {
+        val latestActivity = requireSnapshot(project).activity.first()
+        return flow {
+            pause(delays.activityMillis)
+            emit(
+                ServerSentEvent.builder("Activity stream ready")
+                    .id("stream-ready")
+                    .event("status")
+                    .build(),
+            )
+            pause(delays.activityMillis)
+            emit(
+                ServerSentEvent.builder(latestActivity.description)
+                    .id("activity-${latestActivity.id}")
+                    .event("activity")
+                    .build(),
+            )
+        }
     }
 
     @PostMapping("/projects/{project}/tasks")

--- a/spikes/spring-html-htmx-baseline/spring-webflux/src/test/kotlin/dev/woge/baseline/webflux/WebFluxReferenceJourneyTest.kt
+++ b/spikes/spring-html-htmx-baseline/spring-webflux/src/test/kotlin/dev/woge/baseline/webflux/WebFluxReferenceJourneyTest.kt
@@ -99,4 +99,24 @@ class WebFluxReferenceJourneyTest {
             .expectStatus().is3xxRedirection
             .expectHeader().location("/projects/woge?full=true")
     }
+
+    @Test
+    fun `activity stream emits finite SSE events and rejects unknown projects before streaming`() {
+        client.get().uri("/projects/woge/activity/stream")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM)
+            .expectBody(String::class.java)
+            .value { body ->
+                assertThat(body).contains("id:stream-ready")
+                assertThat(body).contains("event:activity")
+                assertThat(body).contains("Reference project created")
+            }
+
+        client.get().uri("/projects/missing/activity/stream")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .exchange()
+            .expectStatus().isNotFound
+    }
 }


### PR DESCRIPTION
## Outcome

Validate first-class Spring MVC and WebFlux support with executable streaming evidence and a concrete adapter/starter recommendation.

- adds equivalent finite SSE endpoints to both baseline hosts
- uses `SseEmitter` plus explicit lifecycle callbacks for MVC
- uses a cold Kotlin `Flow<ServerSentEvent<String>>` for WebFlux
- extends HTTP tests with ordered SSE, media-type and pre-commit 404 contracts
- documents form binding, response-body, flush, cancellation, context, session, security and blocking-I/O differences
- defines separate MVC/WebFlux adapter modules behind one Spring Boot starter
- records required real-server TCK scenarios and honest M0 limitations

## Evidence

The streaming addition raises measured host-specific Kotlin from 340 to 414 lines. This reinforces the host-port boundary: portable behavior is shared, while request decoding, execution, response commit and cancellation translation stay in adapters.

## Verification

- `./scripts/validate-adrs.sh`
- `spikes/spring-html-htmx-baseline/measure.sh`
- `cd spikes/spring-html-htmx-baseline && ./gradlew test`
- `git diff --check`

## Deliberate follow-up

Real socket disconnect, proxy buffering, blocking-executor saturation and Spring Security/session integrations belong to the M1 adapter TCK and are listed explicitly in the report.

Closes #64.