### PR TITLE
Spike cross-browser fallback patch runtime

### DIFF
--- a/.github/workflows/fallback-patch-runtime-spike.yml
+++ b/.github/workflows/fallback-patch-runtime-spike.yml
@@ -1,0 +1,34 @@
+name: Fallback patch runtime spike
+
+on:
+  pull_request:
+    paths:
+      - "spikes/fallback-patch-runtime/**"
+      - ".github/workflows/fallback-patch-runtime-spike.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "spikes/fallback-patch-runtime/**"
+      - ".github/workflows/fallback-patch-runtime-spike.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  browser-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: spikes/fallback-patch-runtime
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: spikes/fallback-patch-runtime/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium firefox webkit
+      - run: npm test
+      - run: npm run measure

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Typed web-reference spike](../spikes/typed-reference-model/evidence.md)
 - [HTML writer strategy spike](../spikes/html-writer-strategy/evidence.md)
 - [Patch framing spike](../spikes/patch-framing/evidence.md)
+- [Cross-browser fallback patch runtime spike](../spikes/fallback-patch-runtime/evidence.md)
 - [Threat model](security/threat-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)

--- a/docs/adr/0014-small-owned-fallback-patch-runtime.md
+++ b/docs/adr/0014-small-owned-fallback-patch-runtime.md
@@ -1,0 +1,69 @@
+# ADR 0014: Own a small protocol-specific fallback patch runtime
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#3](https://github.com/christian-draeger/woge/issues/3), [#4](https://github.com/christian-draeger/woge/issues/4), [#21](https://github.com/christian-draeger/woge/issues/21), [#25](https://github.com/christian-draeger/woge/issues/25), [#41](https://github.com/christian-draeger/woge/issues/41), [#42](https://github.com/christian-draeger/woge/issues/42)
+
+## Context
+
+Woge must preserve enhanced actions and deferred patches when native Declarative Partial Updates (DPU) are unavailable. The fallback has to consume Woge's length-prefixed protocol, survive arbitrary Fetch stream chunks, enforce active-page identity/revision rules and keep ordinary server HTML as the no-JavaScript baseline.
+
+The [cross-browser spike](../../spikes/fallback-patch-runtime/evidence.md) implemented that narrow path in 8,050 source bytes (2,706 gzip; 2,284 Brotli). Eighteen tests passed in current Playwright Chromium, Firefox and WebKit builds. They include one-byte delivery, representative splits, executable-markup rejection, stale/unknown targets and malformed framing.
+
+Existing choices solve adjacent problems. Google's `template-for-polyfill` 0.1.0 follows emerging `<template for>` syntax but buffers instead of streaming and does not understand Woge frames, terminal states or identity metadata. htmx 2.0.10 offers a broader request, selector, swap, event and history model whose wire semantics are not Woge's typed protocol.
+
+## Decision
+
+Woge owns one small browser fallback runtime for its versioned patch protocol. It is a protocol adapter and DOM sink, not a component framework, virtual DOM, client state graph or general navigation library.
+
+The fallback:
+
+- reads bytes incrementally from a standard Fetch `ReadableStream` and treats only protocol lengths as frame boundaries;
+- resolves opaque generated region IDs from the active page registry rather than accepting selectors;
+- verifies protocol version, page epoch and contiguous target revision before mutation;
+- parses each complete HTML frame through an inert template and rejects ordinary executable patch content by default;
+- distinguishes complete, safe remote error and transport truncation;
+- supports only operations whose ordering, preservation and failure semantics are explicitly versioned and tested.
+
+The initial operation is atomic child replacement. Valid earlier frames may remain visible if a later frame fails. The runtime is compatible with strict CSP and requires neither `unsafe-inline` nor `unsafe-eval`. Server-side context encoding and explicit trusted/raw HTML remain the primary XSS boundary; client rejection is defense in depth rather than a general sanitizer.
+
+Native DPU is implemented behind the same internal patch-application capability once [#3](https://github.com/christian-draeger/woge/issues/3) proves its exact behavior. Runtime selection uses feature detection and preserves the same observable identity, ordering, completion and security contracts. Native syntax is not emitted merely because an API name exists.
+
+`template-for-polyfill`, htmx, Turbo or another frontend library may receive optional adapters when a real consumer demonstrates value. None is a transitive dependency of Woge core or changes the canonical wire protocol. Packaging and loading of the production runtime are decided with the component-distribution work; this ADR fixes ownership and semantics, not the artifact layout.
+
+The M0 JavaScript is executable evidence only. Production code must use bounded buffering/backpressure, generated/golden protocol fixtures, cancellation, stable diagnostics and the full security corpus.
+
+## Alternatives considered
+
+- **Depend only on `template-for-polyfill`:** rejected because it targets parser-level DPU markup, buffers, and lacks Woge framing, identity, limits and terminal semantics. It remains relevant to the native-path spike.
+- **Use htmx as the mandatory runtime:** rejected because its broad selector/request/swap contract would become a second Woge API and still require protocol-specific framing and revision code.
+- **Use Turbo or another navigation/component runtime:** rejected for the same contract overlap and because navigation/hydration is not required to apply a Woge patch.
+- **Ship native DPU only:** rejected because Woge's supported browsers cannot depend on an experimental feature and the HTML baseline alone would lose enhanced updates.
+- **Send one JSON response and replace after download:** rejected because Base64/escaping and whole-response buffering discard incremental patch delivery and explicit truncation semantics.
+- **Let host adapters choose unrelated client protocols:** rejected because Spring MVC, WebFlux and Ktor applications would no longer share browser behavior or portable tests.
+
+## Consequences
+
+### Positive
+
+- Spring and Ktor adapters share one small, testable browser protocol contract.
+- Applications keep standards HTML, CSS, custom elements and optional islands without framework hydration.
+- Native DPU can replace an internal sink later without forcing a public API rewrite.
+- Runtime size and security surface stay narrow and measurable.
+- Optional htmx/native-syntax integrations remain possible at explicit adapter boundaries.
+
+### Negative
+
+- Woge owns security updates, browser compatibility, byte parsing and DOM lifecycle tests.
+- The first implementation cannot inherit the richer history, animation, morphing and extension ecosystems of general libraries.
+- Native and fallback paths require parity tests as DPU evolves.
+- Frame-level buffering means a single large HTML fragment is not progressively parsed.
+
+## Follow-up
+
+- Use [#3](https://github.com/christian-draeger/woge/issues/3) to decide the native DPU mapping and capability detection without weakening fallback guarantees.
+- Implement the production decoder and runtime with golden JVM/browser fixtures in [#20](https://github.com/christian-draeger/woge/issues/20) and [#21](https://github.com/christian-draeger/woge/issues/21).
+- Add append/preserve, focus and stale-response behavior in [#25](https://github.com/christian-draeger/woge/issues/25), [#35](https://github.com/christian-draeger/woge/issues/35) and [#37](https://github.com/christian-draeger/woge/issues/37).
+- Move the negative fixtures into the full malformed/XSS/CSP suites in [#41](https://github.com/christian-draeger/woge/issues/41) and [#42](https://github.com/christian-draeger/woge/issues/42).
+- Keep production runtime packaging aligned with the distribution decision in [#76](https://github.com/christian-draeger/woge/issues/76).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0011](0011-typed-web-references.md) | Accepted | Generate distinct typed descriptors for web references |
 | [0012](0012-html-writer-and-kotlinx-interop.md) | Accepted | Own a minimal streaming HTML writer with kotlinx.html interop |
 | [0013](0013-length-prefixed-patch-framing.md) | Accepted | Use explicit length-prefixed patch frames |
+| [0014](0014-small-owned-fallback-patch-runtime.md) | Accepted | Own a small protocol-specific fallback patch runtime |

--- a/spikes/fallback-patch-runtime/.gitignore
+++ b/spikes/fallback-patch-runtime/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/spikes/fallback-patch-runtime/evidence.md
+++ b/spikes/fallback-patch-runtime/evidence.md
@@ -1,0 +1,103 @@
+# Cross-browser fallback patch runtime evidence
+
+Recorded on 2026-09-03 with Node.js 24, Playwright 1.62.1 and the version-1 framing from [ADR 0013](../../docs/adr/0013-length-prefixed-patch-framing.md).
+
+## Question and boundary
+
+This spike asks whether Woge can apply an action/deferred-response patch when a browser has no native Declarative Partial Updates (DPU) implementation. It does not choose the native initial-document streaming shape; that remains [#3](https://github.com/christian-draeger/woge/issues/3).
+
+The prototype is intentionally one small classic script. It consumes a normal Fetch `ReadableStream<Uint8Array>`, incrementally decodes Woge frames, validates patch metadata and replaces the children of a registered region through an inert `<template>`. The page remains ordinary server-rendered HTML:
+
+```html
+<meta name="woge-page-epoch" content="epoch-a">
+<main data-woge-region="summary-1" data-woge-revision="0">
+  <p>Original content still works without enhancement.</p>
+</main>
+```
+
+No application component is hydrated and the runtime does not interpret component state, CSS classes or custom elements.
+
+## Executable result
+
+Playwright ran the same six scenarios against its pinned engines:
+
+| Engine | Installed test build | Result |
+| --- | --- | --- |
+| Chromium | Chrome for Testing 151.0.7922.34 | 6 passed |
+| Firefox | Firefox 153.0 | 6 passed |
+| WebKit | WebKit 26.5 | 6 passed |
+
+The 18 passing cases prove:
+
+- a `replace` patch works when the complete stream is delivered as individual one-byte chunks;
+- every representative split before, inside and after the preamble/header/content regions produces the same DOM;
+- scripts, inline `on*` handlers, `srcdoc`, blocked active elements and active `javascript:`, `vbscript:` or `data:` URLs are rejected before replacement, including scripts nested in a template;
+- an unknown target, stale revision, duplicate region, remote error and truncated frame fail with stable error codes;
+- wrong preambles, oversized metadata, non-ASCII content types, malformed JSON and bytes after a terminal frame fail without changing the tested region.
+
+Run the evidence with:
+
+```shell
+cd spikes/fallback-patch-runtime
+npm ci
+npx playwright install chromium firefox webkit
+npm test
+npm run measure
+```
+
+The CI workflow repeats the matrix on Linux for every change to the spike.
+
+## Chunk and mutation semantics
+
+The decoder retains incomplete preamble, header and body bytes across reads. It uses declared byte lengths, never a network read boundary, delimiter or decoded character count. A complete frame is parsed and semantically validated before its payload reaches the DOM.
+
+Previously accepted valid frames may already be visible if a later frame or the transport fails. This is intentional streaming behavior, not transactionality across the response. The terminal completion/error frame tells Woge whether the stream ended cleanly; a missing terminal is truncation.
+
+Version 1 resolves an opaque `data-woge-region` value through a page-local registry. Patch metadata must match the document epoch and exactly advance the target revision. Metadata never becomes a CSS selector. The M0 prototype supports child replacement only; append, preservation, focus restoration and live-update scheduling remain later protocol/runtime work.
+
+## Security boundary
+
+Parsing through a detached `<template>` prevents parser-time execution. The prototype additionally rejects the executable elements, attributes and URL schemes named by [WOGE-XSS-002](../../docs/security/threat-model.md). This is defense in depth, not a general HTML sanitizer. Woge's primary guarantee remains context-aware server rendering: ordinary application strings are escaped and explicit trusted/raw HTML is auditable.
+
+The runtime needs no `eval`, dynamic code construction, inline event handler or application-supplied selector. A production build can load as a same-origin external script under a strict Content Security Policy. Trusted Types integration and the complete hostile-markup corpus remain [#42](https://github.com/christian-draeger/woge/issues/42).
+
+## Runtime size
+
+The measurement script reads exactly `runtime.js` and applies Node's level-9 gzip and default Brotli compressors:
+
+```text
+runtime_source_bytes=8050
+runtime_gzip_bytes=2706
+runtime_brotli_bytes=2284
+```
+
+These are reproducible prototype source-transfer measurements, not a minified production budget. The runtime includes frame decoding, limits, metadata/identity validation, active-content rejection, DOM replacement and stable error types.
+
+## Existing alternatives
+
+### `template-for-polyfill` 0.1.0
+
+The Chrome team publishes [`template-for-polyfill`](https://github.com/GoogleChromeLabs/template-for-polyfill) for the emerging DPU `<template for>` syntax. Its npm browser distribution is 2,604 bytes before transfer compression. This is attractive for native-syntax parity and should be exercised by the separate DPU spike.
+
+It is not a substitute for this fallback path. The Chrome documentation states that the polyfill buffers rather than streams, and its documented MutationObserver/parser limitations differ from native parsing. It also does not decode Woge's framed action responses, enforce Woge page epochs/revisions, distinguish completion from truncation or apply Woge's protocol limits. Adopting it as the only runtime would either discard those contracts or require a second Woge layer anyway.
+
+### htmx 2.0.10
+
+[`htmx`](https://htmx.org/docs/) is a mature dependency-free browser library with request triggers, target selectors, swap styles, response headers, history, events and out-of-band swaps. It remains a useful interoperability target and reference for web-native ergonomics.
+
+Using it as Woge core would introduce a second public request/target/synchronization model. Its flexible CSS-selector and response conventions do not directly encode Woge's typed region, epoch, revision, binary framing or terminal-error semantics. An optional htmx adapter can map a deliberately smaller compatible subset later without making every Woge application depend on htmx.
+
+## Compatibility constraints and production gaps
+
+- The fallback targets the browser policy in [ADR 0007](../../docs/adr/0007-browser-support-and-progressive-enhancement.md), not legacy browsers. It requires standard modules or classic scripts plus `ReadableStream`, typed arrays, `DataView`, fatal UTF-8 `TextDecoder`, template fragments, private class fields and `replaceChildren`.
+- Playwright WebKit provides repeatable engine coverage; it is not a substitute for release-candidate Safari/iOS device testing before a public release.
+- Each HTML payload is buffered up to the reviewed 8 MiB frame ceiling before one atomic replacement. Streaming occurs between frames, not inside one fragment.
+- The clear prototype concatenates byte arrays and is intentionally inefficient under one-byte input. Production uses a bounded cursor/ring buffer and backpressure.
+- The registry is captured for one response. Dynamic nested-region registration, cancellation, append/preserve operations, focus/selection behavior and diagnostics require their named M1 issues and tests.
+- Framing survives arbitrary post-content-decoding chunks, but proxy buffering can still delay delivery; [#45](https://github.com/christian-draeger/woge/issues/45) owns that operational evidence.
+
+## Recommendation
+
+Own a small protocol-specific Woge fallback runtime with no mandatory general frontend framework. Keep the native DPU implementation behind the same patch-application boundary and use feature detection to select it only after its semantics are proven. Treat `template-for-polyfill` as native-syntax experiment/compatibility input and htmx as an optional integration, not as replacements for the Woge protocol contract.
+
+The checked-in code is evidence, not production runtime source. M1 should port its observable cases into the production browser module and golden JVM/browser protocol fixtures before publishing an API.

--- a/spikes/fallback-patch-runtime/measure.mjs
+++ b/spikes/fallback-patch-runtime/measure.mjs
@@ -1,0 +1,8 @@
+import { readFile } from "node:fs/promises";
+import { brotliCompressSync, gzipSync } from "node:zlib";
+
+const source = await readFile(new URL("./runtime.js", import.meta.url));
+
+console.log(`runtime_source_bytes=${source.byteLength}`);
+console.log(`runtime_gzip_bytes=${gzipSync(source, { level: 9 }).byteLength}`);
+console.log(`runtime_brotli_bytes=${brotliCompressSync(source).byteLength}`);

--- a/spikes/fallback-patch-runtime/package-lock.json
+++ b/spikes/fallback-patch-runtime/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "woge-fallback-patch-runtime-spike",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "woge-fallback-patch-runtime-spike",
+      "devDependencies": {
+        "@playwright/test": "1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/spikes/fallback-patch-runtime/package.json
+++ b/spikes/fallback-patch-runtime/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "woge-fallback-patch-runtime-spike",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "measure": "node measure.mjs"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/spikes/fallback-patch-runtime/playwright.config.js
+++ b/spikes/fallback-patch-runtime/playwright.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: true,
+  retries: 0,
+  reporter: "line",
+  use: {
+    headless: true,
+  },
+  projects: [
+    { name: "chromium", use: { browserName: "chromium" } },
+    { name: "firefox", use: { browserName: "firefox" } },
+    { name: "webkit", use: { browserName: "webkit" } }
+  ]
+});

--- a/spikes/fallback-patch-runtime/runtime.js
+++ b/spikes/fallback-patch-runtime/runtime.js
@@ -1,0 +1,191 @@
+(() => {
+  "use strict";
+
+  const MAGIC = Uint8Array.of(0x57, 0x4f, 0x47, 0x45, 0x01);
+  const PATCH = 1;
+  const COMPLETE = 2;
+  const ERROR = 3;
+  const MAX_METADATA_BYTES = 64 * 1024;
+  const MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
+  const textDecoder = new TextDecoder("utf-8", { fatal: true });
+  const blockedElements = "script,iframe,object,embed,base,meta[http-equiv]";
+  const urlAttributes = new Set(["href", "src", "action", "formaction", "xlink:href"]);
+
+  class WogePatchError extends Error {
+    constructor(code, message) {
+      super(message);
+      this.name = "WogePatchError";
+      this.code = code;
+    }
+  }
+
+  class FrameDecoder {
+    #buffer = new Uint8Array();
+    #magicRead = false;
+    #terminalRead = false;
+
+    push(chunk) {
+      if (!(chunk instanceof Uint8Array)) fail("WOGE_FRAME_TYPE", "Frame chunk must be bytes");
+      if (this.#terminalRead && chunk.byteLength > 0) fail("WOGE_BYTES_AFTER_TERMINAL", "Bytes follow terminal frame");
+      this.#buffer = concat(this.#buffer, chunk);
+      const frames = [];
+
+      if (!this.#magicRead) {
+        if (this.#buffer.byteLength < MAGIC.byteLength) return frames;
+        for (let index = 0; index < MAGIC.byteLength; index += 1) {
+          if (this.#buffer[index] !== MAGIC[index]) fail("WOGE_PROTOCOL_VERSION", "Unknown stream preamble or version");
+        }
+        this.#buffer = this.#buffer.slice(MAGIC.byteLength);
+        this.#magicRead = true;
+      }
+
+      while (!this.#terminalRead && this.#buffer.byteLength >= 10) {
+        const view = new DataView(this.#buffer.buffer, this.#buffer.byteOffset, 10);
+        const kind = view.getUint8(0);
+        const contentTypeLength = view.getUint8(1);
+        const metadataLength = view.getUint32(2, false);
+        const payloadLength = view.getUint32(6, false);
+        if (![PATCH, COMPLETE, ERROR].includes(kind)) fail("WOGE_FRAME_KIND", `Unknown frame kind: ${kind}`);
+        if (metadataLength > MAX_METADATA_BYTES) fail("WOGE_METADATA_LIMIT", "Frame metadata exceeds 64 KiB");
+        if (payloadLength > MAX_PAYLOAD_BYTES) fail("WOGE_PAYLOAD_LIMIT", "Frame payload exceeds 8 MiB");
+        const frameLength = 10 + contentTypeLength + metadataLength + payloadLength;
+        if (this.#buffer.byteLength < frameLength) return frames;
+
+        let offset = 10;
+        const contentType = decodeAscii(this.#buffer.slice(offset, offset + contentTypeLength));
+        offset += contentTypeLength;
+        const metadataText = decode(textDecoder, this.#buffer.slice(offset, offset + metadataLength), "WOGE_METADATA_ENCODING");
+        offset += metadataLength;
+        const payload = this.#buffer.slice(offset, offset + payloadLength);
+        if ((kind === COMPLETE || kind === ERROR) && payload.byteLength !== 0) {
+          fail("WOGE_TERMINAL_PAYLOAD", "Terminal frame payload must be empty");
+        }
+        frames.push({ kind, contentType, metadataText, payload });
+        this.#buffer = this.#buffer.slice(frameLength);
+        this.#terminalRead = kind === COMPLETE || kind === ERROR;
+      }
+
+      if (this.#terminalRead && this.#buffer.byteLength > 0) fail("WOGE_BYTES_AFTER_TERMINAL", "Bytes follow terminal frame");
+      return frames;
+    }
+
+    finish() {
+      if (!this.#magicRead) fail("WOGE_MISSING_PREAMBLE", "Stream has no complete preamble");
+      if (this.#buffer.byteLength > 0) fail("WOGE_TRUNCATED_FRAME", "Stream ended inside a frame");
+      if (!this.#terminalRead) fail("WOGE_MISSING_TERMINAL", "Stream ended without completion or error");
+    }
+  }
+
+  async function applyPatchStream(stream, root = document) {
+    const epoch = root.querySelector('meta[name="woge-page-epoch"]')?.content;
+    if (!epoch) fail("WOGE_PAGE_EPOCH_MISSING", "Document has no page epoch");
+    const regions = collectRegions(root);
+    const decoder = new FrameDecoder();
+    const reader = stream.getReader();
+    let completeMetadata;
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        for (const frame of decoder.push(value)) {
+          const metadata = parseMetadata(frame.metadataText);
+          if (frame.kind === PATCH) applyReplace(frame, metadata, epoch, regions, root);
+          if (frame.kind === COMPLETE) completeMetadata = metadata;
+          if (frame.kind === ERROR) fail(metadata.code || "WOGE_REMOTE_ERROR", "Server ended patch stream with an error");
+        }
+      }
+      decoder.finish();
+      return completeMetadata;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  function applyReplace(frame, metadata, epoch, regions, root) {
+    if (frame.contentType.toLowerCase() !== "text/html; charset=utf-8") {
+      fail("WOGE_PATCH_CONTENT_TYPE", "Replace patch is not UTF-8 HTML");
+    }
+    if (metadata.operation !== "replace" || metadata.protocolVersion !== 1) {
+      fail("WOGE_PATCH_METADATA", "Unsupported patch operation or protocol");
+    }
+    if (metadata.epoch !== epoch) fail("WOGE_PAGE_EPOCH_STALE", "Patch belongs to another document");
+    const target = regions.get(metadata.target);
+    if (!target) fail("WOGE_TARGET_UNKNOWN", "Patch target is not in the active document");
+    const currentRevision = Number.parseInt(target.dataset.wogeRevision || "", 10);
+    if (!Number.isSafeInteger(currentRevision) || metadata.baseRevision !== currentRevision || metadata.nextRevision !== currentRevision + 1) {
+      fail("WOGE_REVISION_MISMATCH", "Patch does not continue the target revision");
+    }
+
+    const html = decode(textDecoder, frame.payload, "WOGE_HTML_ENCODING");
+    const template = root.createElement("template");
+    template.innerHTML = html;
+    validateInertFragment(template.content);
+    target.replaceChildren(template.content.cloneNode(true));
+    target.dataset.wogeRevision = String(metadata.nextRevision);
+  }
+
+  function collectRegions(root) {
+    const regions = new Map();
+    for (const element of root.querySelectorAll("[data-woge-region]")) {
+      const id = element.getAttribute("data-woge-region");
+      if (!id || regions.has(id)) fail("WOGE_TARGET_DUPLICATE", "Region IDs must be unique");
+      regions.set(id, element);
+    }
+    return regions;
+  }
+
+  function validateInertFragment(fragment) {
+    for (const element of fragment.querySelectorAll("*")) {
+      if (element.matches(blockedElements)) fail("WOGE_PATCH_ACTIVE_ELEMENT", `Patch contains blocked <${element.localName}>`);
+      for (const attribute of element.attributes) {
+        const name = attribute.name.toLowerCase();
+        if (name.startsWith("on") || name === "srcdoc") fail("WOGE_PATCH_ACTIVE_ATTRIBUTE", `Patch contains blocked ${name}`);
+        if (urlAttributes.has(name) && /^(?:[\u0000-\u0020]*)(?:javascript|vbscript|data):/i.test(attribute.value)) {
+          fail("WOGE_PATCH_ACTIVE_URL", `Patch contains blocked ${name} URL`);
+        }
+      }
+      if (element instanceof HTMLTemplateElement) validateInertFragment(element.content);
+    }
+  }
+
+  function parseMetadata(value) {
+    try {
+      const parsed = JSON.parse(value);
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") throw new Error("metadata is not an object");
+      return parsed;
+    } catch {
+      fail("WOGE_METADATA_JSON", "Frame metadata is not valid JSON");
+    }
+  }
+
+  function concat(left, right) {
+    const result = new Uint8Array(left.byteLength + right.byteLength);
+    result.set(left, 0);
+    result.set(right, left.byteLength);
+    return result;
+  }
+
+  function decode(decoder, bytes, code) {
+    try {
+      return decoder.decode(bytes);
+    } catch {
+      fail(code, "Frame text has invalid encoding");
+    }
+  }
+
+  function decodeAscii(bytes) {
+    let value = "";
+    for (const byte of bytes) {
+      if (byte > 0x7f) fail("WOGE_CONTENT_TYPE_ENCODING", "Content type is not ASCII");
+      value += String.fromCharCode(byte);
+    }
+    return value;
+  }
+
+  function fail(code, message) {
+    throw new WogePatchError(code, message);
+  }
+
+  globalThis.WogeFallback = Object.freeze({ applyPatchStream, FrameDecoder, WogePatchError });
+})();

--- a/spikes/fallback-patch-runtime/tests/fallback-runtime.spec.js
+++ b/spikes/fallback-patch-runtime/tests/fallback-runtime.spec.js
@@ -1,0 +1,149 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "@playwright/test";
+import { completeFrame, encodeFrames, errorFrame, patchFrame } from "./protocol-fixture.js";
+
+const runtimePath = fileURLToPath(new URL("../runtime.js", import.meta.url));
+
+test.beforeEach(async ({ page }) => {
+  await page.setContent(`
+    <!doctype html>
+    <html>
+      <head><meta name="woge-page-epoch" content="epoch-a"></head>
+      <body>
+        <main data-woge-region="summary-1" data-woge-revision="0"><p>Original</p></main>
+      </body>
+    </html>
+  `);
+  await page.addScriptTag({ content: await readFile(runtimePath, "utf8") });
+});
+
+test("applies a replace patch from one-byte chunks", async ({ page }) => {
+  const encoded = encodeFrames([
+    patchFrame({ html: '<section class="grid md:grid-cols-2"><woge-card data-state="ready">🐺 Updated</woge-card></section>' }),
+    completeFrame()
+  ]);
+
+  const result = await apply(page, encoded, "one-byte");
+
+  expect(result.error).toBeNull();
+  expect(result.html).toContain("<woge-card");
+  expect(result.html).toContain("🐺 Updated");
+  expect(result.revision).toBe("1");
+});
+
+test("does not depend on one network chunk per frame", async ({ page }) => {
+  const encoded = encodeFrames([patchFrame({ html: "<p>Split safely</p>" }), completeFrame()]);
+
+  for (const split of [0, 1, 4, 5, 9, 17, Math.floor(encoded.length / 2), encoded.length - 1, encoded.length]) {
+    await page.locator("[data-woge-region]").evaluate((element) => {
+      element.innerHTML = "<p>Original</p>";
+      element.dataset.wogeRevision = "0";
+    });
+    const result = await apply(page, encoded, split);
+    expect(result.error, `split ${split}`).toBeNull();
+    expect(result.html).toContain("Split safely");
+  }
+});
+
+test("rejects scripts and inline handlers without changing the DOM", async ({ page }) => {
+  for (const html of [
+    "<p>Unsafe</p><script>globalThis.__patchScriptRan = true</script>",
+    '<img src="missing" onerror="globalThis.__patchScriptRan = true">',
+    '<a href="javascript:globalThis.__patchScriptRan=true">Unsafe</a>',
+    '<template><script>globalThis.__patchScriptRan = true</script></template>'
+  ]) {
+    const encoded = encodeFrames([patchFrame({ html }), completeFrame()]);
+    const result = await apply(page, encoded, "one-byte");
+    expect(result.error).toMatch(/^WOGE_PATCH_ACTIVE_/);
+    expect(result.html).toBe("<p>Original</p>");
+    expect(await page.evaluate(() => globalThis.__patchScriptRan)).toBeUndefined();
+  }
+});
+
+test("fails safely for unknown targets and stale revisions", async ({ page }) => {
+  const unknown = await apply(page, encodeFrames([patchFrame({ target: "missing" }), completeFrame()]), 11);
+  expect(unknown.error).toBe("WOGE_TARGET_UNKNOWN");
+  expect(unknown.html).toBe("<p>Original</p>");
+
+  const stale = await apply(page, encodeFrames([patchFrame({ baseRevision: 9, nextRevision: 10 }), completeFrame()]), 13);
+  expect(stale.error).toBe("WOGE_REVISION_MISMATCH");
+  expect(stale.html).toBe("<p>Original</p>");
+});
+
+test("fails safely for duplicate targets and malformed or error frames", async ({ page }) => {
+  await page.locator("body").evaluate((body) => {
+    body.insertAdjacentHTML("beforeend", '<aside data-woge-region="summary-1" data-woge-revision="0"></aside>');
+  });
+  const duplicate = await apply(page, encodeFrames([patchFrame(), completeFrame()]), 10);
+  expect(duplicate.error).toBe("WOGE_TARGET_DUPLICATE");
+
+  await page.locator("aside").evaluate((element) => element.remove());
+  const complete = encodeFrames([patchFrame(), completeFrame()]);
+  const truncated = await apply(page, complete.slice(0, -1), "one-byte");
+  expect(truncated.error).toBe("WOGE_TRUNCATED_FRAME");
+
+  const remoteError = await apply(page, encodeFrames([errorFrame()]), 7);
+  expect(remoteError.error).toBe("WOGE_RENDER_FAILED");
+});
+
+test("rejects malformed protocol bytes before changing the DOM", async ({ page }) => {
+  const valid = encodeFrames([patchFrame(), completeFrame()]);
+  const malformed = [];
+
+  const badMagic = valid.slice();
+  badMagic[0] = 0;
+  malformed.push([badMagic, "WOGE_PROTOCOL_VERSION"]);
+
+  const oversizedMetadata = valid.slice();
+  new DataView(oversizedMetadata.buffer).setUint32(7, 64 * 1024 + 1, false);
+  malformed.push([oversizedMetadata, "WOGE_METADATA_LIMIT"]);
+
+  const nonAsciiContentType = valid.slice();
+  nonAsciiContentType[15] = 0xff;
+  malformed.push([nonAsciiContentType, "WOGE_CONTENT_TYPE_ENCODING"]);
+
+  const invalidMetadata = valid.slice();
+  const metadataStart = 15 + invalidMetadata[6];
+  invalidMetadata[metadataStart] = "!".charCodeAt(0);
+  malformed.push([invalidMetadata, "WOGE_METADATA_JSON"]);
+
+  const terminalOnly = encodeFrames([completeFrame()]);
+  const trailingByte = new Uint8Array(terminalOnly.byteLength + 1);
+  trailingByte.set(terminalOnly);
+  trailingByte[terminalOnly.byteLength] = 1;
+  malformed.push([trailingByte, "WOGE_BYTES_AFTER_TERMINAL"]);
+
+  for (const [bytes, expectedError] of malformed) {
+    const result = await apply(page, bytes, "one-byte");
+    expect(result.error).toBe(expectedError);
+    expect(result.html).toBe("<p>Original</p>");
+    expect(result.revision).toBe("0");
+  }
+});
+
+async function apply(page, encoded, split) {
+  return page.evaluate(
+    async ({ bytes, splitAt }) => {
+      const all = Uint8Array.from(bytes);
+      const chunks = splitAt === "one-byte"
+        ? Array.from(all, (byte) => Uint8Array.of(byte))
+        : [all.slice(0, splitAt), all.slice(splitAt)];
+      const stream = new ReadableStream({
+        start(controller) {
+          chunks.forEach((chunk) => controller.enqueue(chunk));
+          controller.close();
+        }
+      });
+      let error = null;
+      try {
+        await globalThis.WogeFallback.applyPatchStream(stream);
+      } catch (failure) {
+        error = failure.code || failure.name;
+      }
+      const region = document.querySelector('[data-woge-region="summary-1"]');
+      return { error, html: region.innerHTML, revision: region.dataset.wogeRevision };
+    },
+    { bytes: Array.from(encoded), splitAt: split }
+  );
+}

--- a/spikes/fallback-patch-runtime/tests/protocol-fixture.js
+++ b/spikes/fallback-patch-runtime/tests/protocol-fixture.js
@@ -1,0 +1,55 @@
+const encoder = new TextEncoder();
+
+export function patchFrame({
+  target = "summary-1",
+  epoch = "epoch-a",
+  baseRevision = 0,
+  nextRevision = 1,
+  html = "<p>Updated</p>"
+} = {}) {
+  return {
+    kind: 1,
+    contentType: "text/html; charset=utf-8",
+    metadata: { protocolVersion: 1, operation: "replace", target, epoch, baseRevision, nextRevision },
+    payload: encoder.encode(html)
+  };
+}
+
+export function completeFrame() {
+  return { kind: 2, contentType: "application/json; charset=utf-8", metadata: { patches: 1 }, payload: new Uint8Array() };
+}
+
+export function errorFrame() {
+  return {
+    kind: 3,
+    contentType: "application/problem+json; charset=utf-8",
+    metadata: { code: "WOGE_RENDER_FAILED", correlationId: "test-1" },
+    payload: new Uint8Array()
+  };
+}
+
+export function encodeFrames(frames) {
+  const parts = [Uint8Array.of(0x57, 0x4f, 0x47, 0x45, 0x01)];
+  for (const frame of frames) {
+    const contentType = encoder.encode(frame.contentType);
+    const metadata = encoder.encode(JSON.stringify(frame.metadata));
+    const header = new Uint8Array(10);
+    const view = new DataView(header.buffer);
+    view.setUint8(0, frame.kind);
+    view.setUint8(1, contentType.byteLength);
+    view.setUint32(2, metadata.byteLength, false);
+    view.setUint32(6, frame.payload.byteLength, false);
+    parts.push(header, contentType, metadata, frame.payload);
+  }
+  return concat(parts);
+}
+
+function concat(parts) {
+  const result = new Uint8Array(parts.reduce((size, part) => size + part.byteLength, 0));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.byteLength;
+  }
+  return result;
+}


### PR DESCRIPTION
## Outcome

- proves the version-1 Woge fallback patch path in Chromium, Firefox and WebKit
- decodes length-prefixed frames independently of Fetch chunk boundaries
- validates page epoch, region identity and contiguous revisions before replacement
- rejects executable patch content and malformed protocol data with stable errors
- records runtime size, browser constraints and comparison with `template-for-polyfill` and htmx
- accepts ADR 0014: own a small protocol-specific fallback runtime while keeping native DPU and other libraries behind adapters

## Verification

- `npm test` — 18 passed across Chromium, Firefox and WebKit
- `npm run measure` — 8,050 source bytes; 2,706 gzip; 2,284 Brotli
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #4
