### PR TITLE
Baseline measurable AI-assisted developer experience

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
+- [AI-DX evaluation corpus](ai-dx/corpus-v0.1.md)
 
 ## Planned documentation layers
 

--- a/docs/ai-dx/corpus-v0.1.md
+++ b/docs/ai-dx/corpus-v0.1.md
@@ -1,0 +1,94 @@
+# AI-DX evaluation corpus v0.1
+
+This corpus defines model-neutral tasks and observable results. It deliberately does not prescribe Kotlin API names: the evaluated release's public quick start and API must make the canonical names discoverable. Tasks are cumulative and begin from the same clean Spring Boot consumer scaffold.
+
+## ADX-01 — First page
+
+Build a page at `/projects/{project}` with a document title, skip link, navigation landmark, one `h1` and the selected project's name. Link to it from the application home page using an ordinary URL.
+
+Expected outcome:
+
+- the project name is HTML-escaped;
+- valid and missing projects produce the documented status;
+- the page and link work with JavaScript disabled;
+- the application compiles and its page/browser checks pass.
+
+## ADX-02 — Typed route and link
+
+Add an optional `status` query input to the project page and create a link that selects open tasks. Rename the route input once and repair every affected call site using compiler feedback.
+
+Expected outcome:
+
+- links and route dispatch use the release's typed descriptors rather than duplicated path strings;
+- invalid input follows the documented typed decoding behavior;
+- the rename either updates safely or produces source-located actionable diagnostics.
+
+## ADX-03 — Form action and validation
+
+Add a form that creates a task with a required title, optional owner and optional ISO date. A blank title must show a linked error summary and field error while preserving submitted values.
+
+Expected outcome:
+
+- native `form`, `method`, `action`, names and controls remain visible in source/output;
+- successful HTML-only submission uses the documented redirect behavior;
+- native and enhanced paths share decoding, authorization, CSRF and validation;
+- invalid data cannot be mistaken for a successful action.
+
+## ADX-04 — Deferred region
+
+Render the page shell immediately, then render the project summary and task table as independently completing regions. Make the test control completion order without sleeps.
+
+Expected outcome:
+
+- one portable application implementation works through every required server adapter;
+- the enhancement path observes shell-first and completion-order output;
+- the HTML-only path remains useful and never strands the user at a loading placeholder;
+- cancellation stops outstanding child work.
+
+## ADX-05 — Multi-target action
+
+After creating a task, update the summary, task table and activity regions from one action.
+
+Expected outcome:
+
+- targets use typed rendered-region references, not hand-written CSS selectors;
+- a stale or unknown target fails safely;
+- focus and a concise completion announcement follow the documented contract;
+- the server remains authoritative for all three results.
+
+## ADX-06 — Authorized live update
+
+Subscribe to project activity and append one event. Reconnect from the last event and reject a duplicate or stale update.
+
+Expected outcome:
+
+- authorization occurs before the live response commits and remains scoped to the project;
+- event identity/revision behavior is deterministic;
+- disconnect cancels the producer;
+- ordinary navigation/refresh exposes the same data without JavaScript.
+
+## ADX-07 — Compiler-guided repair
+
+Start from the versioned negative fixture that intentionally supplies a page reference where an action target requires a rendered-region reference. Compile it, use only the diagnostic and public documentation to repair it, then rerun all checks.
+
+Expected outcome:
+
+- the invalid combination does not compile;
+- the diagnostic identifies the received and required concepts at the application source location;
+- a minimal valid example is discoverable without an internal repository search;
+- the participant repairs the fixture without casts, suppression or raw-string escape hatches.
+
+## ADX-08 — Standards-native styling
+
+Style the resulting responsive screen first with plain modern CSS, then replace the theme with the documented optional Tailwind path without changing page/action/component semantics.
+
+Expected outcome:
+
+- external CSS, classes, custom properties, data/ARIA attributes and the cascade remain ordinary web concepts;
+- the plain-CSS solution can use documented current features and fallbacks without a Kotlin property catalog;
+- Tailwind utilities remain string classes and generated assets remain compatible with streamed patches;
+- both variants pass the same accessibility and browser checks.
+
+## Versioning
+
+Changing expected behavior creates a new corpus version. Editorial clarification may update v0.1 when it does not alter success criteria. Every result names the exact corpus file commit. Versioned code fixtures land with the published scaffold and may refine concrete identifiers without weakening these outcomes.

--- a/docs/ai-dx/evaluation.md
+++ b/docs/ai-dx/evaluation.md
@@ -19,7 +19,7 @@ Avoid magic strings, hidden global state, ambiguous overloads and several spelli
 
 ## Evaluation tasks
 
-The initial corpus will ask a participant to:
+The versioned [v0.1 corpus](corpus-v0.1.md) asks a participant to:
 
 1. serve a standards-compliant page with Spring Boot;
 2. add a typed route and ordinary link;
@@ -46,6 +46,30 @@ Record:
 
 Human-authored and AI-assisted solutions have the same correctness gates. Model runs are evidence collected at milestones, not nondeterministic pull-request CI requirements.
 
+## Run protocol
+
+1. Start from a clean copy of the named published scaffold. Record its version, Woge version, JDK, Kotlin, Gradle, operating system and documentation commit.
+2. Give the participant only the canonical task, public documentation and normal compiler/test output. Record any additional clarification verbatim.
+3. Commit after each task so changed files, dependencies and application lines are attributable.
+4. Run the same deterministic compiler, unit, adapter, browser, accessibility and security checks for every participant.
+5. Record outcome and counts with the [result template](results/README.md). Do not store secrets, private prompts or model chain-of-thought.
+6. Treat a hard-gate failure as a failed task even if the screen appears correct. Do not average unsafe output into a passing score.
+
+Correction iterations count participant edits followed by a compiler or test run after the first submitted solution. Clarifying a task before editing is not a correction. An invented API is a referenced Woge type, function, annotation, configuration key or artifact that does not exist in the evaluated version. Unnecessary code is reported as added production files, dependencies and nonblank application lines relative to the human control; it is evidence for review, not an automatic failure.
+
+## Result interpretation
+
+| Signal | Pass expectation |
+| --- | --- |
+| Compile and deterministic tests | All pass |
+| Security/accessibility/no-JavaScript hard gates | No regression or bypass |
+| Invented Woge API | Zero in the final solution |
+| Corrections | Recorded per task; repeated patterns become diagnostic or documentation issues |
+| Added dependencies and code | No unexplained dependency; material excess over the control is reviewed |
+| Adapter portability | Shared application source remains unchanged across required hosts |
+
+The rubric rewards small orthogonal APIs, explicit types, deterministic defaults and actionable diagnostics by measuring whether participants discover the canonical path and repair invalid code. It does not reward generated-code volume or framework-specific shortcuts.
+
 ## Evaluation policy
 
 - Keep tasks and expected observable outcomes under version control.
@@ -53,3 +77,5 @@ Human-authored and AI-assisted solutions have the same correctness gates. Model 
 - Convert repeated failure patterns into API, diagnostic or documentation issues.
 - Rerun the corpus before MVP API freeze and each compatibility release.
 - Publish limitations and methodology with results.
+
+The [pre-API control](results/2026-09-03-pre-api-control.md) establishes the initial comparison and concrete design improvements. The first scored consumer run is tracked by [#93](https://github.com/christian-draeger/woge/issues/93) because it requires the published M1 scaffold.

--- a/docs/ai-dx/results/2026-09-03-pre-api-control.md
+++ b/docs/ai-dx/results/2026-09-03-pre-api-control.md
@@ -1,0 +1,50 @@
+# Pre-API AI-DX control — 2026-09-03
+
+This is an architecture control, not a scored Woge consumer run. It applies corpus v0.1 to the hand-written Spring HTML + htmx baseline before Woge has a public API or published scaffold. Its purpose is to expose the ceremony and unsafe gaps Woge must remove. The first comparable human/model consumer run is [#93](https://github.com/christian-draeger/woge/issues/93).
+
+## Environment
+
+- Date: 2026-09-03
+- Participant kind: maintainer-guided AI-assisted repository review
+- Corpus: [`corpus-v0.1.md`](../corpus-v0.1.md)
+- Starting point: [`spikes/spring-html-htmx-baseline`](../../../spikes/spring-html-htmx-baseline/README.md)
+- Toolchain: repository Gradle wrapper; exact dependency versions in the baseline version catalog
+- Hosts: Spring MVC and Spring WebFlux
+- Command: `./gradlew test`
+- Result: successful; 9 tests, 0 failures, 0 errors, 0 skipped
+
+The run used repository documentation because no public consumer documentation exists yet. It therefore cannot measure external discoverability and is not compared across model families.
+
+## Corpus coverage
+
+| Task | Control result | Evidence or gap |
+| --- | --- | --- |
+| ADX-01 first page | Partial pass | Semantic page and missing-project handling exist; route/link strings remain application-owned |
+| ADX-02 typed route | Fail | 27 `/projects/` occurrences have no generated typed descriptor or compile-safe rename path |
+| ADX-03 form/validation | Partial pass | Native/htmx validation behavior is tested, but authentication and CSRF are absent |
+| ADX-04 deferred region | Partial pass | Three requests complete independently; this is not one shell-first streamed response and cancellation lacks real disconnect tests |
+| ADX-05 multi-target | Partial pass | htmx out-of-band updates work through two CSS target selectors; targets are not typed |
+| ADX-06 live update | Partial pass | Both hosts emit a finite SSE sequence; authorization, reconnect, stale rejection and real disconnect cancellation are absent |
+| ADX-07 compiler repair | Not runnable | No Woge descriptors, negative fixture or Woge diagnostic exists yet |
+| ADX-08 styling | Partial pass | Plain CSS exists; modern CSS/Tailwind interchange and browser evidence are pending |
+
+Reproduced source measurements are 116 shared Kotlin lines, 274 template/CSS lines, 208 MVC host Kotlin lines and 206 WebFlux host Kotlin lines. There are 27 route-string occurrences, two htmx target-selector occurrences and two unique target selectors.
+
+## Metrics and limitations
+
+- Compile/test pass rate: 9 of 9 existing deterministic tests pass.
+- Unsafe behavior: two release-blocking categories are known—no authentication/authorization and no CSRF protection. Focus restoration and live-region verbosity also lack conformance evidence.
+- Invented Woge APIs: not measurable because no Woge API was offered to the participant.
+- Correction iterations: the baseline implementation recorded one host-parity correction when WebFlux form binding required an explicit form object instead of MVC-style individual request parameters. This was a runtime-contract discovery, not the future ADX-07 compile fixture.
+- Unnecessary application code proxy: 414 host-specific Kotlin lines and 27 route-string occurrences for a small shared journey.
+- Model comparison: intentionally absent; one repository-aware run cannot establish model reliability.
+
+## Improvements required before API freeze
+
+1. Generate one typed route/action/region vocabulary and make invalid cross-kind references fail at the application source location.
+2. Publish one Spring Boot consumer scaffold and canonical task guide with no maintainer-only setup.
+3. Make MVC, WebFlux and Ktor decode one typed form/action contract identically.
+4. Provide deterministic negative compile fixtures with stable diagnostic identifiers and a minimal valid repair example.
+5. Turn authorization, CSRF, no-JavaScript behavior, focus restoration, adapter parity and browser behavior into shared hard gates.
+6. Remove application-owned transport controllers and string patch selectors without hiding ordinary HTML, CSS or HTTP.
+7. Keep the actual consumer run separate from pull-request CI and record all environment/version inputs in [#93](https://github.com/christian-draeger/woge/issues/93).

--- a/docs/ai-dx/results/README.md
+++ b/docs/ai-dx/results/README.md
@@ -1,0 +1,43 @@
+# AI-DX result records
+
+Copy this template for every human or AI-assisted run. One file records one participant and one uninterrupted starting state.
+
+## Environment
+
+- Date:
+- Participant kind: human control or AI-assisted
+- Model family/version when disclosed:
+- Corpus path and commit:
+- Scaffold and Woge versions:
+- Documentation commit:
+- JDK, Kotlin and Gradle versions:
+- Operating system:
+- Starting commit:
+
+## Results
+
+| Task | Compile | Tests | Unsafe or inaccessible behavior | Invented APIs | Correction iterations | Added production files/dependencies/nonblank lines | Notes |
+| --- | --- | --- | --- | ---: | ---: | --- | --- |
+| ADX-01 |  |  |  |  |  |  |  |
+| ADX-02 |  |  |  |  |  |  |  |
+| ADX-03 |  |  |  |  |  |  |  |
+| ADX-04 |  |  |  |  |  |  |  |
+| ADX-05 |  |  |  |  |  |  |  |
+| ADX-06 |  |  |  |  |  |  |  |
+| ADX-07 |  |  |  |  |  |  |  |
+| ADX-08 |  |  |  |  |  |  |  |
+
+## Deterministic gates
+
+- Commands and exit status:
+- Adapter/browser matrix:
+- Security checks:
+- Accessibility and no-JavaScript checks:
+
+## Clarifications and correction log
+
+Record user-visible clarifications and compile/test iterations. Do not include hidden reasoning or chain-of-thought.
+
+## Follow-up
+
+List repeated failure patterns and linked API, diagnostic or documentation issues. Separate framework defects from participant mistakes.


### PR DESCRIPTION
## Summary

- version the model-neutral v0.1 AI-DX corpus with eight cumulative application tasks
- define hard gates, measurable counters, and a reusable result record
- record the pre-API Spring baseline and seven concrete improvements required before API freeze
- defer the first comparable published-scaffold consumer runs to #93

## Verification

- baseline `./gradlew test` (9 tests passed)
- baseline `./measure.sh`
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #72
