### PR TITLE
Validate the typed web-reference model

### DIFF
--- a/.github/workflows/typed-reference-spike.yml
+++ b/.github/workflows/typed-reference-spike.yml
@@ -1,0 +1,31 @@
+name: Typed reference spike
+
+on:
+  pull_request:
+    paths:
+      - "spikes/typed-reference-model/**"
+      - ".github/workflows/typed-reference-spike.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "spikes/typed-reference-model/**"
+      - ".github/workflows/typed-reference-spike.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: "21"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Validate positive and negative reference fixtures
+        run: ./spikes/typed-reference-model/validate.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)
 - [Frontend extensibility and complex-screen acceptance](architecture/frontend-extensibility.md)
 - [Component identity, page epochs and revisions](architecture/identity-and-revisions.md)
+- [Typed web-reference spike](../spikes/typed-reference-model/evidence.md)
 - [Threat model](security/threat-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)

--- a/docs/adr/0011-typed-web-references.md
+++ b/docs/adr/0011-typed-web-references.md
@@ -1,0 +1,70 @@
+# ADR 0011: Generate distinct typed descriptors for web references
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#7](https://github.com/christian-draeger/woge/issues/7), [#8](https://github.com/christian-draeger/woge/issues/8), [#19](https://github.com/christian-draeger/woge/issues/19), [#25](https://github.com/christian-draeger/woge/issues/25), [#26](https://github.com/christian-draeger/woge/issues/26), [#27](https://github.com/christian-draeger/woge/issues/27), [#28](https://github.com/christian-draeger/woge/issues/28), [#33](https://github.com/christian-draeger/woge/issues/33)
+
+## Context
+
+Woge needs refactor-safe links, actions and patch targets. A function reference such as `::CartSummary` knows a Kotlin function type, but it does not identify a route schema, one keyed rendering, a region owned by that rendering or a stable protocol descriptor. A generic string or `Ref<T>` makes distinct web concepts interchangeable when their payload happens to match.
+
+The [compile-checked spike](../../spikes/typed-reference-model/evidence.md) tested repeated instances, route/action separation, component-owned regions and invalid calls using ordinary Kotlin diagnostics.
+
+## Decision
+
+Code generation produces separate public descriptor kinds:
+
+- `PageRef<Parameters>` builds an ordinary URL from typed path/query input;
+- `ActionRef<Command, Result>` identifies one registered action and typed invocation;
+- `ComponentRef<ComponentType, Props>` identifies a component declaration;
+- `ComponentInstance<ComponentType, Props>` binds that declaration to one rendered key/input in a page epoch;
+- `RegionSlot<ComponentType, RegionInput>` is a named patchable slot declared by that component;
+- `RegionInstance<ComponentType, RegionInput>` binds the slot to one matching rendered component instance.
+
+Every generated component owns a nested nominal marker type. Region slots and component instances share that marker, so Kotlin rejects binding a `TaskRow` region to a `ProjectCard` even if props or region inputs are structurally identical. Repeated instances keep the same component marker and differ by a strongly typed explicit key under the [identity contract](0010-identity-epochs-and-revisions.md).
+
+Patch builders accept `RegionInstance`, never `PageRef`, `ComponentRef`, raw DOM ID or CSS selector. The region's input/model type remains in the descriptor so a target cannot be rendered with an unrelated payload. Routes and actions likewise remain distinct even when parameter/command classes match.
+
+Generated names are deterministic, singular and visible to completion/hover. The initial convention is a declaration-derived PascalCase descriptor (`ProjectPage`, `CreateTaskAction`, `TaskRow`) with generated nested input/marker types and lower-camel region properties (`TaskRow.status`). Generation sorts canonical declaration identities and rejects source-name, protocol-ID and route/action collisions. It does not generate ambiguous convenience overloads.
+
+Application authors use these as ordinary values and functions. No composition receiver, remembered state, recomposition or mobile lifecycle is introduced. Generated URL values become normal `href` strings at the HTML boundary, and host adapters register the same framework-neutral descriptors.
+
+Kotlin's normal type checker owns call-site mismatch diagnostics and already reports source location plus actual/expected shape. KSP declaration errors additionally provide a stable diagnostic identifier, violated rule, received declaration shape and minimal valid form. Positive and negative fixtures remain in the AI-DX corpus.
+
+Raw URLs and application-owned DOM/JavaScript remain available at explicit web escape hatches, but they cannot masquerade as typed Woge routes or targets. Host-specific extension descriptors stay in adapter modules.
+
+## Alternatives considered
+
+- **Raw function references:** rejected as the public reference model because they omit generated route/protocol identity, rendered instance, keys and region ownership.
+- **One generic `Ref<T>`:** rejected because page, action, component and region values with the same payload become interchangeable.
+- **Strings for routes and CSS selectors for targets:** rejected as the normal API because refactors, ownership and active-page validation become runtime-only.
+- **Component type equals rendered instance:** rejected because repeated and keyed renderings of one declaration cannot be addressed safely.
+- **Structural region typing by payload only:** rejected because two unrelated components often render the same view type.
+- **Compose-style receiver/state model:** rejected because typed references need nominal values, not recomposition or a new UI lifecycle.
+- **Encode every HTML/CSS concept as generated Kotlin types:** rejected because descriptors solve Woge-owned routing/patch identity; normal browser attributes/classes/styles remain web strings.
+
+## Consequences
+
+### Positive
+
+- Invalid page/action/target and cross-component combinations fail during compilation.
+- Repeated keyed instances remain expressive without generating per-instance declarations.
+- IDE completion exposes one canonical descriptor path and deterministic names help coding models.
+- Host adapters, URL builders and patch IR share one framework-neutral registry vocabulary.
+- The normal mental model remains page URL, form action, component instance and named HTML region.
+
+### Negative
+
+- Generated APIs contain generic marker types that can make error text verbose.
+- KSP naming and diagnostics become compatibility-sensitive public tooling.
+- Applications must provide typed keys for repeated patchable content.
+- Explicit escape hatches are more ceremony than raw strings.
+
+## Follow-up
+
+- Settle annotation/declaration syntax and implement deterministic KSP output in [#26](https://github.com/christian-draeger/woge/issues/26), [#27](https://github.com/christian-draeger/woge/issues/27) and [#28](https://github.com/christian-draeger/woge/issues/28).
+- Implement opaque rendered-instance/region IDs without exposing canonical keys in [#25](https://github.com/christian-draeger/woge/issues/25).
+- Use `RegionInstance` in Patch IR and multi-target update APIs in [#19](https://github.com/christian-draeger/woge/issues/19) and [#33](https://github.com/christian-draeger/woge/issues/33).
+- Preserve the spike's negative cases as stable compile-testing fixtures with KSP diagnostic IDs in [#74](https://github.com/christian-draeger/woge/issues/74).
+- Revisit only surface names after the first complete M1/M2 consumer examples; retain descriptor-kind and ownership separation unless superseded by new evidence.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0008](0008-security-trust-boundaries.md) | Accepted | Make native and enhanced paths share secure boundaries |
 | [0009](0009-frontend-extension-contract.md) | Accepted | Layer frontend extensions over semantic server HTML |
 | [0010](0010-identity-epochs-and-revisions.md) | Accepted | Scope rendered identity and revisions to a page epoch |
+| [0011](0011-typed-web-references.md) | Accepted | Generate distinct typed descriptors for web references |

--- a/spikes/typed-reference-model/.gitignore
+++ b/spikes/typed-reference-model/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/spikes/typed-reference-model/README.md
+++ b/spikes/typed-reference-model/README.md
@@ -1,0 +1,24 @@
+# Typed reference model spike
+
+This compile-checked spike tests the smallest type vocabulary needed to replace route and patch-target strings. It is evidence for ADR 0011, not production API source.
+
+Run:
+
+```shell
+./spikes/typed-reference-model/validate.sh
+```
+
+The script reuses the repository's existing Gradle wrapper, runs three positive tests and proves that three negative fixtures fail with Kotlin type diagnostics. See [evidence.md](evidence.md) for the result and trade-offs.
+
+## Web concept map
+
+| Familiar web concept | Proposed Kotlin descriptor |
+| --- | --- |
+| Page route plus path/query values | `PageRef<Parameters>` and `href(parameters)` |
+| Server action plus submitted command | `ActionRef<Command, Result>` and `invoke(command)` |
+| Reusable component definition | `ComponentRef<ComponentType, Props>` |
+| One keyed component in this document | `ComponentInstance<ComponentType, Props>` |
+| Named patchable place declared by a component | `RegionSlot<ComponentType, RegionInput>` |
+| That region on one rendered component instance | `RegionInstance<ComponentType, RegionInput>` |
+
+These are ordinary typed values. They do not introduce recomposition, remembered state or a Compose-style runtime.

--- a/spikes/typed-reference-model/build.gradle.kts
+++ b/spikes/typed-reference-model/build.gradle.kts
@@ -1,0 +1,41 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("jvm") version "2.4.0"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+        explicitApi()
+    }
+}
+
+dependencies {
+    testImplementation(kotlin("test-junit5"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+val negativeFixture = providers.gradleProperty("negativeFixture").orNull
+if (negativeFixture != null) {
+    require(negativeFixture.matches(Regex("[a-z0-9-]+"))) {
+        "negativeFixture must be a lowercase fixture name"
+    }
+    val fixtureDirectory = layout.projectDirectory.dir("fixtures/negative/$negativeFixture")
+    require(fixtureDirectory.asFile.isDirectory) {
+        "Unknown negative fixture: $negativeFixture"
+    }
+    sourceSets.main {
+        kotlin.srcDir(fixtureDirectory)
+    }
+    layout.buildDirectory = layout.projectDirectory.dir("build/negative-$negativeFixture")
+}

--- a/spikes/typed-reference-model/evidence.md
+++ b/spikes/typed-reference-model/evidence.md
@@ -1,0 +1,73 @@
+# Typed reference evidence
+
+Recorded on 2026-09-03 with Kotlin 2.4.0 and the repository Gradle 8.14.4 wrapper.
+
+## Positive cases
+
+Three tests compile and pass:
+
+1. a `PageRef` produces an ordinary percent-encoded URL while an `ActionRef` creates a typed invocation;
+2. `TaskRow` creates two distinct rendered instances from `TaskId(1)` and `TaskId(2)`;
+3. the generated `TaskRow.status` slot binds to each matching instance and `UpdateBuilder.replace` accepts only its `TaskStatusView` input.
+
+This is the minimal valid target shape:
+
+```kotlin
+val row = TaskRow.instance(
+    key = TaskId(1),
+    props = TaskRowProps("Write docs", completed = false),
+)
+val status = TaskRow.status.of(row, TaskStatusView(completed = true))
+
+UpdateBuilder().replace(status, TaskStatusView(completed = true))
+```
+
+Multiple component instances do not need generated names such as `TaskRow1` and `TaskRow2`; the descriptor type stays `TaskRow.Type`, while the typed key distinguishes each `ComponentInstance`.
+
+## Negative compiler fixtures
+
+All diagnostics are source-located and report actual versus expected concepts.
+
+Using a page descriptor as a patch target:
+
+```text
+PageAsRegion.kt:8:29 Argument type mismatch: actual type is 'ProjectPage',
+but 'RegionInstance<..., TaskStatusView>' was expected.
+```
+
+Binding a `TaskRow` region to a rendered `ProjectCard`:
+
+```text
+WrongComponentOwner.kt:11:23 Argument type mismatch:
+actual type is 'ComponentInstance<ProjectCard.Type, ProjectCardProps>',
+but 'ComponentInstance<TaskRow.Type, *>' was expected.
+```
+
+Passing a string where a typed component key is required:
+
+```text
+WrongComponentKey.kt:7:22 Argument type mismatch: actual type is 'String',
+but 'TaskId' was expected.
+```
+
+The compiler supplies the source location and expected/received shape. Public documentation must place the valid pattern next to generated KSP diagnostics; custom diagnostics should add a stable searchable ID when generation rejects a declaration before ordinary type checking can run.
+
+## Naming and generation assessment
+
+The prototype uses one generated singleton per declaration and one nested nominal marker type per component:
+
+- page `projectPage` → `ProjectPage` with nested `Parameters`;
+- action `createTask` → `CreateTaskAction` with explicit command/result types;
+- component `taskRow` → `TaskRow`, nested unconstructable `Type`, and region property `status`;
+- no generated overload differs only by receiver magic or erased generic type.
+
+Generation must sort canonical declaration IDs, reject naming/route/action collisions and produce byte-stable source for unchanged inputs. A component's nominal marker exists only to prevent cross-component binding; application authors never instantiate or persist it.
+
+## Alternatives observed
+
+- A raw function reference carries a Kotlin function signature but not route templates, generated URL encoding, region ownership, stable protocol ID or key requirements.
+- A single `Ref<T>` makes page/action/region misuse possible whenever payload types coincide.
+- String routes and CSS targets are easy to escape into but lose compiler refactoring and active-page target validation.
+- Encoding rendered instances as a Compose-style receiver/state scope adds unfamiliar lifecycle semantics that this problem does not need.
+
+The main cost of the nominal model is generic type verbosity in diagnostics and generated API signatures. Generated singleton names and nested marker types keep that cost out of normal call sites.

--- a/spikes/typed-reference-model/fixtures/negative/page-as-region/PageAsRegion.kt
+++ b/spikes/typed-reference-model/fixtures/negative/page-as-region/PageAsRegion.kt
@@ -1,0 +1,9 @@
+package dev.woge.spike.references.negative
+
+import dev.woge.spike.references.ProjectPage
+import dev.woge.spike.references.TaskStatusView
+import dev.woge.spike.references.UpdateBuilder
+
+public fun invalidPageTarget() {
+    UpdateBuilder().replace(ProjectPage, TaskStatusView(completed = true))
+}

--- a/spikes/typed-reference-model/fixtures/negative/wrong-component-key/WrongComponentKey.kt
+++ b/spikes/typed-reference-model/fixtures/negative/wrong-component-key/WrongComponentKey.kt
@@ -1,0 +1,8 @@
+package dev.woge.spike.references.negative
+
+import dev.woge.spike.references.TaskRow
+import dev.woge.spike.references.TaskRowProps
+
+public fun invalidComponentKey() {
+    TaskRow.instance("task-1", TaskRowProps("Wrong key type", completed = false))
+}

--- a/spikes/typed-reference-model/fixtures/negative/wrong-component-owner/WrongComponentOwner.kt
+++ b/spikes/typed-reference-model/fixtures/negative/wrong-component-owner/WrongComponentOwner.kt
@@ -1,0 +1,12 @@
+package dev.woge.spike.references.negative
+
+import dev.woge.spike.references.ProjectCard
+import dev.woge.spike.references.ProjectCardProps
+import dev.woge.spike.references.ProjectSlug
+import dev.woge.spike.references.TaskRow
+import dev.woge.spike.references.TaskStatusView
+
+public fun invalidRegionOwner() {
+    val projectCard = ProjectCard.instance(ProjectSlug("woge"), ProjectCardProps("Woge"))
+    TaskRow.status.of(projectCard, TaskStatusView(completed = true))
+}

--- a/spikes/typed-reference-model/settings.gradle.kts
+++ b/spikes/typed-reference-model/settings.gradle.kts
@@ -1,0 +1,14 @@
+rootProject.name = "typed-reference-model"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/spikes/typed-reference-model/src/main/kotlin/dev/woge/spike/references/ReferenceModel.kt
+++ b/spikes/typed-reference-model/src/main/kotlin/dev/woge/spike/references/ReferenceModel.kt
@@ -1,0 +1,130 @@
+package dev.woge.spike.references
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@JvmInline
+public value class DescriptorId(public val value: String)
+
+@JvmInline
+public value class WogeUrl(public val value: String)
+
+public interface PageRef<P : Any> {
+    public val id: DescriptorId
+
+    public fun href(parameters: P): WogeUrl
+}
+
+public interface ActionRef<C : Any, R : Any> {
+    public val id: DescriptorId
+
+    public fun invoke(command: C): ActionInvocation<C, R> = ActionInvocation(this, command)
+}
+
+public class ActionInvocation<C : Any, R : Any> internal constructor(
+    public val action: ActionRef<C, R>,
+    public val command: C,
+)
+
+public interface ComponentRef<C : Any, P : Any> {
+    public val id: DescriptorId
+}
+
+public interface KeyedComponentRef<C : Any, K : Any, P : Any> : ComponentRef<C, P> {
+    public fun canonicalKey(key: K): String
+
+    public fun instance(key: K, props: P): ComponentInstance<C, P> =
+        ComponentInstance(this, canonicalKey(key), props)
+}
+
+public class ComponentInstance<C : Any, P : Any> internal constructor(
+    public val component: ComponentRef<C, P>,
+    internal val canonicalKey: String,
+    public val props: P,
+)
+
+public class RegionSlot<C : Any, R : Any> internal constructor(
+    public val id: DescriptorId,
+) {
+    public fun of(owner: ComponentInstance<C, *>, input: R): RegionInstance<C, R> =
+        RegionInstance(owner, this, input)
+}
+
+public class RegionInstance<C : Any, R : Any> internal constructor(
+    public val owner: ComponentInstance<C, *>,
+    public val slot: RegionSlot<C, R>,
+    public val input: R,
+)
+
+public class ReplaceUpdate<C : Any, R : Any> internal constructor(
+    public val target: RegionInstance<C, R>,
+    public val model: R,
+)
+
+public class UpdateBuilder {
+    private val mutableUpdates: MutableList<ReplaceUpdate<*, *>> = mutableListOf()
+
+    public val updates: List<ReplaceUpdate<*, *>>
+        get() = mutableUpdates.toList()
+
+    public fun <C : Any, R : Any> replace(target: RegionInstance<C, R>, model: R) {
+        mutableUpdates += ReplaceUpdate(target, model)
+    }
+}
+
+@JvmInline
+public value class ProjectSlug(public val value: String)
+
+public object ProjectPage : PageRef<ProjectPage.Parameters> {
+    public data class Parameters(
+        public val project: ProjectSlug,
+        public val status: String? = null,
+    )
+
+    override val id: DescriptorId = DescriptorId("page.project.v1")
+
+    override fun href(parameters: Parameters): WogeUrl {
+        val project = encode(parameters.project.value)
+        val query = parameters.status?.let { "?status=${encode(it)}" }.orEmpty()
+        return WogeUrl("/projects/$project$query")
+    }
+}
+
+@JvmInline
+public value class TaskId(public val value: Long)
+
+public data class TaskRowProps(
+    public val title: String,
+    public val completed: Boolean,
+)
+
+public data class TaskStatusView(public val completed: Boolean)
+
+public object TaskRow : KeyedComponentRef<TaskRow.Type, TaskId, TaskRowProps> {
+    public sealed interface Type
+
+    override val id: DescriptorId = DescriptorId("component.task-row.v1")
+    public val status: RegionSlot<Type, TaskStatusView> =
+        RegionSlot(DescriptorId("component.task-row.v1#region.status"))
+
+    override fun canonicalKey(key: TaskId): String = key.value.toString()
+}
+
+public data class ProjectCardProps(public val title: String)
+
+public object ProjectCard : KeyedComponentRef<ProjectCard.Type, ProjectSlug, ProjectCardProps> {
+    public sealed interface Type
+
+    override val id: DescriptorId = DescriptorId("component.project-card.v1")
+    override fun canonicalKey(key: ProjectSlug): String = key.value
+}
+
+public data class CreateTaskCommand(public val title: String)
+public data class CreateTaskResult(public val id: TaskId)
+
+public object CreateTaskAction : ActionRef<CreateTaskCommand, CreateTaskResult> {
+    override val id: DescriptorId = DescriptorId("action.create-task.v1")
+}
+
+private fun encode(value: String): String =
+    URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")

--- a/spikes/typed-reference-model/src/test/kotlin/dev/woge/spike/references/ReferenceModelTest.kt
+++ b/spikes/typed-reference-model/src/test/kotlin/dev/woge/spike/references/ReferenceModelTest.kt
@@ -1,0 +1,44 @@
+package dev.woge.spike.references
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+public class ReferenceModelTest {
+    @Test
+    public fun `page links and actions remain different descriptor kinds`() {
+        val url = ProjectPage.href(ProjectPage.Parameters(ProjectSlug("woge docs"), status = "open"))
+        val action = CreateTaskAction.invoke(CreateTaskCommand("Document typed references"))
+
+        assertEquals("/projects/woge%20docs?status=open", url.value)
+        assertEquals("action.create-task.v1", action.action.id.value)
+    }
+
+    @Test
+    public fun `one component type creates distinct keyed rendered instances`() {
+        val first = TaskRow.instance(TaskId(1), TaskRowProps("First", completed = false))
+        val second = TaskRow.instance(TaskId(2), TaskRowProps("Second", completed = true))
+
+        assertEquals(TaskRow, first.component)
+        assertEquals(TaskRow, second.component)
+        assertNotEquals(first.canonicalKey, second.canonicalKey)
+    }
+
+    @Test
+    public fun `region slots accept only their owner type and region input`() {
+        val first = TaskRow.instance(TaskId(1), TaskRowProps("First", completed = false))
+        val second = TaskRow.instance(TaskId(2), TaskRowProps("Second", completed = true))
+        val firstStatus = TaskRow.status.of(first, TaskStatusView(completed = true))
+        val secondStatus = TaskRow.status.of(second, TaskStatusView(completed = false))
+        val updates = UpdateBuilder()
+
+        updates.replace(firstStatus, TaskStatusView(completed = true))
+        updates.replace(secondStatus, TaskStatusView(completed = false))
+
+        assertEquals(2, updates.updates.size)
+        assertNotEquals(
+            updates.updates[0].target.owner.canonicalKey,
+            updates.updates[1].target.owner.canonicalKey,
+        )
+    }
+}

--- a/spikes/typed-reference-model/validate.sh
+++ b/spikes/typed-reference-model/validate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -u
+
+spike_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+gradle_wrapper="$spike_directory/../spring-html-htmx-baseline/gradlew"
+failure_count=0
+
+"$gradle_wrapper" -p "$spike_directory" test
+
+for fixture in page-as-region wrong-component-owner wrong-component-key; do
+  output_file=$(mktemp)
+  if "$gradle_wrapper" -p "$spike_directory" \
+    -PnegativeFixture="$fixture" \
+    --no-configuration-cache \
+    --no-build-cache \
+    compileKotlin >"$output_file" 2>&1; then
+    printf 'Negative fixture unexpectedly compiled: %s\n' "$fixture" >&2
+    failure_count=$((failure_count + 1))
+  elif ! grep -Eq 'Argument type mismatch|Type mismatch|Cannot infer type|None of the following candidates' "$output_file"; then
+    printf 'Negative fixture failed without an expected type diagnostic: %s\n' "$fixture" >&2
+    cat "$output_file" >&2
+    failure_count=$((failure_count + 1))
+  else
+    printf 'Negative fixture rejected as expected: %s\n' "$fixture"
+  fi
+  rm -f "$output_file"
+done
+
+if (( failure_count > 0 )); then
+  exit 1
+fi
+
+printf 'Typed-reference validation passed.\n'


### PR DESCRIPTION
## Summary

- accept ADR 0011 for distinct page, action, component, rendered-instance, region-slot, and region-instance descriptors
- add a compile-checked Kotlin 2.4 prototype with repeated keyed component instances and typed multi-target updates
- verify three negative fixtures for page-as-target, wrong component owner, and wrong key type
- document deterministic generated naming, web concept mapping, diagnostics, and explicit escape hatches

## Verification

- `./spikes/typed-reference-model/validate.sh`
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #7
