### PR TITLE
Compare HTML DSL and streaming writer strategies

### DIFF
--- a/.github/workflows/html-writer-spike.yml
+++ b/.github/workflows/html-writer-spike.yml
@@ -1,0 +1,31 @@
+name: HTML writer strategy spike
+
+on:
+  pull_request:
+    paths:
+      - "spikes/html-writer-strategy/**"
+      - ".github/workflows/html-writer-spike.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "spikes/html-writer-strategy/**"
+      - ".github/workflows/html-writer-spike.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: "21"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Validate writer behavior and compiler failures
+        run: ./spikes/html-writer-strategy/validate.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Frontend extensibility and complex-screen acceptance](architecture/frontend-extensibility.md)
 - [Component identity, page epochs and revisions](architecture/identity-and-revisions.md)
 - [Typed web-reference spike](../spikes/typed-reference-model/evidence.md)
+- [HTML writer strategy spike](../spikes/html-writer-strategy/evidence.md)
 - [Threat model](security/threat-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)

--- a/docs/adr/0012-html-writer-and-kotlinx-interop.md
+++ b/docs/adr/0012-html-writer-and-kotlinx-interop.md
@@ -1,0 +1,70 @@
+# ADR 0012: Own a minimal streaming HTML writer with kotlinx.html interop
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#5](https://github.com/christian-draeger/woge/issues/5), [#6](https://github.com/christian-draeger/woge/issues/6), [#16](https://github.com/christian-draeger/woge/issues/16), [#17](https://github.com/christian-draeger/woge/issues/17), [#22](https://github.com/christian-draeger/woge/issues/22), [#42](https://github.com/christian-draeger/woge/issues/42), [#78](https://github.com/christian-draeger/woge/issues/78), [#88](https://github.com/christian-draeger/woge/issues/88)
+
+## Context
+
+Woge components need safe HTML output that can reach a host response incrementally and pause at generated region/frame boundaries. The API should look like HTML to a web developer, preserve current/future attributes and CSS, provide useful completion and make raw content visibly unsafe.
+
+The [executable comparison](../../spikes/html-writer-strategy/evidence.md) rendered one utility-heavy custom-element component through a purpose-built writer and `kotlinx.html` 0.12.0. Both escaped hostile text, represented Boolean/custom/data/ARIA attributes and streamed to a sink without a DOM. `kotlinx.html` has mature known-tag completion; the purpose-built sink gives Woge direct control over region, framing and trusted-content boundaries. An `Appendable` bridge proved streaming interoperability.
+
+## Decision
+
+Woge owns a deliberately small `HtmlSink` and structural `HtmlWriter` contract. Generated/component rendering writes start tags, quoted attributes, escaped text, explicit raw content and end tags directly to the sink. The writer never builds or exposes an in-memory DOM. The sink decides buffering, flush, frame and downstream-failure behavior; the HTML DSL does not treat network chunks as frames.
+
+The canonical concepts are:
+
+- `text(value)` for escaped HTML text;
+- common HTML tag/void-tag wrappers for completion and familiar nesting;
+- `element(name)` and `voidElement(name)` as future/custom-element fallbacks;
+- one generic quoted `attribute(name, value)` plus narrow convenience for Boolean presence, classes, declaration-list style, `data-*` and `aria-*`;
+- an explicit `UnsafeHtml` (final name may change only before API freeze) required by `raw(...)`.
+
+Text and quoted-attribute contexts have separate encoders. Element/attribute syntax rejects delimiter/control injection but generic APIs do not use a catalog of known platform names. URL-bearing attributes use typed/validated URL values where Woge creates them; application-owned custom attributes remain strings. Script/raw-text/style handling receives explicit APIs and security/CSS review instead of passing through the normal text encoder accidentally.
+
+Common tag wrappers follow browser names and documentation rather than inventing a Compose-like widget vocabulary. The wrapper set is generated or mechanically maintained from standards data, but missing/new/custom elements remain usable immediately through `element`. Attribute values, class lists, Tailwind utilities, inline declaration lists and CSS custom properties are ordinary ordered strings. Woge does not generate typed CSS properties or utility classes.
+
+A DSL marker prevents accidental outer-receiver calls. Canonical methods avoid several equivalent spellings. Public examples use explicit `text(...)` rather than unary operators so a web developer new to Kotlin can identify escaping behavior at a glance.
+
+An optional `woge-html-kotlinx` interoperability artifact adapts a Woge sink to `Appendable`/`TagConsumer` so existing `kotlinx.html` blocks/extensions can stream inside an explicitly bounded component render. `kotlinx.html` types do not enter Woge core, protocol, host SPI or generated descriptor signatures. Rendering from other template engines crosses a documented buffered/trusted boundary; Woge never guesses that an arbitrary string is safe HTML.
+
+The spike prototype is evidence, not production code. M1 implementation must settle sink failure/cancellation, complete escaping and Unicode behavior, tag wrapper generation, raw-text/void rules, URL attributes and source diagnostics before publishing the API.
+
+## Alternatives considered
+
+- **Expose `kotlinx.html` as the only public rendering API:** rejected as the core contract because Woge-specific frame/region/trusted boundaries would depend on external consumer/receiver types and custom/new tags need additional helpers. It remains a supported adapter.
+- **Build a complete typed replacement for every tag, attribute and value:** rejected because it would lag the platform and create a second HTML vocabulary.
+- **Use only `element(name)` and maps:** rejected as the documented path because common tags would lose IDE completion, hover documentation and typo detection.
+- **Render a complete string/DOM before writing:** rejected because it prevents shell-first and completion-order output and raises memory use.
+- **Accept raw HTML as `String`:** rejected because safe and unsafe content become indistinguishable at review and compile time.
+- **Use unary plus as the only text API:** rejected as the canonical teaching form because its escaping behavior is not obvious to web developers unfamiliar with Kotlin DSL conventions.
+- **Make Tailwind/CSS properties typed Kotlin enums:** rejected because ordinary class/CSS strings already preserve the ecosystem and new web standards.
+
+## Consequences
+
+### Positive
+
+- Woge owns the exact streaming, trusted-content and generated-region boundary it must keep stable.
+- Common rendering reads like HTML while generic fallbacks keep new platform vocabulary open.
+- Raw content and Boolean presence errors receive normal compiler feedback.
+- Existing `kotlinx.html` code can stream through an optional adapter without infecting portable descriptors.
+- Plain CSS, modern declaration strings and Tailwind classes compose without framework parsing.
+
+### Negative
+
+- Woge must maintain common tag wrappers, escaping tests and HTML syntax behavior.
+- The generic fallback cannot offer the same completion as known wrappers.
+- `kotlinx.html` interoperability adds a separate artifact and receiver boundary.
+- Template-engine output may require buffering or an explicit trusted conversion.
+
+## Follow-up
+
+- Implement production escaped text/attributes, Boolean/custom attributes and raw-content boundaries in [#16](https://github.com/christian-draeger/woge/issues/16).
+- Implement buffered/streaming sinks and downstream failure behavior in [#17](https://github.com/christian-draeger/woge/issues/17).
+- Add common tag wrappers, generic future-tag fixtures and compile-verified newcomer examples in [#73](https://github.com/christian-draeger/woge/issues/73) and [#74](https://github.com/christian-draeger/woge/issues/74).
+- Prototype the optional `woge-html-kotlinx` artifact only after the core sink works; keep it out of the initial mandatory graph until demanded by a consumer fixture.
+- Decide CSS language injection, style-block/declaration types and optional scoping in [#88](https://github.com/christian-draeger/woge/issues/88).
+- Keep HTML framing separate and choose it in [#6](https://github.com/christian-draeger/woge/issues/6).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0009](0009-frontend-extension-contract.md) | Accepted | Layer frontend extensions over semantic server HTML |
 | [0010](0010-identity-epochs-and-revisions.md) | Accepted | Scope rendered identity and revisions to a page epoch |
 | [0011](0011-typed-web-references.md) | Accepted | Generate distinct typed descriptors for web references |
+| [0012](0012-html-writer-and-kotlinx-interop.md) | Accepted | Own a minimal streaming HTML writer with kotlinx.html interop |

--- a/spikes/html-writer-strategy/.gitignore
+++ b/spikes/html-writer-strategy/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/spikes/html-writer-strategy/README.md
+++ b/spikes/html-writer-strategy/README.md
@@ -1,0 +1,11 @@
+# HTML writer strategy spike
+
+This spike compares `kotlinx.html` 0.12.0 with a small Woge-owned streaming writer. Both render the same utility-heavy custom-element task card and write incrementally without an in-memory DOM.
+
+Run:
+
+```shell
+./spikes/html-writer-strategy/validate.sh
+```
+
+The validator runs seven behavior tests and two deliberately invalid compile fixtures. See [evidence.md](evidence.md) and [ADR 0012](../../docs/adr/0012-html-writer-and-kotlinx-interop.md).

--- a/spikes/html-writer-strategy/build.gradle.kts
+++ b/spikes/html-writer-strategy/build.gradle.kts
@@ -1,0 +1,42 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("jvm") version "2.4.0"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+        explicitApi()
+    }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.12.0")
+    testImplementation(kotlin("test-junit5"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+val negativeFixture = providers.gradleProperty("negativeFixture").orNull
+if (negativeFixture != null) {
+    require(negativeFixture.matches(Regex("[a-z0-9-]+"))) {
+        "negativeFixture must be a lowercase fixture name"
+    }
+    val fixtureDirectory = layout.projectDirectory.dir("fixtures/negative/$negativeFixture")
+    require(fixtureDirectory.asFile.isDirectory) {
+        "Unknown negative fixture: $negativeFixture"
+    }
+    sourceSets.main {
+        kotlin.srcDir(fixtureDirectory)
+    }
+    layout.buildDirectory = layout.projectDirectory.dir("build/negative-$negativeFixture")
+}

--- a/spikes/html-writer-strategy/evidence.md
+++ b/spikes/html-writer-strategy/evidence.md
@@ -1,0 +1,64 @@
+# HTML writer strategy evidence
+
+Recorded on 2026-09-03 with Kotlin 2.4.0, Gradle 8.14.4 and `kotlinx-html-jvm` 0.12.0, the latest Maven Central release observed during the spike.
+
+## Compared fixture
+
+Both renderers produce an `<article>` with:
+
+- ordinary classes including `md:grid-cols-[minmax(0,1fr)_auto]`;
+- a CSS declaration list containing `--accent: oklch(...)` and `container-type`;
+- `data-state`, `aria-busy` and conditional `disabled`;
+- hostile text containing `<script>`, quotes and `&`;
+- a custom `<woge-status>` element.
+
+The Woge prototype uses a generic `element("woge-status")`. `kotlinx.html` needs a small `HTMLTag` subclass and `FlowContent` extension for an ergonomic custom tag. Both allow arbitrary attributes through an attribute map/builder and leave CSS/Tailwind values as strings.
+
+## Result matrix
+
+| Concern | Woge-owned writer prototype | `kotlinx.html` 0.12.0 |
+| --- | --- | --- |
+| Text/attribute escaping | Explicit context functions; hostile fixture passes | Library escaping; hostile fixture passes |
+| Boolean attributes | `boolean("disabled", condition)` emits presence/absence | Typed `disabled = condition`; presence/absence passes |
+| `data-*` / `aria-*` / unknown attributes | Canonical `attribute` plus thin `data`/`aria` helpers | `attributes["..."]` |
+| Custom elements/new tags | Generic `element(name)` works immediately | Generic `HTMLTag` helper requires consumer-aware boilerplate |
+| Classes/Tailwind | Ordered string contributors; no utility parsing | Ordinary `classes` string |
+| Inline CSS/custom properties | Ordered declaration-list strings | Ordinary `style` attribute string |
+| Raw HTML | Only `raw(UnsafeHtml)` | Explicit `unsafe { raw(...) }` block |
+| Incremental output | Every token writes to `HtmlSink`; first token observed before close | `appendHTML()` writes repeatedly to `Appendable`; no DOM |
+| Woge sink interop | Native | A 16-line `Appendable` bridge writes into the same sink |
+| IDE discovery | Small canonical primitives; common tag wrappers still required | Rich completion for known tags/typed attributes; wildcard/import surface is larger |
+| New platform vocabulary | Generic fallback works without a Woge release | Attribute map works; ergonomic new/custom tags may await/helper code |
+| Woge frame/region ownership | Direct sink and component boundary | Requires adapter types around `TagConsumer`/receivers |
+
+Output formatting differs: `appendHTML()` may pretty-print whitespace, while the Woge writer emits only requested text. Tests compare semantic tokens where whitespace is not significant.
+
+## Compiler and runtime failures
+
+Ordinary Kotlin type checking rejects accidental raw HTML:
+
+```text
+RawString.kt:6:9 Argument type mismatch: actual type is 'String',
+but 'UnsafeHtml' was expected.
+```
+
+It also rejects a string pretending to be Boolean presence:
+
+```text
+BooleanString.kt:7:29 Argument type mismatch: actual type is 'String',
+but 'Boolean' was expected.
+```
+
+Invalid element/attribute names fail before any injected suffix is written. The prototype intentionally validates only syntax delimiters for generic attributes instead of maintaining an allowlist of known attributes. Text and quoted attributes use separate escaping paths.
+
+## IDE and AI-DX assessment
+
+A Woge-owned surface should expose one obvious `text`, `element`, `voidElement`, `attribute`, `boolean`, `classes`, `styles` and explicit raw-HTML path. `@DslMarker` prevents accidental calls through an outer receiver. Common standard tags can have generated/documented wrappers so completion resembles HTML; `element(name)` and `attribute(name, value)` remain the future/custom fallback.
+
+The normal call site needs only Woge HTML/component imports. The optional adapter lets existing `kotlinx.html` extensions stream into Woge instead of converting through a DOM. Diagnostics stay ordinary Kotlin actual/expected errors, while generated component declaration errors follow the stable AI-DX diagnostic policy.
+
+## Recommendation
+
+Own the minimal `HtmlSink` and structural writer contract in Woge, because frame boundaries, trusted content, generated regions and adapter lifecycle are Woge responsibilities. Keep CSS, class utilities and unknown attributes as standards strings. Offer an optional streaming `kotlinx.html` adapter; do not fork or wrap every kotlinx tag type.
+
+Do not ship the prototype unchanged. M1 must add common standard tag wrappers, URL-bearing attribute types, complete escaping/Unicode fixtures, void/raw-text element policy and sink failure semantics. The generic fallback prevents that convenience list from becoming an HTML feature gate.

--- a/spikes/html-writer-strategy/fixtures/negative/boolean-string/BooleanString.kt
+++ b/spikes/html-writer-strategy/fixtures/negative/boolean-string/BooleanString.kt
@@ -1,0 +1,9 @@
+package dev.woge.spike.html.negative
+
+import dev.woge.spike.html.renderHtml
+
+public fun invalidBooleanAttribute(): String = renderHtml {
+    element("button", attributes = {
+        boolean("disabled", "true")
+    })
+}

--- a/spikes/html-writer-strategy/fixtures/negative/raw-string/RawString.kt
+++ b/spikes/html-writer-strategy/fixtures/negative/raw-string/RawString.kt
@@ -1,0 +1,7 @@
+package dev.woge.spike.html.negative
+
+import dev.woge.spike.html.renderHtml
+
+public fun invalidRawString(): String = renderHtml {
+    raw("<strong>not explicitly trusted</strong>")
+}

--- a/spikes/html-writer-strategy/settings.gradle.kts
+++ b/spikes/html-writer-strategy/settings.gradle.kts
@@ -1,0 +1,14 @@
+rootProject.name = "html-writer-strategy"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/spikes/html-writer-strategy/src/main/kotlin/dev/woge/spike/html/ComparisonRenderers.kt
+++ b/spikes/html-writer-strategy/src/main/kotlin/dev/woge/spike/html/ComparisonRenderers.kt
@@ -1,0 +1,93 @@
+package dev.woge.spike.html
+
+import kotlinx.html.BODY
+import kotlinx.html.FlowContent
+import kotlinx.html.HTMLTag
+import kotlinx.html.TagConsumer
+import kotlinx.html.article
+import kotlinx.html.body
+import kotlinx.html.button
+import kotlinx.html.h2
+import kotlinx.html.p
+import kotlinx.html.stream.appendHTML
+import kotlinx.html.stream.createHTML
+import kotlinx.html.visit
+
+public data class TaskCard(
+    public val title: String,
+    public val pending: Boolean,
+)
+
+public fun renderWithWogeWriter(card: TaskCard, sink: HtmlSink): Unit = HtmlWriter(sink).run {
+    element(
+        name = "article",
+        attributes = {
+            classes("task-card", "grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]")
+            data("state", if (card.pending) "pending" else "ready")
+            aria("busy", card.pending.toString())
+            styles("--accent: oklch(62% 0.2 250);", "container-type: inline-size;")
+        },
+    ) {
+        element("h2") { text(card.title) }
+        element("woge-status", attributes = { attribute("kind", "task") }) {
+            text(if (card.pending) "Saving" else "Saved")
+        }
+        element("button", attributes = { boolean("disabled", card.pending) }) {
+            text("Complete")
+        }
+    }
+}
+
+public fun renderWithKotlinxHtml(card: TaskCard): String = createHTML().article(
+    classes = "task-card grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]",
+) {
+    attributes["data-state"] = if (card.pending) "pending" else "ready"
+    attributes["aria-busy"] = card.pending.toString()
+    attributes["style"] = "--accent: oklch(62% 0.2 250); container-type: inline-size;"
+    h2 { +card.title }
+    wogeStatus {
+        attributes["kind"] = "task"
+        +(if (card.pending) "Saving" else "Saved")
+    }
+    button {
+        disabled = card.pending
+        +"Complete"
+    }
+}
+
+public fun renderKotlinxIntoAppendable(card: TaskCard, appendable: Appendable): Unit {
+    appendable.appendHTML().body {
+        renderKotlinxTaskCard(card)
+    }
+}
+
+public fun renderKotlinxIntoWogeSink(card: TaskCard, sink: HtmlSink): Unit {
+    renderKotlinxIntoAppendable(card, SinkAppendable(sink))
+}
+
+private fun BODY.renderKotlinxTaskCard(card: TaskCard) {
+    article {
+        h2 { +card.title }
+    }
+}
+
+private class WogeStatus(consumer: TagConsumer<*>) :
+    HTMLTag("woge-status", consumer, emptyMap(), inlineTag = false, emptyTag = false)
+
+private fun FlowContent.wogeStatus(block: WogeStatus.() -> Unit = {}) {
+    WogeStatus(consumer).visit(block)
+}
+
+private class SinkAppendable(private val sink: HtmlSink) : Appendable {
+    override fun append(csq: CharSequence?): Appendable = apply {
+        sink.write(csq?.toString() ?: "null")
+    }
+
+    override fun append(csq: CharSequence?, start: Int, end: Int): Appendable = apply {
+        sink.write(csq?.subSequence(start, end)?.toString() ?: "null")
+    }
+
+    override fun append(c: Char): Appendable = apply {
+        sink.write(c.toString())
+    }
+}

--- a/spikes/html-writer-strategy/src/main/kotlin/dev/woge/spike/html/WogeHtmlWriter.kt
+++ b/spikes/html-writer-strategy/src/main/kotlin/dev/woge/spike/html/WogeHtmlWriter.kt
@@ -1,0 +1,159 @@
+package dev.woge.spike.html
+
+@DslMarker
+public annotation class WogeHtmlDsl
+
+public fun interface HtmlSink {
+    public fun write(value: String)
+}
+
+@JvmInline
+public value class UnsafeHtml internal constructor(internal val value: String)
+
+public fun unsafeHtml(value: String): UnsafeHtml = UnsafeHtml(value)
+
+@WogeHtmlDsl
+public class Attributes internal constructor() {
+    private val values: LinkedHashMap<String, AttributeValue> = linkedMapOf()
+
+    public fun attribute(name: String, value: String) {
+        requireAttributeName(name)
+        values[name] = AttributeValue.Text(value)
+    }
+
+    public fun boolean(name: String, present: Boolean = true) {
+        requireAttributeName(name)
+        if (present) values[name] = AttributeValue.Present else values.remove(name)
+    }
+
+    public fun data(name: String, value: String) {
+        requireToken(name, "data attribute")
+        attribute("data-$name", value)
+    }
+
+    public fun aria(name: String, value: String) {
+        requireToken(name, "ARIA attribute")
+        attribute("aria-$name", value)
+    }
+
+    public fun classes(vararg contributors: String) {
+        val addition = contributors.filter(String::isNotBlank).joinToString(" ")
+        if (addition.isEmpty()) return
+        val existing = (values["class"] as? AttributeValue.Text)?.value
+        values["class"] = AttributeValue.Text(listOfNotNull(existing, addition).joinToString(" "))
+    }
+
+    public fun styles(vararg declarationLists: String) {
+        val addition = declarationLists.filter(String::isNotBlank).joinToString(" ")
+        if (addition.isEmpty()) return
+        val existing = (values["style"] as? AttributeValue.Text)?.value
+        values["style"] = AttributeValue.Text(listOfNotNull(existing, addition).joinToString(" "))
+    }
+
+    internal fun entries(): List<Pair<String, AttributeValue>> = values.toList()
+}
+
+@WogeHtmlDsl
+public class HtmlWriter(public val sink: HtmlSink) {
+    public fun text(value: String) {
+        sink.write(escapeText(value))
+    }
+
+    public fun raw(value: UnsafeHtml) {
+        sink.write(value.value)
+    }
+
+    public fun element(
+        name: String,
+        attributes: Attributes.() -> Unit = {},
+        content: HtmlWriter.() -> Unit = {},
+    ) {
+        requireElementName(name)
+        sink.write("<$name")
+        writeAttributes(attributes)
+        sink.write(">")
+        content()
+        sink.write("</$name>")
+    }
+
+    public fun voidElement(
+        name: String,
+        attributes: Attributes.() -> Unit = {},
+    ) {
+        requireElementName(name)
+        sink.write("<$name")
+        writeAttributes(attributes)
+        sink.write(">")
+    }
+
+    private fun writeAttributes(block: Attributes.() -> Unit) {
+        val attributes = Attributes().apply(block)
+        for ((name, value) in attributes.entries()) {
+            sink.write(" $name")
+            if (value is AttributeValue.Text) {
+                sink.write("=\"")
+                sink.write(escapeAttribute(value.value))
+                sink.write("\"")
+            }
+        }
+    }
+}
+
+public fun renderHtml(block: HtmlWriter.() -> Unit): String = buildString {
+    HtmlWriter(HtmlSink(::append)).block()
+}
+
+internal sealed interface AttributeValue {
+    data object Present : AttributeValue
+    data class Text(val value: String) : AttributeValue
+}
+
+private val attributeToken = Regex("[a-z][a-z0-9._:-]*")
+private val invalidNameCharacters = setOf('\u0000', '<', '>', '/', '=', '"', '\'')
+
+private fun requireElementName(value: String) {
+    require(value.firstOrNull()?.isLetter() == true && value.none(::isInvalidNameCharacter)) {
+        "Invalid HTML element name: $value"
+    }
+}
+
+private fun requireAttributeName(value: String) {
+    require(value.isNotEmpty() && value.none(::isInvalidNameCharacter)) {
+        "Invalid HTML attribute name: $value"
+    }
+}
+
+private fun requireToken(value: String, kind: String) {
+    require(attributeToken.matches(value)) { "Invalid $kind token: $value" }
+}
+
+private fun isInvalidNameCharacter(character: Char): Boolean =
+    character.isWhitespace() || character in invalidNameCharacters
+
+private fun escapeText(value: String): String = buildString(value.length) {
+    value.forEach { character ->
+        append(
+            when (character) {
+                '&' -> "&amp;"
+                '<' -> "&lt;"
+                '>' -> "&gt;"
+                else -> character
+            },
+        )
+    }
+}
+
+private fun escapeAttribute(value: String): String = buildString(value.length) {
+    value.forEach { character ->
+        append(
+            when (character) {
+                '&' -> "&amp;"
+                '<' -> "&lt;"
+                '>' -> "&gt;"
+                '"' -> "&quot;"
+                '\'' -> "&#39;"
+                else -> character
+            },
+        )
+    }
+}

--- a/spikes/html-writer-strategy/src/test/kotlin/dev/woge/spike/html/HtmlWriterComparisonTest.kt
+++ b/spikes/html-writer-strategy/src/test/kotlin/dev/woge/spike/html/HtmlWriterComparisonTest.kt
@@ -1,0 +1,117 @@
+package dev.woge.spike.html
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+public class HtmlWriterComparisonTest {
+    private val hostileCard = TaskCard(
+        title = "Fix <script>alert(\"x\")</script> & docs",
+        pending = true,
+    )
+
+    @Test
+    public fun `purpose built writer preserves web attributes and escapes text`() {
+        val html = renderHtml { renderWithWogeWriter(hostileCard, sink) }
+
+        assertContains(html, "class=\"task-card grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]\"")
+        assertContains(html, "data-state=\"pending\"")
+        assertContains(html, "aria-busy=\"true\"")
+        assertContains(html, "style=\"--accent: oklch(62% 0.2 250); container-type: inline-size;\"")
+        assertContains(html, "<woge-status kind=\"task\">Saving</woge-status>")
+        assertContains(html, "<button disabled>Complete</button>")
+        assertContains(html, "Fix &lt;script&gt;alert(\"x\")&lt;/script&gt; &amp; docs")
+    }
+
+    @Test
+    public fun `kotlinx html supports the same output concepts`() {
+        val html = renderWithKotlinxHtml(hostileCard)
+
+        assertContains(html, "data-state=\"pending\"")
+        assertContains(html, "aria-busy=\"true\"")
+        assertContains(html, "md:grid-cols-[minmax(0,1fr)_auto]")
+        assertContains(html, "<woge-status kind=\"task\">Saving</woge-status>")
+        assertContains(html, "disabled")
+        assertContains(html, "Fix &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; docs")
+        assertFalse(renderWithKotlinxHtml(hostileCard.copy(pending = false)).contains("disabled"))
+    }
+
+    @Test
+    public fun `writer emits incrementally without building a DOM`() {
+        val chunks = mutableListOf<String>()
+
+        renderWithWogeWriter(TaskCard("Stream", pending = false), HtmlSink(chunks::add))
+
+        assertTrue(chunks.size > 10)
+        assertEquals("<article", chunks.first())
+        assertEquals("</article>", chunks.last())
+        assertContains(chunks.joinToString(""), "<h2>Stream</h2>")
+    }
+
+    @Test
+    public fun `kotlinx html can target an appendable without a DOM`() {
+        val appendable = RecordingAppendable()
+
+        renderKotlinxIntoAppendable(TaskCard("Stream", pending = false), appendable)
+
+        assertTrue(appendable.writeCount > 1)
+        assertContains(appendable.toString(), "<article>")
+        assertContains(appendable.toString(), "<h2>Stream</h2>")
+    }
+
+    @Test
+    public fun `kotlinx html adapter can write through the Woge sink`() {
+        val chunks = mutableListOf<String>()
+
+        renderKotlinxIntoWogeSink(TaskCard("Interop", pending = false), HtmlSink(chunks::add))
+
+        assertTrue(chunks.size > 1)
+        assertContains(chunks.joinToString(""), "<h2>Interop</h2>")
+    }
+
+    @Test
+    public fun `raw HTML requires an explicit unsafe value`() {
+        val html = renderHtml {
+            text("<strong>escaped</strong>")
+            raw(unsafeHtml("<strong>explicit raw</strong>"))
+        }
+
+        assertEquals("&lt;strong&gt;escaped&lt;/strong&gt;<strong>explicit raw</strong>", html)
+    }
+
+    @Test
+    public fun `element and attribute names cannot inject markup`() {
+        assertFailsWith<IllegalArgumentException> {
+            renderHtml { element("div onclick=alert(1)") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            renderHtml { element("div", attributes = { attribute("x\" onmouseover", "bad") }) }
+        }
+    }
+}
+
+private class RecordingAppendable : Appendable {
+    private val value = StringBuilder()
+    var writeCount: Int = 0
+        private set
+
+    override fun append(csq: CharSequence?): Appendable = apply {
+        writeCount += 1
+        value.append(csq)
+    }
+
+    override fun append(csq: CharSequence?, start: Int, end: Int): Appendable = apply {
+        writeCount += 1
+        value.append(csq, start, end)
+    }
+
+    override fun append(c: Char): Appendable = apply {
+        writeCount += 1
+        value.append(c)
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/spikes/html-writer-strategy/validate.sh
+++ b/spikes/html-writer-strategy/validate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -u
+
+spike_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+gradle_wrapper="$spike_directory/../spring-html-htmx-baseline/gradlew"
+failure_count=0
+
+"$gradle_wrapper" -p "$spike_directory" test
+
+for fixture in raw-string boolean-string; do
+  output_file=$(mktemp)
+  if "$gradle_wrapper" -p "$spike_directory" \
+    -PnegativeFixture="$fixture" \
+    --no-configuration-cache \
+    --no-build-cache \
+    compileKotlin >"$output_file" 2>&1; then
+    printf 'Negative fixture unexpectedly compiled: %s\n' "$fixture" >&2
+    failure_count=$((failure_count + 1))
+  elif ! grep -Eq 'Argument type mismatch|Type mismatch' "$output_file"; then
+    printf 'Negative fixture failed without an expected type diagnostic: %s\n' "$fixture" >&2
+    cat "$output_file" >&2
+    failure_count=$((failure_count + 1))
+  else
+    printf 'Negative fixture rejected as expected: %s\n' "$fixture"
+  fi
+  rm -f "$output_file"
+done
+
+if (( failure_count > 0 )); then
+  exit 1
+fi
+
+printf 'HTML writer strategy validation passed.\n'


### PR DESCRIPTION
## Summary

- compare a Woge-owned structural writer with `kotlinx.html` 0.12.0 using one modern utility-heavy custom-element component
- verify escaping, Boolean/custom/data/ARIA attributes, CSS/class preservation, explicit raw HTML, and incremental no-DOM output
- add two negative compiler fixtures and a direct `kotlinx.html` Appendable-to-Woge-sink bridge
- accept ADR 0012 for a minimal Woge sink/writer plus optional streaming kotlinx.html interoperability

## Verification

- `./spikes/html-writer-strategy/validate.sh` (7 behavior tests, 2 expected compiler failures)
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #5
