### PR TITLE
Define and enforce initial module boundaries

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
       - ".github/workflows/docs.yml"
       - "docs/**"
       - "scripts/validate-adrs.sh"
+      - "scripts/validate-module-boundaries.sh"
+      - "config/architecture/module-boundaries.tsv"
   push:
     branches:
       - main
@@ -13,6 +15,8 @@ on:
       - ".github/workflows/docs.yml"
       - "docs/**"
       - "scripts/validate-adrs.sh"
+      - "scripts/validate-module-boundaries.sh"
+      - "config/architecture/module-boundaries.tsv"
 
 permissions:
   contents: read
@@ -25,3 +29,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate architecture decisions
         run: ./scripts/validate-adrs.sh
+      - name: Validate module boundaries
+        run: ./scripts/validate-module-boundaries.sh

--- a/config/architecture/module-boundaries.tsv
+++ b/config/architecture/module-boundaries.tsv
@@ -1,0 +1,11 @@
+# module	role	exposure	path	dependencies	optional_dependencies
+woge-core	foundation	public	modules/woge-core	-	-
+woge-protocol	protocol	public	modules/woge-protocol	woge-core	-
+woge-host-spi	port	public	modules/woge-host-spi	woge-core,woge-protocol	-
+woge-server-runtime	runtime	internal	modules/woge-server-runtime	woge-core,woge-protocol,woge-host-spi	-
+woge-adapter-tck	test-support	support	testing/woge-adapter-tck	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
+woge-spring-mvc	adapter	public	adapters/woge-spring-mvc	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
+woge-spring-webflux	adapter	public	adapters/woge-spring-webflux	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
+woge-ktor	adapter	public	adapters/woge-ktor	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
+woge-spring-boot-autoconfigure	integration	public	integrations/woge-spring-boot-autoconfigure	woge-host-spi	woge-spring-mvc,woge-spring-webflux
+woge-spring-boot-starter	integration	public	integrations/woge-spring-boot-starter	woge-spring-boot-autoconfigure	-

--- a/docs/adr/0006-initial-module-boundaries.md
+++ b/docs/adr/0006-initial-module-boundaries.md
@@ -1,0 +1,76 @@
+# ADR 0006: Enforce a small inward-pointing initial module graph
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#9](https://github.com/christian-draeger/woge/issues/9), [#18](https://github.com/christian-draeger/woge/issues/18), [#65](https://github.com/christian-draeger/woge/issues/65), [#66](https://github.com/christian-draeger/woge/issues/66), [#67](https://github.com/christian-draeger/woge/issues/67), [#68](https://github.com/christian-draeger/woge/issues/68), [#69](https://github.com/christian-draeger/woge/issues/69)
+
+## Context
+
+Woge needs enough separation to keep Spring MVC, Spring WebFlux and Ktor replaceable without turning the first build into dozens of tiny artifacts. The server [use-case ports](0005-server-host-use-case-ports.md) define ownership at runtime; the build must make the same boundary difficult to violate accidentally.
+
+The module graph also needs honest distinctions between stable user-facing API, implementation artifacts and reusable test support. Browser patch engines, local islands, CSS compilation and code generation still have unresolved M0 decisions and must not force dependencies into the server core prematurely.
+
+## Decision
+
+The initial build has ten modules. Every production dependency points inward toward Woge-owned web concepts and no host adapter depends on another host adapter.
+
+| Module | Responsibility | Exposure | Allowed direct dependencies |
+| --- | --- | --- | --- |
+| `woge-core` | HTML/component application model and portable value types | Public | None |
+| `woge-protocol` | Host-neutral document, patch and live frame values | Public | Core |
+| `woge-host-spi` | Page, action and live-update use-case ports | Public | Core, protocol |
+| `woge-server-runtime` | Shared dispatch and execution implementation | Internal implementation artifact | Core, protocol, host SPI |
+| `woge-adapter-tck` | Reusable adapter contract fixtures | Test-support artifact | Core, protocol, host SPI, runtime |
+| `woge-spring-mvc` | Servlet/Spring MVC transport mapping | Public integration | Core, protocol, host SPI, runtime |
+| `woge-spring-webflux` | Reactive Spring WebFlux transport mapping | Public integration | Core, protocol, host SPI, runtime |
+| `woge-ktor` | Ktor transport mapping | Public integration | Core, protocol, host SPI, runtime |
+| `woge-spring-boot-autoconfigure` | Conditional Spring Boot wiring and diagnostics | Public integration | Host SPI and optional MVC/WebFlux adapters |
+| `woge-spring-boot-starter` | Spring Boot dependency entry point | Public integration | Auto-configuration only |
+
+The source paths and exact required/optional dependency edges live in the machine-readable [`module-boundaries.tsv`](../../config/architecture/module-boundaries.tsv). The manifest is the source of truth until the Gradle scaffold exists; Gradle project declarations must then agree with it.
+
+`woge-core`, `woge-protocol`, `woge-host-spi` and `woge-server-runtime` are portable. Their source may not import Spring, Reactor, Servlet or Ktor packages. The first three are intentional public API surfaces. `woge-server-runtime` is published only as an implementation dependency required by adapters; its packages and declarations are documented as internal and are excluded from compatibility promises.
+
+The TCK depends inward and exports only Woge-owned fixtures and a small adapter-harness contract. Adapter production code never depends on the TCK. Each adapter consumes it from its test source set, so a framework-specific fixture cannot become part of the portable application corpus.
+
+Spring Boot auto-configuration may compile against both adapter APIs as optional dependencies, but it does not make both web stacks runtime dependencies. The manifest records those edges separately from required dependencies. Auto-configuration activates exactly one adapter based on the application classpath, following the [Spring support model](../architecture/spring-support-model.md). The starter owns the convenient entry point and auto-configuration metadata; transport behavior stays in the separate adapter artifacts.
+
+The initial graph deliberately excludes browser patch runtimes, a native-DPU encoder, local-island runtimes, CSS scoping/build tooling, component distribution and generated-descriptor processors. Their M0 spikes decide whether each deserves a module. Examples and benchmark applications are build consumers, not production modules.
+
+CI runs [`validate-module-boundaries.sh`](../../scripts/validate-module-boundaries.sh). It validates dependency existence, role direction, duplicate paths and cycles. As source directories appear, the same check rejects host-framework imports from portable modules. M1 adds Gradle dependency verification and public binary-API validation when there are compiled artifacts to inspect.
+
+## Alternatives considered
+
+- **One artifact containing core and all adapters:** rejected because it leaks host dependencies, pulls incompatible web stacks together and prevents meaningful architecture checks.
+- **A separate module for every conceptual type immediately:** rejected because module count would encode untested assumptions and make the walking skeleton expensive to change.
+- **Spring as the internal runtime abstraction:** rejected because Ktor would become a wrapper around Spring concepts and portable APIs could accidentally expose Reactor or Servlet types.
+- **Ktor as the internal runtime abstraction:** rejected for the symmetrical reason; Ktor remains a first-class adapter, not the definition of Woge's host boundary.
+- **Put TCK fixtures in each adapter:** rejected because semantic parity would drift and framework-specific tests could silently replace the shared contract.
+- **A starter that depends on both Spring web stacks:** rejected because classpath selection becomes ambiguous and every application pays for an unused stack.
+- **Create browser and styling modules now:** rejected until framing, fallback runtime, DPU, CSS and island spikes establish their actual boundaries.
+
+## Consequences
+
+### Positive
+
+- Framework leakage is prevented by both dependency direction and source checks.
+- Spring MVC, WebFlux and Ktor can evolve independently against one host contract.
+- Spring Boot remains the primary ergonomic entry point without owning transport semantics.
+- Internal implementation and test-support artifacts are visibly different from promised public APIs.
+- Unresolved browser and styling decisions cannot distort the first server build.
+
+### Negative
+
+- Ten modules are more build machinery than a single proof-of-concept artifact.
+- Auto-configuration needs optional classpath handling and explicit ambiguity diagnostics.
+- The server runtime crosses a module boundary despite not being public API.
+- Source-import checks are an early guardrail, not a substitute for compiled dependency and binary-API analysis.
+
+## Follow-up
+
+- Materialize the manifest in the Gradle scaffold and add dependency-verification tests in [#13](https://github.com/christian-draeger/woge/issues/13).
+- Add public binary-API validation while implementing the core and host SPI in [#17](https://github.com/christian-draeger/woge/issues/17) and [#18](https://github.com/christian-draeger/woge/issues/18).
+- Consume `woge-adapter-tck` only from adapter test source sets in [#65](https://github.com/christian-draeger/woge/issues/65).
+- Verify that the Spring Boot starter does not pull both web stacks in [#69](https://github.com/christian-draeger/woge/issues/69).
+- Add browser, CSS, island or code-generation modules only after their M0 ADRs establish a proven boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0003](0003-web-first-documentation-and-ai-dx.md) | Accepted | Use web-first documentation and compiler-guided AI DX |
 | [0004](0004-project-operations-reference-application.md) | Accepted | Use one project operations dashboard as the reference application |
 | [0005](0005-server-host-use-case-ports.md) | Accepted | Model server adapters as Woge use-case exchanges |
+| [0006](0006-initial-module-boundaries.md) | Accepted | Enforce a small inward-pointing initial module graph |

--- a/scripts/validate-module-boundaries.sh
+++ b/scripts/validate-module-boundaries.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -u
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+manifest="$repository_root/config/architecture/module-boundaries.tsv"
+failure_count=0
+
+fail() {
+  printf 'Module-boundary validation: %s\n' "$1" >&2
+  failure_count=$((failure_count + 1))
+}
+
+if [[ ! -f "$manifest" ]]; then
+  printf 'Module-boundary validation: missing %s\n' "$manifest" >&2
+  exit 1
+fi
+
+records=$(mktemp)
+edges=$(mktemp)
+trap 'rm -f "$records" "$edges"' EXIT
+
+grep -v '^[[:space:]]*#' "$manifest" | grep -v '^[[:space:]]*$' > "$records"
+[[ -s "$records" ]] || fail "manifest has no module rows"
+
+if awk -F '\t' 'NF != 6 { exit 1 }' "$records"; then
+  :
+else
+  fail "every manifest row must have six tab-separated columns"
+fi
+
+duplicates=$(cut -f1 "$records" | sort | uniq -d)
+[[ -z "$duplicates" ]] || fail "duplicate modules: $(printf '%s' "$duplicates" | tr '\n' ' ')"
+
+duplicate_paths=$(cut -f4 "$records" | sort | uniq -d)
+[[ -z "$duplicate_paths" ]] || fail "duplicate module paths: $(printf '%s' "$duplicate_paths" | tr '\n' ' ')"
+
+required_modules=(
+  woge-core
+  woge-protocol
+  woge-host-spi
+  woge-server-runtime
+  woge-adapter-tck
+  woge-spring-mvc
+  woge-spring-webflux
+  woge-ktor
+  woge-spring-boot-autoconfigure
+  woge-spring-boot-starter
+)
+
+for required_module in "${required_modules[@]}"; do
+  if ! awk -F '\t' -v name="$required_module" '$1 == name { found = 1 } END { exit !found }' "$records"; then
+    fail "missing required initial module '$required_module'"
+  fi
+done
+
+role_allows() {
+  case "$1:$2" in
+    protocol:foundation|port:foundation|port:protocol|runtime:foundation|runtime:protocol|runtime:port) return 0 ;;
+    adapter:foundation|adapter:protocol|adapter:port|adapter:runtime) return 0 ;;
+    test-support:foundation|test-support:protocol|test-support:port|test-support:runtime) return 0 ;;
+    integration:foundation|integration:protocol|integration:port|integration:runtime|integration:adapter|integration:integration) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while IFS=$'\t' read -r module role exposure source_path dependencies optional_dependencies; do
+  case "$role" in
+    foundation|protocol|port|runtime|adapter|integration|test-support) ;;
+    *) fail "$module has unknown role '$role'" ;;
+  esac
+
+  case "$exposure" in
+    public|internal|support) ;;
+    *) fail "$module has unknown exposure '$exposure'" ;;
+  esac
+
+  all_dependencies="$dependencies,$optional_dependencies"
+  all_dependencies=${all_dependencies//-,/}
+  all_dependencies=${all_dependencies//,-/}
+  [[ "$all_dependencies" == "-" ]] && continue
+
+  IFS=',' read -r -a dependency_list <<< "$all_dependencies"
+  for dependency in "${dependency_list[@]}"; do
+    dependency_record=$(awk -F '\t' -v name="$dependency" '$1 == name { print; exit }' "$records")
+    if [[ -z "$dependency_record" ]]; then
+      fail "$module depends on unknown module '$dependency'"
+      continue
+    fi
+
+    dependency_role=$(printf '%s\n' "$dependency_record" | cut -f2)
+    if ! role_allows "$role" "$dependency_role"; then
+      fail "$module ($role) may not depend on $dependency ($dependency_role)"
+    fi
+    printf '%s %s\n' "$module" "$dependency" >> "$edges"
+  done
+done < "$records"
+
+if [[ -s "$edges" ]] && ! tsort "$edges" >/dev/null 2>&1; then
+  fail "the declared project dependencies contain a cycle"
+fi
+
+for module in woge-core woge-protocol woge-host-spi woge-server-runtime; do
+  source_path=$(awk -F '\t' -v name="$module" '$1 == name { print $4; exit }' "$records")
+  [[ -n "$source_path" ]] || continue
+  [[ -d "$repository_root/$source_path" ]] || continue
+
+  forbidden_imports='^[[:space:]]*import[[:space:]]+(org\.springframework|reactor\.|jakarta\.servlet|javax\.servlet|io\.ktor)'
+  if command -v rg >/dev/null 2>&1; then
+    matches=$(rg -n --glob '*.kt' "$forbidden_imports" "$repository_root/$source_path" || true)
+  else
+    matches=$(grep -R -n -E --include='*.kt' "$forbidden_imports" "$repository_root/$source_path" || true)
+  fi
+  [[ -z "$matches" ]] || fail "$module imports a host framework:\n$matches"
+done
+
+if (( failure_count > 0 )); then
+  printf 'Module-boundary validation failed with %d problem(s).\n' "$failure_count" >&2
+  exit 1
+fi
+
+printf 'Module-boundary validation passed.\n'


### PR DESCRIPTION
## Summary
- accept ADR 0006 for the ten-module initial dependency graph
- distinguish public, internal, optional integration, and test-support boundaries
- add a machine-readable module manifest and CI validation for direction, cycles, and framework leakage

## Verification
- 
- ADR validation passed.
- Module-boundary validation passed.
- 

Closes #9