### PR TITLE
Evaluate robust framing for streamed patches

### DIFF
--- a/.github/workflows/patch-framing-spike.yml
+++ b/.github/workflows/patch-framing-spike.yml
@@ -1,0 +1,31 @@
+name: Patch framing spike
+
+on:
+  pull_request:
+    paths:
+      - "spikes/patch-framing/**"
+      - ".github/workflows/patch-framing-spike.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "spikes/patch-framing/**"
+      - ".github/workflows/patch-framing-spike.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: "21"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Validate framing and record measurements
+        run: ./spikes/patch-framing/validate.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Component identity, page epochs and revisions](architecture/identity-and-revisions.md)
 - [Typed web-reference spike](../spikes/typed-reference-model/evidence.md)
 - [HTML writer strategy spike](../spikes/html-writer-strategy/evidence.md)
+- [Patch framing spike](../spikes/patch-framing/evidence.md)
 - [Threat model](security/threat-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)

--- a/docs/adr/0013-length-prefixed-patch-framing.md
+++ b/docs/adr/0013-length-prefixed-patch-framing.md
@@ -1,0 +1,65 @@
+# ADR 0013: Use explicit length-prefixed patch frames
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#4](https://github.com/christian-draeger/woge/issues/4), [#6](https://github.com/christian-draeger/woge/issues/6), [#19](https://github.com/christian-draeger/woge/issues/19), [#20](https://github.com/christian-draeger/woge/issues/20), [#21](https://github.com/christian-draeger/woge/issues/21), [#23](https://github.com/christian-draeger/woge/issues/23), [#41](https://github.com/christian-draeger/woge/issues/41), [#45](https://github.com/christian-draeger/woge/issues/45)
+
+## Context
+
+Fetch `ReadableStream` chunks are arbitrary transport observations, not application message boundaries. HTML can contain every normal text delimiter, UTF-8 code points span reads, and compression/proxies may split or combine output differently from the server's writes. Woge therefore needs explicit incremental framing for fallback patches, completion and safe post-commit errors.
+
+The [framing spike](../../spikes/patch-framing/evidence.md) implemented length-prefix and `multipart/mixed` encoders/decoders. Both passed every possible two-chunk split, one-byte reads and gzip transport. For a 240-byte metadata/payload fixture, length-prefix used 114 overhead bytes versus multipart's 465 and required less parser/encoder code.
+
+## Decision
+
+The MVP fallback stream uses `application/vnd.woge.patch-stream; version=1` with a five-byte `WOGE`/binary-version preamble. Each frame has a fixed ten-byte header: kind, content-type length, unsigned big-endian metadata length and unsigned big-endian payload length, followed by those three exact byte regions.
+
+Frame kinds are:
+
+1. **Patch:** canonical UTF-8 JSON metadata plus arbitrary payload bytes; initial payload content type is `text/html; charset=utf-8`.
+2. **Complete:** terminal, empty payload and canonical JSON completion metadata.
+3. **Error:** terminal, empty payload and safe `application/problem+json` metadata containing only allowed code, correlation ID and recovery intent.
+
+Metadata is limited to 64 KiB and payload to 8 MiB before allocation in version 1. Content type is limited to 255 UTF-8 bytes and rejects control characters. Unknown preamble versions, frame kinds, invalid/oversized lengths, malformed metadata, target/revision violations, truncation, missing terminal frames and bytes after terminal fail closed.
+
+The browser parser operates on bytes after normal HTTP content decoding and retains partial header/content state across arbitrary reads. It validates metadata and active page/target/revision rules before parsing/applying HTML. A frame becomes observable only when all declared bytes are present and valid.
+
+The encoder writes the HTML sink into the current frame payload accounting boundary; it does not assume one sink write equals one network or parser read. Production implementations use bounded cursor/ring buffers and backpressure rather than the spike's copy-oriented arrays.
+
+Errors before response commit use normal HTTP status/content negotiation. After commit, only a safe terminal error frame is possible; transport loss remains distinguishable as truncation. Completion and error are mutually exclusive.
+
+## Alternatives considered
+
+- **`multipart/mixed`:** rejected for the MVP because browsers expose the response as bytes rather than incremental MIME parts, so Woge still needs a parser while paying boundary/header/Base64 overhead and more states.
+- **ReadableStream chunk equals frame:** rejected because HTTP stacks, TLS, compression and proxies can split/combine writes arbitrarily.
+- **Newline/record-separator/NDJSON framing:** rejected for arbitrary HTML because escaping or Base64 expands payloads and incremental UTF-8/text handling remains necessary.
+- **One complete JSON document:** rejected because it buffers the whole stream and delays shell/patch application.
+- **SSE for action/deferred responses:** rejected as the universal framing because EventSource is GET-oriented and text-only; SSE remains appropriate for live one-way updates.
+- **No explicit completion frame:** rejected because clean completion, truncation and safe application error would be ambiguous after HTTP status is committed.
+- **64-bit unbounded lengths:** rejected because browser-safe numeric handling and resource limits are simpler with reviewed version-1 ceilings well below 32-bit limits.
+
+## Consequences
+
+### Positive
+
+- Arbitrary HTML and Unicode need no delimiter escaping or Base64.
+- Parsers survive any byte split and validate size before allocation.
+- Completion, application error and transport truncation are distinguishable.
+- Per-frame content type leaves room for non-HTML payloads in a later protocol version without guessing.
+- The format has substantially lower measured overhead than the multipart prototype.
+
+### Negative
+
+- Network traces need a small decoder rather than being directly readable text.
+- Woge owns a versioned binary parser in JVM and browser runtimes.
+- Proxy buffering can still delay valid frames and requires operational testing.
+- Changing ceilings/header fields requires protocol-version compatibility work.
+
+## Follow-up
+
+- Put target, epoch, base/next revision and operation metadata into canonical Patch IR JSON in [#19](https://github.com/christian-draeger/woge/issues/19).
+- Implement golden version-1 encoder/decoder fixtures across JVM and browser in [#20](https://github.com/christian-draeger/woge/issues/20) and [#21](https://github.com/christian-draeger/woge/issues/21).
+- Add random splits, lengths, metadata and malformed target fuzzing in [#41](https://github.com/christian-draeger/woge/issues/41).
+- Measure actual flush/compression/proxy behavior separately in [#23](https://github.com/christian-draeger/woge/issues/23) and [#45](https://github.com/christian-draeger/woge/issues/45).
+- Generate a human-readable diagnostic decoder with the production protocol implementation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0010](0010-identity-epochs-and-revisions.md) | Accepted | Scope rendered identity and revisions to a page epoch |
 | [0011](0011-typed-web-references.md) | Accepted | Generate distinct typed descriptors for web references |
 | [0012](0012-html-writer-and-kotlinx-interop.md) | Accepted | Own a minimal streaming HTML writer with kotlinx.html interop |
+| [0013](0013-length-prefixed-patch-framing.md) | Accepted | Use explicit length-prefixed patch frames |

--- a/spikes/patch-framing/.gitignore
+++ b/spikes/patch-framing/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/spikes/patch-framing/README.md
+++ b/spikes/patch-framing/README.md
@@ -1,0 +1,11 @@
+# Patch framing spike
+
+This spike compares `multipart/mixed` with an explicit length-prefixed Woge stream. Both codecs carry the same Patch IR metadata and arbitrary UTF-8 HTML without treating network chunks as frame boundaries.
+
+Run:
+
+```shell
+./spikes/patch-framing/validate.sh
+```
+
+The validator tests every possible two-chunk split, one-byte reads, gzip transport, terminal completion/error frames and malformed input, then prints reproducible size measurements. See [evidence.md](evidence.md) and [ADR 0013](../../docs/adr/0013-length-prefixed-patch-framing.md).

--- a/spikes/patch-framing/build.gradle.kts
+++ b/spikes/patch-framing/build.gradle.kts
@@ -1,0 +1,31 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("jvm") version "2.4.0"
+    application
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+        explicitApi()
+    }
+}
+
+dependencies {
+    testImplementation(kotlin("test-junit5"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+application {
+    mainClass = "dev.woge.spike.framing.FramingMeasurementKt"
+}

--- a/spikes/patch-framing/evidence.md
+++ b/spikes/patch-framing/evidence.md
@@ -1,0 +1,79 @@
+# Patch framing evidence
+
+Recorded on 2026-09-03 with Kotlin 2.4.0 and Gradle 8.14.4.
+
+## Fixture and verification
+
+The stream contains two HTML patches and one completion frame. Its payload includes UTF-8 (`🐺`), CR/LF text and a boundary-like string. Metadata contains target and base/next revision fields. The error fixture replaces completion with a safe problem code and correlation ID.
+
+For both codecs, tests feed:
+
+- every split `0..encodedSize` as two reads;
+- the entire stream as individual one-byte reads;
+- the gzip-compressed/decompressed stream as individual bytes;
+- a truncated stream;
+- unknown frame kind/version or oversized length data.
+
+All valid permutations decode to byte-identical content type, metadata and payload. Invalid streams fail without emitting the malformed frame, and `finish()` rejects a missing terminal/final boundary.
+
+## Measured result
+
+```text
+payload_and_metadata_bytes=240
+length_prefixed_bytes=354
+multipart_bytes=705
+length_prefixed_overhead_bytes=114
+multipart_overhead_bytes=465
+```
+
+The prototype source (encoder plus incremental decoder) is 101 lines for length-prefix and 146 lines for multipart, excluding shared frame types and tests. These are comparison values, not production size claims.
+
+| Concern | Length-prefixed | `multipart/mixed` |
+| --- | --- | --- |
+| Arbitrary payload bytes | Exact byte length | Exact `Content-Length` inside each MIME part |
+| Chunk splitting | Fixed state/remaining-byte counts | Boundary, header, body and final-boundary states |
+| Metadata | Length-delimited UTF-8 | Base64url header value to avoid header injection |
+| Sample overhead | 114 bytes | 465 bytes |
+| Human inspection | Needs decoder/hexdump | Headers are readable but metadata is encoded |
+| Boundary collision | None | Avoided by honoring part content length; boundary parsing still required between parts |
+| Browser implementation | `DataView`/byte queue | MIME parsing must be implemented because Fetch does not expose multipart body parts incrementally |
+
+Multipart's standard media type did not provide a native incremental browser parser, so its extra headers/boundaries did not remove client code. A text delimiter or NDJSON alternative would need escaping/Base64 for arbitrary HTML and still require an incremental text decoder.
+
+## Proposed version 1 format
+
+Response media type:
+
+```text
+application/vnd.woge.patch-stream; version=1
+```
+
+Preamble:
+
+| Bytes | Meaning |
+| ---: | --- |
+| 4 | ASCII `WOGE` |
+| 1 | binary protocol version (`0x01`) |
+
+Each frame:
+
+| Bytes | Meaning |
+| ---: | --- |
+| 1 | kind: patch `1`, complete `2`, safe error `3` |
+| 1 | UTF-8 content-type byte length |
+| 4 | unsigned big-endian metadata byte length |
+| 4 | unsigned big-endian payload byte length |
+| variable | content type |
+| variable | UTF-8 metadata (canonical JSON in production) |
+| variable | payload bytes |
+
+The spike bounds metadata at 64 KiB and payload at 8 MiB before allocation. These are initial safety ceilings, configurable only downward until production evidence justifies a reviewed change. Content type is explicit per frame. Complete/error are terminal and have an empty payload; bytes after a terminal frame fail.
+
+Patch metadata is parsed and semantically validated before HTML reaches the DOM sink. A post-commit error frame contains only a stable safe code, correlation ID and allowed recovery intent. Stack traces, user input and rendered HTML never enter it. A pre-commit failure remains a normal HTTP error response.
+
+## Limitations before production
+
+- Prototype decoders append/copy byte arrays for clarity; production uses a bounded cursor/ring buffer.
+- Tests prove framing survives content decoding, not that proxies flush promptly. Buffering measurements remain in [#45](https://github.com/christian-draeger/woge/issues/45).
+- Canonical JSON schema, protocol negotiation and browser TypeScript/JavaScript implementation land with Patch IR and fallback encoder/runtime.
+- The 8 MiB ceiling is a safety maximum, not a recommendation to emit large patches.

--- a/spikes/patch-framing/settings.gradle.kts
+++ b/spikes/patch-framing/settings.gradle.kts
@@ -1,0 +1,14 @@
+rootProject.name = "patch-framing"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/Frames.kt
+++ b/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/Frames.kt
@@ -1,0 +1,101 @@
+package dev.woge.spike.framing
+
+import java.nio.charset.StandardCharsets
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.CharacterCodingException
+
+public enum class FrameKind(public val code: Int) {
+    PATCH(1),
+    COMPLETE(2),
+    ERROR(3),
+    ;
+
+    public val terminal: Boolean
+        get() = this != PATCH
+
+    public companion object {
+        public fun fromCode(code: Int): FrameKind = entries.firstOrNull { it.code == code }
+            ?: throw FrameException("Unknown frame kind: $code")
+    }
+}
+
+public class WireFrame(
+    public val kind: FrameKind,
+    public val contentType: String,
+    public val metadata: String,
+    public val payload: ByteArray,
+) {
+    public companion object {
+        public fun patch(metadata: String, html: String): WireFrame = WireFrame(
+            kind = FrameKind.PATCH,
+            contentType = "text/html; charset=utf-8",
+            metadata = metadata,
+            payload = html.toByteArray(StandardCharsets.UTF_8),
+        )
+
+        public fun complete(metadata: String = "{}"): WireFrame = WireFrame(
+            kind = FrameKind.COMPLETE,
+            contentType = "application/json; charset=utf-8",
+            metadata = metadata,
+            payload = byteArrayOf(),
+        )
+
+        public fun error(safeMetadata: String): WireFrame = WireFrame(
+            kind = FrameKind.ERROR,
+            contentType = "application/problem+json; charset=utf-8",
+            metadata = safeMetadata,
+            payload = byteArrayOf(),
+        )
+    }
+}
+
+public class FrameException(message: String) : IllegalArgumentException(message)
+
+public interface FrameDecoder {
+    public fun feed(chunk: ByteArray): List<WireFrame>
+    public fun finish()
+}
+
+internal const val MAX_METADATA_BYTES: Int = 64 * 1024
+internal const val MAX_PAYLOAD_BYTES: Int = 8 * 1024 * 1024
+
+internal fun validateFrame(frame: WireFrame) {
+    val metadataSize = frame.metadata.toByteArray(StandardCharsets.UTF_8).size
+    if (metadataSize > MAX_METADATA_BYTES) throw FrameException("Metadata exceeds $MAX_METADATA_BYTES bytes")
+    if (frame.payload.size > MAX_PAYLOAD_BYTES) throw FrameException("Payload exceeds $MAX_PAYLOAD_BYTES bytes")
+    if (frame.kind.terminal && frame.payload.isNotEmpty()) {
+        throw FrameException("Terminal frame payload must be empty")
+    }
+    if ('\r' in frame.contentType || '\n' in frame.contentType) {
+        throw FrameException("Invalid content type")
+    }
+    if (frame.contentType.any { it.code !in 0x20..0x7e }) throw FrameException("Content type must be ASCII")
+}
+
+internal fun ByteArray.startsWith(prefix: ByteArray): Boolean =
+    size >= prefix.size && prefix.indices.all { this[it] == prefix[it] }
+
+internal fun ByteArray.dropPrefix(count: Int): ByteArray = copyOfRange(count, size)
+
+internal fun ByteArray.indexOf(needle: ByteArray): Int {
+    if (needle.isEmpty()) return 0
+    for (start in 0..size - needle.size) {
+        if (needle.indices.all { offset -> this[start + offset] == needle[offset] }) return start
+    }
+    return -1
+}
+
+internal fun ByteArray.decodeUtf8(field: String): String = decodeStrict(StandardCharsets.UTF_8, field)
+
+internal fun ByteArray.decodeAscii(field: String): String = decodeStrict(StandardCharsets.US_ASCII, field)
+
+private fun ByteArray.decodeStrict(charset: java.nio.charset.Charset, field: String): String = try {
+    charset.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+        .decode(ByteBuffer.wrap(this))
+        .toString()
+} catch (_: CharacterCodingException) {
+    throw FrameException("Invalid $field encoding")
+}

--- a/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/FramingMeasurement.kt
+++ b/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/FramingMeasurement.kt
@@ -1,0 +1,26 @@
+package dev.woge.spike.framing
+
+public fun main() {
+    val frames = measurementFrames()
+    val lengthPrefixed = LengthPrefixedCodec.encode(frames)
+    val multipart = MultipartCodec("woge-measurement-boundary").encode(frames)
+    val payloadBytes = frames.sumOf { it.payload.size + it.metadata.encodeToByteArray().size }
+
+    println("payload_and_metadata_bytes=$payloadBytes")
+    println("length_prefixed_bytes=${lengthPrefixed.size}")
+    println("multipart_bytes=${multipart.size}")
+    println("length_prefixed_overhead_bytes=${lengthPrefixed.size - payloadBytes}")
+    println("multipart_overhead_bytes=${multipart.size - payloadBytes}")
+}
+
+internal fun measurementFrames(): List<WireFrame> = listOf(
+    WireFrame.patch(
+        metadata = "{\"target\":\"summary\",\"baseRevision\":0,\"nextRevision\":1}",
+        html = "<section><h2>Summary</h2><p>3 open · 🐺</p></section>",
+    ),
+    WireFrame.patch(
+        metadata = "{\"target\":\"tasks\",\"baseRevision\":0,\"nextRevision\":1}",
+        html = "<section><h2>Tasks</h2><p>Boundary-like: \\r\\n--woge</p></section>",
+    ),
+    WireFrame.complete("{\"patches\":2}"),
+)

--- a/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/LengthPrefixedCodec.kt
+++ b/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/LengthPrefixedCodec.kt
@@ -1,0 +1,101 @@
+package dev.woge.spike.framing
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+
+public object LengthPrefixedCodec {
+    public const val mediaType: String = "application/vnd.woge.patch-stream; version=1"
+    private val magic = byteArrayOf('W'.code.toByte(), 'O'.code.toByte(), 'G'.code.toByte(), 'E'.code.toByte(), 1)
+
+    public fun encode(frames: List<WireFrame>): ByteArray {
+        validateSequence(frames)
+        val output = ByteArrayOutputStream().apply { write(magic) }
+        frames.forEach { frame ->
+            val contentType = frame.contentType.toByteArray(StandardCharsets.US_ASCII)
+            val metadata = frame.metadata.toByteArray(StandardCharsets.UTF_8)
+            require(contentType.size <= 255) { "Content type is too long" }
+            val header = ByteBuffer.allocate(10).order(ByteOrder.BIG_ENDIAN)
+                .put(frame.kind.code.toByte())
+                .put(contentType.size.toByte())
+                .putInt(metadata.size)
+                .putInt(frame.payload.size)
+                .array()
+            output.write(header)
+            output.write(contentType)
+            output.write(metadata)
+            output.write(frame.payload)
+        }
+        return output.toByteArray()
+    }
+
+    public fun decoder(): FrameDecoder = Decoder()
+
+    private class Decoder : FrameDecoder {
+        private var buffer: ByteArray = byteArrayOf()
+        private var magicRead: Boolean = false
+        private var terminalRead: Boolean = false
+
+        override fun feed(chunk: ByteArray): List<WireFrame> {
+            if (terminalRead && chunk.isNotEmpty()) throw FrameException("Bytes after terminal frame")
+            buffer += chunk
+            val frames = mutableListOf<WireFrame>()
+
+            if (!magicRead) {
+                if (buffer.size < magic.size) return frames
+                if (!buffer.startsWith(magic)) throw FrameException("Invalid Woge framing magic or version")
+                buffer = buffer.dropPrefix(magic.size)
+                magicRead = true
+            }
+
+            while (buffer.size >= 10 && !terminalRead) {
+                val header = ByteBuffer.wrap(buffer, 0, 10).order(ByteOrder.BIG_ENDIAN)
+                val kind = FrameKind.fromCode(header.get().toInt() and 0xff)
+                val contentTypeSize = header.get().toInt() and 0xff
+                val metadataSize = header.int
+                val payloadSize = header.int
+                validateLengths(metadataSize, payloadSize)
+                val frameSize = 10L + contentTypeSize + metadataSize + payloadSize
+                if (frameSize > Int.MAX_VALUE || buffer.size < frameSize.toInt()) return frames
+
+                var offset = 10
+                val contentType = buffer.copyOfRange(offset, offset + contentTypeSize)
+                    .decodeAscii("content type")
+                offset += contentTypeSize
+                val metadata = buffer.copyOfRange(offset, offset + metadataSize)
+                    .decodeUtf8("metadata")
+                offset += metadataSize
+                val payload = buffer.copyOfRange(offset, offset + payloadSize)
+                val frame = WireFrame(kind, contentType, metadata, payload)
+                validateFrame(frame)
+                frames += frame
+                buffer = buffer.dropPrefix(frameSize.toInt())
+                terminalRead = kind.terminal
+            }
+
+            if (terminalRead && buffer.isNotEmpty()) throw FrameException("Bytes after terminal frame")
+            return frames
+        }
+
+        override fun finish() {
+            if (!magicRead) throw FrameException("Missing Woge framing preamble")
+            if (buffer.isNotEmpty()) throw FrameException("Truncated Woge frame")
+            if (!terminalRead) throw FrameException("Missing terminal frame")
+        }
+    }
+
+    private fun validateLengths(metadataSize: Int, payloadSize: Int) {
+        if (metadataSize !in 0..MAX_METADATA_BYTES) throw FrameException("Invalid metadata length: $metadataSize")
+        if (payloadSize !in 0..MAX_PAYLOAD_BYTES) throw FrameException("Invalid payload length: $payloadSize")
+    }
+}
+
+private fun validateSequence(frames: List<WireFrame>) {
+    require(frames.isNotEmpty()) { "At least one frame is required" }
+    frames.forEachIndexed { index, frame ->
+        validateFrame(frame)
+        require(!frame.kind.terminal || index == frames.lastIndex) { "Terminal frame must be last" }
+    }
+    require(frames.last().kind.terminal) { "A terminal frame is required" }
+}

--- a/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/MultipartCodec.kt
+++ b/spikes/patch-framing/src/main/kotlin/dev/woge/spike/framing/MultipartCodec.kt
@@ -1,0 +1,146 @@
+package dev.woge.spike.framing
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+public class MultipartCodec(private val boundary: String) {
+    init {
+        require(boundary.matches(Regex("[A-Za-z0-9._-]{8,70}"))) { "Unsafe multipart boundary" }
+    }
+
+    public val mediaType: String = "multipart/mixed; boundary=$boundary"
+
+    public fun encode(frames: List<WireFrame>): ByteArray {
+        validateMultipartSequence(frames)
+        val output = ByteArrayOutputStream()
+        frames.forEach { frame ->
+            val metadata = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(frame.metadata.toByteArray(StandardCharsets.UTF_8))
+            output.write("--$boundary\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.write("Woge-Kind: ${frame.kind.name}\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.write("Content-Type: ${frame.contentType}\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.write("Woge-Metadata: $metadata\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.write("Content-Length: ${frame.payload.size}\r\n\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.write(frame.payload)
+            output.write("\r\n".toByteArray(StandardCharsets.US_ASCII))
+        }
+        output.write("--$boundary--\r\n".toByteArray(StandardCharsets.US_ASCII))
+        return output.toByteArray()
+    }
+
+    public fun decoder(): FrameDecoder = Decoder(boundary)
+
+    private class Decoder(boundary: String) : FrameDecoder {
+        private val partPrefix = "--$boundary\r\n".toByteArray(StandardCharsets.US_ASCII)
+        private val finalBoundary = "--$boundary--\r\n".toByteArray(StandardCharsets.US_ASCII)
+        private val headerEnd = "\r\n\r\n".toByteArray(StandardCharsets.US_ASCII)
+        private var buffer: ByteArray = byteArrayOf()
+        private var pending: PendingPart? = null
+        private var terminalRead: Boolean = false
+        private var closed: Boolean = false
+
+        override fun feed(chunk: ByteArray): List<WireFrame> {
+            if (closed && chunk.isNotEmpty()) throw FrameException("Bytes after final multipart boundary")
+            buffer += chunk
+            val frames = mutableListOf<WireFrame>()
+
+            while (!closed) {
+                if (terminalRead && pending == null) {
+                    if (buffer.size < finalBoundary.size) break
+                    if (!buffer.startsWith(finalBoundary)) throw FrameException("Missing final multipart boundary")
+                    buffer = buffer.dropPrefix(finalBoundary.size)
+                    closed = true
+                    if (buffer.isNotEmpty()) throw FrameException("Bytes after final multipart boundary")
+                    break
+                }
+
+                val current = pending
+                if (current == null) {
+                    val end = buffer.indexOf(headerEnd)
+                    if (end < 0) {
+                        if (buffer.size > 8 * 1024) throw FrameException("Multipart headers exceed 8192 bytes")
+                        break
+                    }
+                    val headerBytes = buffer.copyOfRange(0, end)
+                    if (!headerBytes.startsWith(partPrefix.copyOfRange(0, partPrefix.size - 2))) {
+                        throw FrameException("Invalid multipart boundary")
+                    }
+                    val headerText = headerBytes.decodeAscii("multipart header")
+                    pending = parseHeaders(headerText.substringAfter("\r\n"))
+                    buffer = buffer.dropPrefix(end + headerEnd.size)
+                    continue
+                }
+
+                val required = current.contentLength.toLong() + 2
+                if (required > Int.MAX_VALUE || buffer.size < required.toInt()) break
+                if (buffer[current.contentLength] != '\r'.code.toByte() ||
+                    buffer[current.contentLength + 1] != '\n'.code.toByte()
+                ) {
+                    throw FrameException("Multipart body is not followed by CRLF")
+                }
+                val payload = buffer.copyOfRange(0, current.contentLength)
+                val frame = WireFrame(current.kind, current.contentType, current.metadata, payload)
+                validateFrame(frame)
+                frames += frame
+                terminalRead = frame.kind.terminal
+                pending = null
+                buffer = buffer.dropPrefix(current.contentLength + 2)
+            }
+
+            return frames
+        }
+
+        override fun finish() {
+            if (pending != null || buffer.isNotEmpty()) throw FrameException("Truncated multipart stream")
+            if (!terminalRead) throw FrameException("Missing terminal frame")
+            if (!closed) throw FrameException("Missing final multipart boundary")
+        }
+
+        private fun parseHeaders(text: String): PendingPart {
+            val headers = linkedMapOf<String, String>()
+            text.split("\r\n").forEach { line ->
+                val separator = line.indexOf(':')
+                if (separator <= 0) throw FrameException("Malformed multipart header")
+                val name = line.substring(0, separator).lowercase()
+                if (name in headers) throw FrameException("Duplicate multipart header: $name")
+                headers[name] = line.substring(separator + 1).trim()
+            }
+            val kind = headers["woge-kind"]?.let { value ->
+                FrameKind.entries.firstOrNull { it.name == value }
+            } ?: throw FrameException("Missing or invalid Woge-Kind")
+            val contentType = headers["content-type"] ?: throw FrameException("Missing Content-Type")
+            val metadata = try {
+                Base64.getUrlDecoder().decode(headers["woge-metadata"] ?: "")
+                    .decodeUtf8("metadata")
+            } catch (_: IllegalArgumentException) {
+                throw FrameException("Invalid Woge-Metadata")
+            }
+            if (metadata.toByteArray(StandardCharsets.UTF_8).size > MAX_METADATA_BYTES) {
+                throw FrameException("Metadata exceeds $MAX_METADATA_BYTES bytes")
+            }
+            val contentLength = headers["content-length"]?.toIntOrNull()
+                ?: throw FrameException("Missing or invalid Content-Length")
+            if (contentLength !in 0..MAX_PAYLOAD_BYTES) {
+                throw FrameException("Invalid payload length: $contentLength")
+            }
+            return PendingPart(kind, contentType, metadata, contentLength)
+        }
+    }
+
+    private data class PendingPart(
+        val kind: FrameKind,
+        val contentType: String,
+        val metadata: String,
+        val contentLength: Int,
+    )
+}
+
+private fun validateMultipartSequence(frames: List<WireFrame>) {
+    require(frames.isNotEmpty()) { "At least one frame is required" }
+    frames.forEachIndexed { index, frame ->
+        validateFrame(frame)
+        require(!frame.kind.terminal || index == frames.lastIndex) { "Terminal frame must be last" }
+    }
+    require(frames.last().kind.terminal) { "A terminal frame is required" }
+}

--- a/spikes/patch-framing/src/test/kotlin/dev/woge/spike/framing/FramingCodecTest.kt
+++ b/spikes/patch-framing/src/test/kotlin/dev/woge/spike/framing/FramingCodecTest.kt
@@ -1,0 +1,123 @@
+package dev.woge.spike.framing
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+public class FramingCodecTest {
+    private val frames = measurementFrames()
+
+    @Test
+    public fun `length prefixed frames survive every two-chunk byte split`() {
+        assertEverySplit(LengthPrefixedCodec.encode(frames), LengthPrefixedCodec::decoder)
+    }
+
+    @Test
+    public fun `multipart frames survive every two-chunk byte split`() {
+        val codec = MultipartCodec("woge-test-boundary")
+        assertEverySplit(codec.encode(frames), codec::decoder)
+    }
+
+    @Test
+    public fun `both formats survive one-byte reads and gzip transport`() {
+        val multipart = MultipartCodec("woge-test-boundary")
+        val cases = listOf(
+            LengthPrefixedCodec.encode(frames) to LengthPrefixedCodec::decoder,
+            multipart.encode(frames) to multipart::decoder,
+        )
+
+        for ((encoded, decoderFactory) in cases) {
+            assertDecoded(encoded.map { byteArrayOf(it) }, decoderFactory)
+            assertDecoded(gunzip(gzip(encoded)).map { byteArrayOf(it) }, decoderFactory)
+        }
+    }
+
+    @Test
+    public fun `safe error is an explicit terminal frame`() {
+        val errorFrames = listOf(
+            WireFrame.patch("{\"target\":\"summary\"}", "<p>partial</p>"),
+            WireFrame.error("{\"code\":\"WOGE_RENDER_FAILED\",\"correlationId\":\"test-1\"}"),
+        )
+
+        assertDecoded(
+            listOf(LengthPrefixedCodec.encode(errorFrames)),
+            LengthPrefixedCodec::decoder,
+            errorFrames,
+        )
+    }
+
+    @Test
+    public fun `truncated and unknown frames fail closed`() {
+        val encoded = LengthPrefixedCodec.encode(frames)
+        val truncated = LengthPrefixedCodec.decoder()
+        truncated.feed(encoded.copyOf(encoded.size - 1))
+        assertFailsWith<FrameException> { truncated.finish() }
+
+        val unknown = encoded.copyOf().also { it[5] = 99 }
+        assertFailsWith<FrameException> { LengthPrefixedCodec.decoder().feed(unknown) }
+
+        val malformedMetadata = encoded.copyOf().also { bytes ->
+            val contentTypeLength = bytes[6].toInt() and 0xff
+            val metadataStart = 5 + 10 + contentTypeLength
+            bytes[metadataStart] = 0xc3.toByte()
+            bytes[metadataStart + 1] = 0x28.toByte()
+        }
+        assertFailsWith<FrameException> { LengthPrefixedCodec.decoder().feed(malformedMetadata) }
+
+        val multipart = MultipartCodec("woge-test-boundary").encode(frames)
+        val truncatedMultipart = MultipartCodec("woge-test-boundary").decoder()
+        truncatedMultipart.feed(multipart.copyOf(multipart.size - 1))
+        assertFailsWith<FrameException> { truncatedMultipart.finish() }
+    }
+
+    @Test
+    public fun `oversized metadata is rejected before allocation`() {
+        val header = byteArrayOf(
+            'W'.code.toByte(), 'O'.code.toByte(), 'G'.code.toByte(), 'E'.code.toByte(), 1,
+            FrameKind.PATCH.code.toByte(), 0,
+            0, 1, 0, 1,
+            0, 0, 0, 0,
+        )
+
+        assertFailsWith<FrameException> { LengthPrefixedCodec.decoder().feed(header) }
+    }
+
+    private fun assertEverySplit(encoded: ByteArray, decoderFactory: () -> FrameDecoder) {
+        for (split in 0..encoded.size) {
+            assertDecoded(
+                listOf(encoded.copyOfRange(0, split), encoded.copyOfRange(split, encoded.size)),
+                decoderFactory,
+            )
+        }
+    }
+
+    private fun assertDecoded(
+        chunks: List<ByteArray>,
+        decoderFactory: () -> FrameDecoder,
+        expected: List<WireFrame> = frames,
+    ) {
+        val decoder = decoderFactory()
+        val actual = chunks.flatMap(decoder::feed)
+        decoder.finish()
+        assertEquals(expected.size, actual.size)
+        expected.zip(actual).forEach { (expectedFrame, actualFrame) ->
+            assertEquals(expectedFrame.kind, actualFrame.kind)
+            assertEquals(expectedFrame.contentType, actualFrame.contentType)
+            assertEquals(expectedFrame.metadata, actualFrame.metadata)
+            assertContentEquals(expectedFrame.payload, actualFrame.payload)
+        }
+    }
+
+    private fun gzip(value: ByteArray): ByteArray = ByteArrayOutputStream().use { output ->
+        GZIPOutputStream(output).use { it.write(value) }
+        output.toByteArray()
+    }
+
+    private fun gunzip(value: ByteArray): ByteArray =
+        GZIPInputStream(ByteArrayInputStream(value)).use { it.readAllBytes() }
+}

--- a/spikes/patch-framing/validate.sh
+++ b/spikes/patch-framing/validate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -u
+
+spike_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+gradle_wrapper="$spike_directory/../spring-html-htmx-baseline/gradlew"
+
+"$gradle_wrapper" -p "$spike_directory" test
+"$gradle_wrapper" -p "$spike_directory" run --quiet


### PR DESCRIPTION
## Summary

- prototype incremental `multipart/mixed` and explicit length-prefixed codecs for identical patch streams
- test every possible byte split, one-byte reads, gzip transport, Unicode/boundary-like HTML, completion/error frames, truncation, unknown kinds, oversized lengths, and malformed UTF-8
- record payload overhead and parser/encoder complexity measurements
- accept ADR 0013 for bounded versioned length-prefixed MVP framing

## Verification

- `./spikes/patch-framing/validate.sh`
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #6
