### PR TITLE
Define frontend extensibility and complex-screen acceptance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Hand-written Spring HTML baseline](../spikes/spring-html-htmx-baseline/evidence.md)
 - [Spring MVC and WebFlux support model](architecture/spring-support-model.md)
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)
+- [Frontend extensibility and complex-screen acceptance](architecture/frontend-extensibility.md)
 - [Threat model](security/threat-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)

--- a/docs/adr/0009-frontend-extension-contract.md
+++ b/docs/adr/0009-frontend-extension-contract.md
@@ -1,0 +1,64 @@
+# ADR 0009: Layer frontend extensions over semantic server HTML
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#4](https://github.com/christian-draeger/woge/issues/4), [#5](https://github.com/christian-draeger/woge/issues/5), [#21](https://github.com/christian-draeger/woge/issues/21), [#43](https://github.com/christian-draeger/woge/issues/43), [#75](https://github.com/christian-draeger/woge/issues/75), [#76](https://github.com/christian-draeger/woge/issues/76), [#77](https://github.com/christian-draeger/woge/issues/77), [#80](https://github.com/christian-draeger/woge/issues/80), [#88](https://github.com/christian-draeger/woge/issues/88)
+
+## Context
+
+Woge must support polished dashboards, dense forms, data tables, overlays, live feedback and application-specific interactions. A server-driven framework can fail this goal either by forbidding normal browser techniques or by adding a second opaque client framework that owns the DOM, styling and state.
+
+The intended audience already knows HTML, CSS and JavaScript. Tailwind and reusable component systems should be first-class options, but neither may define Woge's component semantics. Local client state is sometimes appropriate for continuous interaction, while core navigation and mutations still need useful HTML-only paths.
+
+## Decision
+
+Frontend extension is layered over semantic server HTML through four additive lanes: standards-shaped HTML, standards-native styling, small lifecycle-managed browser behavior and explicit local islands. The detailed ownership rules and complex-screen gates live in the [frontend extensibility contract](../architecture/frontend-extensibility.md).
+
+Every HTML element remains open to arbitrary classes, custom properties, `style`, `data-*`, `aria-*`, custom attributes and custom elements. Applications load normal stylesheets and external JavaScript modules. Woge does not create a comprehensive typed CSS-property DSL, a typed Tailwind-utility catalog or an internal CSS feature allowlist.
+
+Patch identity is independent from presentation. Generated rendered-region references, page epochs and revisions address updates; class names and arbitrary CSS selectors do not. Styling tools may change classes/assets without changing route, action, patch or progressive-enhancement semantics.
+
+Plain CSS is the zero-tooling baseline. Tailwind, CSS Modules-style generated names and optional component-local scoping are replaceable build/authoring adapters. Current and unknown valid CSS is preserved according to the browser policy. Exact IDE-injection and scoping mechanics are decided by [#88](https://github.com/christian-draeger/woge/issues/88).
+
+Small DOM behavior uses standard APIs through explicit mount/update/dispose ownership around patches. Native HTML capabilities such as dialog and popover are preferred when they satisfy the interaction. Core runtime and headless behavior require neither a virtual DOM nor an application-wide hydration graph.
+
+A local island is an explicit subtree for interaction that genuinely benefits from client rendering/state. Its adapter owns that subtree and documents serialization, lifecycle, browser support, CSP, bundle cost and fallback. The surrounding document, server-authoritative workflow and unrelated components remain independent. No Kotlin/JS, Kotlin/Wasm or JavaScript framework becomes mandatory through this escape hatch.
+
+The project operations screen and measurable matrix in the contract are the common acceptance fixture for CSS, Tailwind, component distribution, headless primitives and islands. A component demo alone cannot establish complex-application support.
+
+## Alternatives considered
+
+- **Server HTML plus no client extension points:** rejected because it cannot cover rich local interaction or established frontend tooling.
+- **Virtual DOM/hydration as the default:** rejected because it duplicates server state and asks web developers to adopt a client-framework ownership model for core workflows.
+- **Compose-style Kotlin UI abstraction:** rejected because it hides standard HTML/CSS concepts and does not match the target audience's browser knowledge.
+- **Tailwind as Woge's component API:** rejected because utility classes are a presentation choice and dynamic extraction/build rules would leak into portable semantics.
+- **A comprehensive typed Kotlin CSS DSL:** rejected because it would lag the CSS platform, multiply spellings and weaken existing IDE/browser documentation. Narrow typed design tokens remain possible.
+- **Arbitrary JavaScript mutating any Woge region without ownership:** rejected because patches, dirty controls, focus and third-party lifecycle would become nondeterministic.
+- **Require every interaction to have an equivalent no-JavaScript animation/widget:** rejected because some sensor/continuous interactions are inherently client-only; the containing task needs an honest fallback, not a fake equivalent.
+
+## Consequences
+
+### Positive
+
+- Web developers retain normal CSS, DOM, custom-element and module skills.
+- Tailwind and future styling tools remain optional and removable.
+- Complex client behavior has an explicit escape hatch without turning the whole application into an island.
+- Patch identity and accessibility behavior remain stable across visual themes.
+- One representative screen produces comparable evidence for component decisions.
+
+### Negative
+
+- Woge must specify patch/controller/island ownership and test their lifecycle carefully.
+- Plain CSS, Tailwind and optional behavior paths increase the integration-test matrix.
+- A source-owned component model may require update tooling and provenance metadata.
+- Some applications will deliberately cross out of portable server components and must own the extra browser dependencies.
+
+## Follow-up
+
+- Decide standards-native CSS literals and optional scoping in [#88](https://github.com/christian-draeger/woge/issues/88).
+- Run the Tailwind extraction/build spike in [#77](https://github.com/christian-draeger/woge/issues/77).
+- Compare source-owned, packaged/headless and hybrid component distribution in [#76](https://github.com/christian-draeger/woge/issues/76).
+- Implement the framework-neutral asset/attribute contract in [#78](https://github.com/christian-draeger/woge/issues/78).
+- Establish numeric runtime/CSS/interaction budgets from measured evidence in [#46](https://github.com/christian-draeger/woge/issues/46).
+- Keep local-island implementation outside the initial module graph until a later spike proves one concrete interaction and boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0006](0006-initial-module-boundaries.md) | Accepted | Enforce a small inward-pointing initial module graph |
 | [0007](0007-browser-support-and-progressive-enhancement.md) | Accepted | Guarantee an HTML baseline before browser enhancement |
 | [0008](0008-security-trust-boundaries.md) | Accepted | Make native and enhanced paths share secure boundaries |
+| [0009](0009-frontend-extension-contract.md) | Accepted | Layer frontend extensions over semantic server HTML |

--- a/docs/architecture/frontend-extensibility.md
+++ b/docs/architecture/frontend-extensibility.md
@@ -1,0 +1,71 @@
+# Frontend extensibility and complex-screen acceptance
+
+This document is the shared acceptance contract for styling, component-distribution and optional client-behavior work. It describes observable web behavior, not a proposed Kotlin API.
+
+## Extension lanes
+
+Woge supports four additive lanes. An application can stop after any lane.
+
+| Lane | Authoring surface | Ownership |
+| --- | --- | --- |
+| Semantic server HTML | Native elements, attributes, typed Woge pages/actions/regions | Server-authoritative and useful without JavaScript |
+| Standards-native styling | External CSS, stylesheet/declaration literals, classes, custom properties and cascade | Application; Woge transports strings and assets without a CSS allowlist |
+| Small browser behavior | External JavaScript modules, custom elements or headless controllers using standard DOM APIs | Application/component; lifecycle is explicit around patch application |
+| Local island | An explicit subtree with its own client renderer/state when browser-local interaction requires it | Island adapter inside a documented boundary; surrounding page remains server-owned |
+
+Tailwind, CSS Modules-style names and future style processors use the styling lane. They may generate assets or class names but cannot become the semantic component/action API. A local island is an escape hatch, not the default rendering model.
+
+## DOM and styling ownership
+
+- Region identity, patch targeting, revisions and focus keys use Woge metadata, never styling classes or arbitrary CSS selectors.
+- Every element accepts ordinary ordered classes, `style`, custom properties, `id`, `data-*`, `aria-*`, custom attributes and custom-element names. Woge does not interpret utility tokens or rewrite application class order.
+- A replace operation owns the server-rendered region subtree. Focus, dirty controls and explicitly preserved application state follow one patch-preservation contract; a third-party controller cannot assume arbitrary nodes survive replacement.
+- A local island owns only its declared root. Woge does not patch through that root unless the island's adapter has an explicit update/dispose contract. Island state is not silently treated as authoritative server state.
+- Headless behavior mounts, updates and disposes through a small lifecycle tied to real DOM nodes. It uses event delegation or custom-element lifecycle where suitable and requires no virtual DOM or application-wide hydration graph.
+- Component state and variants may be typed in Kotlin and rendered as semantic attributes/classes. CSS values and Tailwind utilities remain ordinary strings rather than generated Kotlin property/utility enums.
+- Page assets are normal stylesheet links and external module scripts with explicit URL, CSP nonce/integrity and loading semantics. Core flows require no inline executable handler.
+- Plain CSS and the HTML-only workflow are the reference implementation. Removing Tailwind, an optional controller or an island cannot change page/action/patch wire semantics.
+
+## Representative complex screen
+
+The project operations page is expanded into one coherent screen rather than a component gallery:
+
+- responsive application header, primary navigation and collapsible narrow-screen navigation;
+- project summary cards and live activity feedback;
+- URL-backed task filtering, sorting and pagination;
+- a dense create/edit form with grouped controls, validation summary and field messages;
+- a task data table that becomes a readable narrow-screen representation without losing header relationships;
+- a detail dialog or drawer enhancement with an ordinary page fallback;
+- loading, empty, partial-error, validation-error, stale-update and reconnect states;
+- light, dark, forced-colors/high-contrast and reduced-motion behavior;
+- one application-owned custom element or headless controller and one bounded local-island proof when that lane is implemented.
+
+All variants reuse the same page, action, component and region model. A styling or behavior option may add assets and attributes, but it cannot fork server business logic.
+
+## Measurable acceptance matrix
+
+| Area | Required check |
+| --- | --- |
+| Responsive layout | The journey is usable at 320 CSS px, a mid-size viewport and a wide desktop viewport with no hidden action or two-dimensional page overflow; intentional table overflow is labeled and keyboard reachable |
+| Keyboard/focus | The complete create/filter/update/dialog journey works without a pointer; patch replacement, removal, validation and navigation have deterministic focus outcomes |
+| Semantics | Landmarks, heading order, native labels, table relationships and status messages pass automated checks plus the published manual audit |
+| Preferences/themes | Light, dark, forced-colors and reduced-motion modes retain readable focus, contrast and state; information never depends on color or motion alone |
+| No JavaScript | Navigation, filtering, pagination, create/edit/status mutation and the dialog's task complete as ordinary page/form journeys; live data remains available by refresh |
+| Patch stability | Plain-CSS, Tailwind and custom-element variants produce the same target/revision outcomes; styling classes never affect identity; dirty value and focus fixtures pass |
+| CSS openness | Current selectors, at-rules, values and custom properties from the browser policy pass through unchanged; unknown valid syntax is not rejected by Woge |
+| Tool interchange | The same semantic component is rendered with plain CSS and Tailwind; removing either theme changes only classes/assets and presentation tests |
+| Optional behavior | Each controller/island records its external module bytes, lifecycle tests, CSP behavior, no-JavaScript fallback and supported-browser subset |
+| Performance | Reports separate compressed core runtime, each opt-in behavior, plain-CSS output, Tailwind output, first shell/patch timing and patch-apply time under the reference fixture |
+| AI/human DX | Corpus ADX-08 can find the normal class/CSS/module escape hatches and switch styling paths without invented Woge APIs or semantic changes |
+
+Numeric release limits belong to [#46](https://github.com/christian-draeger/woge/issues/46), after the first implementations provide evidence. Until then, a solution fails this contract if it silently adds an application-wide client framework, requires hydration for a core workflow, hides an unmeasured runtime/style asset, or cannot produce separate measurements.
+
+## Evidence required from dependent spikes
+
+- [#88](https://github.com/christian-draeger/woge/issues/88): external CSS, IDE-recognized literals, modern syntax preservation and optional deterministic scoping.
+- [#77](https://github.com/christian-draeger/woge/issues/77): Kotlin/generated-source extraction, static class rules, plain-CSS coexistence and reproducible Tailwind output.
+- [#76](https://github.com/christian-draeger/woge/issues/76): one substantially customized complex component in each viable source-owned, binary/headless or hybrid distribution model.
+- [#4](https://github.com/christian-draeger/woge/issues/4): cross-browser patch behavior with styling/custom-element preservation and no executable patch content.
+- [#80](https://github.com/christian-draeger/woge/issues/80): shared accessibility and lifecycle behavior for headless primitives.
+
+Evidence is comparable only when it uses this screen, state matrix and the [browser-support policy](browser-support-policy.md). Isolated visual demos can inform a decision but cannot satisfy the contract.


### PR DESCRIPTION
## Summary

- accept ADR 0009 for four additive frontend extension lanes over semantic server HTML
- define DOM, styling, headless-controller, custom-element, and local-island ownership
- establish one complex project-dashboard screen and measurable cross-cutting acceptance matrix
- make plain CSS the baseline while keeping Tailwind, scoping, and CSS Modules-style tooling removable adapters

## Verification

- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #75
