### PR TITLE
Spike native Declarative Partial Updates

### DIFF
--- a/.github/workflows/native-dpu-spike.yml
+++ b/.github/workflows/native-dpu-spike.yml
@@ -1,0 +1,33 @@
+name: Native DPU spike
+
+on:
+  pull_request:
+    paths:
+      - "spikes/native-dpu/**"
+      - ".github/workflows/native-dpu-spike.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "spikes/native-dpu/**"
+      - ".github/workflows/native-dpu-spike.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  chromium-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: spikes/native-dpu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: spikes/native-dpu/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm test

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [HTML writer strategy spike](../spikes/html-writer-strategy/evidence.md)
 - [Patch framing spike](../spikes/patch-framing/evidence.md)
 - [Cross-browser fallback patch runtime spike](../spikes/fallback-patch-runtime/evidence.md)
+- [Native Declarative Partial Updates spike](../spikes/native-dpu/evidence.md)
 - [Threat model](security/threat-model.md)
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)

--- a/docs/adr/0015-limit-native-dpu-to-initial-document-optimization.md
+++ b/docs/adr/0015-limit-native-dpu-to-initial-document-optimization.md
@@ -1,0 +1,73 @@
+# ADR 0015: Limit native DPU to an opt-in initial-document optimization
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owners: Woge maintainers
+- Related issues: [#3](https://github.com/christian-draeger/woge/issues/3), [#4](https://github.com/christian-draeger/woge/issues/4), [#11](https://github.com/christian-draeger/woge/issues/11), [#19](https://github.com/christian-draeger/woge/issues/19), [#21](https://github.com/christian-draeger/woge/issues/21), [#42](https://github.com/christian-draeger/woge/issues/42)
+
+## Context
+
+Chrome 150 shipped `<template for>` out-of-order streaming and HTML processing instructions. The public WICG design continues to evolve and other Woge-supported engines do not yet provide the same path. Woge needs to decide how much of this now-real browser primitive to expose without making Chrome syntax, parser trust or browser timing part of its Kotlin API.
+
+The [native DPU spike](../../spikes/native-dpu/evidence.md) ran real streamed HTTP fixtures in Chrome for Testing 151. Marker replacement, range replacement, repeated append, nested/parent/shadow scoping, a body-to-head patch and completion-order delivery worked in stable configuration. Script-initiated `streamAppendHTMLUnsafe` required the experimental flag. A fragment parser could not reach the existing document.
+
+The security fixture is decisive: a script and inline error handler delivered inside a native parser patch both executed. Native DPU supplies parser patching, not Woge's inert-patch, epoch, revision, framing, limit or terminal-error contract.
+
+## Decision
+
+The maximum MVP support for native DPU is an opt-in limited-availability encoder for initial-document completion-order patches on Chrome 150 and newer. It remains an internal implementation of transport-neutral Patch IR and does not appear in component, action, page, Spring, Ktor or application-domain APIs.
+
+The adapter is off by default until its capability negotiation and parity suite ship. An application enabling it accepts the named Chrome-only optimization tier; every affected region still provides the complete or linked HTML-only fallback required by [ADR 0007](0007-browser-support-and-progressive-enhancement.md). Unsupported, absent or unadvertised capability uses the complete-page or Woge fallback path. User-agent sniffing is not capability detection.
+
+Initial mappings are deliberately narrow:
+
+- child/range replacement uses generated `<?start name="…">` and `<?end>` instructions;
+- ordered append uses a generated marker that each non-terminal template deliberately re-emits;
+- generated templates are placed in the narrowest owning parent/tree scope;
+- a body-level template is reserved for a page-owned target that genuinely needs page/head reach;
+- target names are opaque, page-scoped generated values and never application selectors.
+
+The native channel accepts only Woge-structured, context-encoded markup whose element/attribute stream is known to contain no active content. Raw/unsafe HTML, script, inline handlers, `srcdoc`, executable URLs and equivalent escape hatches make the native encoder ineligible and fail or route through a separately reviewed path before bytes are committed. Native parser behavior is never described as sanitization.
+
+The stable action, enhanced-navigation and live-update path continues to use the framed cross-browser runtime from [ADR 0014](0014-small-owned-fallback-patch-runtime.md). Woge does not use experimental `streamAppendHTMLUnsafe` for those MVP responses: it would still need the Woge decoder and identity checks, adds active parser semantics, and cannot express terminal/truncation or revision rules itself.
+
+Client-side feature detection may use the reflected `HTMLTemplateElement.prototype.htmlFor` capability, backed by a behavioral canary if browser evidence requires it. Because the server cannot observe a browser property on the first request, native response selection requires an explicit previously established client capability signal or application/deployment opt-in strategy. A missing or stale signal must fail toward the supported fallback, not toward an unresolved loading-only page.
+
+An unresolved native template remains in the DOM and becomes a development diagnostic signal. It is not a reliable production error transport. Native/fallback parity tests own content, order and accessibility outcomes; exact DOM marker/template residue is adapter-internal.
+
+This ADR refines the possible native adapter anticipated by ADRs 0007 and 0014. It does not make the Chrome-only path part of Woge's supported cross-browser enhancement tier.
+
+## Alternatives considered
+
+- **Use native DPU for every Chrome patch:** rejected because action/live patches still need framing, identity, revisions, safe terminal errors and active-content controls.
+- **Make Chrome DPU the default initial response:** rejected because first-request capability is not directly available and unresolved templates/loading content would weaken the HTML baseline elsewhere.
+- **Infer support from the User-Agent header:** rejected because it is brittle, proxy/cache-hostile and cannot verify runtime behavior.
+- **Adopt `template-for-polyfill` for every non-Chrome browser:** rejected as a mandatory layer because it buffers, has parser-observation differences and would add another runtime path; it remains test/reference input.
+- **Ignore native DPU until all browsers ship:** rejected because an isolated encoder and executable fixture let Woge learn from the platform without exposing it publicly.
+- **Allow trusted/raw HTML because it came from the server:** rejected because the observed native sink executes active markup and server origin does not prove every rendered value or extension is safe.
+
+## Consequences
+
+### Positive
+
+- Woge can exploit real browser completion-order parsing without coupling Kotlin applications to proposal syntax.
+- Spring MVC, WebFlux and Ktor retain identical public ports and Patch IR.
+- Cross-browser security, ordering and failure semantics remain canonical.
+- Generated parent/tree placement uses the platform's scope boundary instead of page-wide names by default.
+- The opt-in tier can expand if interoperability and safe insertion APIs improve.
+
+### Negative
+
+- The MVP may ship no enabled native adapter until negotiation/parity work is complete.
+- Native initial documents and framed updates need separate encoder/TCK coverage.
+- Raw HTML or executable extensions cannot use the native optimization.
+- Capability signaling across requests adds cache-variation and expiry concerns.
+- Chrome's native DOM residue/error behavior is less explicit than Woge protocol errors.
+
+## Follow-up
+
+- Keep the fixture pinned and update the exact Chrome status in release evidence; any non-Chromium implementation triggers parity testing before support expands.
+- Model generated range/marker encoding behind Patch IR in [#19](https://github.com/christian-draeger/woge/issues/19), not in component APIs.
+- Add active-content eligibility and hostile-markup parity to [#42](https://github.com/christian-draeger/woge/issues/42).
+- Design capability signaling, cache variation and fallback behavior with enhanced navigation rather than adding browser checks to server adapters.
+- Revisit experimental Streaming HTML methods only after they ship in the stable supported matrix and provide a measurable benefit over Woge's small runtime.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0012](0012-html-writer-and-kotlinx-interop.md) | Accepted | Own a minimal streaming HTML writer with kotlinx.html interop |
 | [0013](0013-length-prefixed-patch-framing.md) | Accepted | Use explicit length-prefixed patch frames |
 | [0014](0014-small-owned-fallback-patch-runtime.md) | Accepted | Own a small protocol-specific fallback patch runtime |
+| [0015](0015-limit-native-dpu-to-initial-document-optimization.md) | Accepted | Limit native DPU to an opt-in initial-document optimization |

--- a/docs/architecture/browser-support-policy.md
+++ b/docs/architecture/browser-support-policy.md
@@ -15,6 +15,8 @@ Last policy review: 2026-09-03.
 
 “Current and previous” is evaluated on the release date, not hard-coded in library source. A release record names exact versions. Playwright's WebKit is a useful cross-engine signal but is not branded Safari, so it does not replace the release smoke test. Unsupported legacy browsers and embedded webviews may still receive the HTML baseline, but they are not compatibility targets until an adapter documents them.
 
+Chrome 150 shipped native `<template for>` out-of-order streaming, but this remains a limited-availability Woge adapter rather than part of the supported enhancement tier. The [native DPU evidence](../../spikes/native-dpu/evidence.md) limits M0/MVP use to an off-by-default Chrome 150+ initial-document encoder for Woge-generated active-content-free patches. Framed action, navigation and live updates continue through the cross-browser runtime. [ADR 0015](../adr/0015-limit-native-dpu-to-initial-document-optimization.md) records the full ceiling and capability-negotiation constraint.
+
 The enhancement runtime may depend by default only on APIs available across the supported stable set. A narrowly missing API needs a tested fallback or a small replaceable polyfill; user-agent sniffing is not a substitute for capability detection.
 
 ## Behavior without JavaScript
@@ -76,5 +78,7 @@ The CSS authoring spike in [#88](https://github.com/christian-draeger/woge/issue
 - [Web Platform Baseline](https://web.dev/baseline)
 - [Playwright browser coverage](https://playwright.dev/docs/browsers)
 - [W3C CSS Snapshot 2026](https://www.w3.org/TR/css-2026/)
+- [Chrome 150 out-of-order streaming release note](https://developer.chrome.com/release-notes/150#out_of_order_streaming)
+- [WICG Declarative Partial Updates patching explainer](https://github.com/WICG/declarative-partial-updates/blob/main/patching-explainer.md)
 - [WCAG 2.2 understanding focus order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
 - [WCAG 2.2 understanding status messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html)

--- a/spikes/native-dpu/.gitignore
+++ b/spikes/native-dpu/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/spikes/native-dpu/evidence.md
+++ b/spikes/native-dpu/evidence.md
@@ -1,0 +1,90 @@
+# Native Declarative Partial Updates evidence
+
+Recorded on 2026-09-03 with Node.js 24, Playwright 1.62.1 and Chrome for Testing 151.0.7922.34. The executable fixtures are in [`fixtures/primitives.html`](fixtures/primitives.html) and [`tests/native-dpu.spec.js`](tests/native-dpu.spec.js).
+
+## Status changed during M0
+
+The issue began as an experimental-Chromium question. The platform moved while Woge was planning: [Chrome 150 release notes](https://developer.chrome.com/release-notes/150#out_of_order_streaming) list out-of-order streaming and HTML processing instructions as stable DOM/HTML features. Chrome 151 therefore applies `<template for>` without an experiment flag.
+
+The wider script-initiated Streaming HTML API is still separate. In the tested Chrome 151 build, `streamAppendHTMLUnsafe` is absent in the normal configuration and present with `--enable-experimental-web-platform-features`.
+
+This is still a limited-availability platform feature rather than a Woge cross-browser guarantee. Firefox and WebKit continue to use Woge's supported fallback path.
+
+## Reproduction matrix
+
+The suite runs every case once in normal Chromium and once with experimental web-platform features enabled:
+
+```shell
+cd spikes/native-dpu
+npm ci
+npx playwright install chromium
+npm test
+```
+
+```text
+chromium-stable:                      6 passed, 1 streaming-API case skipped
+chromium-experimental-html-streaming: 7 passed
+total:                               13 passed, 1 skipped
+```
+
+The CI workflow repeats the same pinned matrix on Linux. Tests use a real local HTTP response parser, not only `innerHTML` or a DOM reconstruction.
+
+## Observed patch primitives
+
+| Woge-relevant behavior | Native syntax | Chrome 151 observation |
+| --- | --- | --- |
+| Replace one marker | `<?marker name="x">` then `<template for="x">…</template>` | Template content replaces the marker; the applied template is removed |
+| Replace a range | `<?start name="x">fallback<?end>` | Both instructions and the fallback range are replaced atomically when the template closes |
+| Append repeatedly | Each template writes content and a new `<?marker name="x">` | Two templates append in parser/completion order and leave the final marker available |
+| Nested ranges | Inner start/end inside an outer start/end | Inner patch applies while the outer range remains addressable |
+| Local parent scope | Template inside an owner element targets its descendants | Applies within that parent subtree |
+| Cross-parent scope | Template in a sibling owner targets a marker outside its parent | Does not apply; target stays unchanged and the template remains in the DOM as an error signal |
+| Shadow tree scope | Light and declarative-shadow trees reuse the same name | Each same-name template resolves only in its own tree scope |
+| Body exception | Body-level template targets a head marker | Applies to the head, matching the documented page-wide exception |
+
+Markers are real `ProcessingInstruction` nodes (`nodeType === 7`) in supporting Chrome. A repeated append is not a separate `append` operation: the prior template must deliberately emit the next marker. If it omits that marker, the address disappears.
+
+Names and tree/parent placement are therefore observable protocol data. Woge must generate opaque collision-resistant names and place a template in the narrowest owner scope. A body-level template has page-wide reach and is reserved for a page-owned target such as head metadata.
+
+## Completion-order streaming
+
+The test server writes both placeholders first, then exposes its live HTTP response to the test. The test deliberately releases the `fast` template while the earlier `slow` region remains pending, observes `Fast ready` in the DOM, verifies `Slow pending` is still visible, and only then releases the slow template and closes the response.
+
+This demonstrates actual completion-order HTML parsing without timers or an assumption that coroutine completion follows document order. It also confirms that a template becomes visible when its closing tag is parsed, before the response completes.
+
+## Parser and dynamic-update constraints
+
+- A template parsed through `insertAdjacentHTML` belongs to an intermediate fragment and cannot reach an existing document marker. In the fixture the target remains pending and the inert template remains in the body.
+- With the experiment flag, writing the same template through `body.streamAppendHTMLUnsafe()` uses a streaming parser attached to the existing tree and does patch the descendant.
+- The stable `HTMLTemplateElement.prototype.htmlFor` reflection is a usable client-side capability signal in Chrome 151. It does not let the server know support on the first request, so Woge must not replace capability negotiation with user-agent sniffing.
+- The native mechanism has no Woge page epoch, target revision, terminal completion/error frame, size ceiling or stale-intent rule. Those remain responsibilities of the framed fallback/action protocol.
+- A template that cannot resolve does not produce a transport error; it stays in the DOM. Production diagnostics would have to detect/report that condition separately.
+
+## Security observation
+
+The most important negative fixture puts a classic script and an image `onerror` handler inside an initial-parser native patch. Chrome 151 inserts both and executes both. Native DPU is therefore not an inert/sanitizing sink and cannot directly satisfy Woge's WOGE-XSS-002 patch contract.
+
+This does not make the platform feature inherently unsafe: parser-delivered application HTML traditionally has active semantics. It does mean Woge may use the native path only for structurally generated, context-encoded patch markup that has passed an active-content policy. An `UnsafeHtml`/raw block, script, inline handler, `srcdoc` or active URL cannot enter this channel. Content requiring an explicit executable extension remains an external module/island outside the patch.
+
+The native path also cannot inspect a later malformed template before the HTML parser mutates earlier valid targets. Woge must preserve the same streaming partial-commit model and never claim response-wide atomicity.
+
+## Maximum recommended support
+
+For the MVP, native DPU is an opt-in, limited-availability encoder for initial-document completion-order patches in Chrome 150+. It is suitable only when:
+
+1. the public Kotlin operation already maps to the transport-neutral Patch IR;
+2. all target names and template placement are generated by Woge;
+3. the rendered patch is structurally known to contain no active/raw content;
+4. the region's complete or linked HTML-only fallback still meets the browser policy;
+5. absence or failure of native support selects the normal complete-page or Woge fallback behavior.
+
+Do not use `streamAppendHTMLUnsafe` as the MVP action/live-update sink. It is still experimental in the tested stable Chrome configuration, does not remove the need for Woge framing/ordering checks, and has active parser semantics. Action, navigation and live responses continue through the cross-browser runtime accepted by [ADR 0014](../../docs/adr/0014-small-owned-fallback-patch-runtime.md).
+
+The adapter stays off by default until capability negotiation and native/fallback parity tests exist. It never changes the public Kotlin API and never becomes a Spring-, Ktor- or browser-specific application concept.
+
+## Primary references
+
+- [Chrome 150: Out of order streaming](https://developer.chrome.com/release-notes/150#out_of_order_streaming)
+- [Chrome: Declarative partial updates](https://developer.chrome.com/blog/declarative-partial-updates)
+- [WICG patching explainer](https://github.com/WICG/declarative-partial-updates/blob/main/patching-explainer.md)
+- [WHATWG HTML pull request 11818](https://github.com/whatwg/html/pull/11818)

--- a/spikes/native-dpu/fixtures/primitives.html
+++ b/spikes/native-dpu/fixtures/primitives.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Woge native DPU primitives</title>
+    <?marker name="head-marker">
+  </head>
+  <body>
+    <section id="marker">Before <?marker name="single"> After</section>
+
+    <section id="range">
+      <?start name="range"><em>Range pending</em><?end>
+    </section>
+
+    <ul id="items"><?marker name="items"></ul>
+
+    <section id="local-scope">
+      <div id="local-target"><?start name="local-target">Local pending<?end></div>
+      <template for="local-target"><strong>Local ready</strong></template>
+    </section>
+
+    <section id="nested-ranges">
+      <?start name="outer-range">
+      <div id="inner-range"><?start name="inner-range">Inner pending<?end></div>
+      <?end>
+    </section>
+
+    <div id="light-target"><?start name="same-name">Light pending<?end></div>
+    <div id="shadow-host">
+      <template shadowrootmode="open">
+        <section id="shadow-target"><?start name="same-name">Shadow pending<?end></section>
+        <template for="same-name"><strong>Shadow ready</strong></template>
+      </template>
+    </div>
+
+    <section id="left-scope">
+      <div id="cross-scope-target"><?start name="cross-scope">Cross-scope pending<?end></div>
+    </section>
+    <section id="right-scope">
+      <template for="cross-scope"><strong>Must not cross scope</strong></template>
+    </section>
+
+    <section id="dynamic-target"><?start name="dynamic-target">Dynamic pending<?end></section>
+
+    <template for="single"><strong>Inserted</strong></template>
+    <template for="range"><strong>Range ready</strong></template>
+    <template for="items"><li>One</li><?marker name="items"></template>
+    <template for="items"><li>Two</li><?marker name="items"></template>
+    <template for="inner-range"><strong>Inner ready</strong></template>
+    <template for="same-name"><strong>Light ready</strong></template>
+    <template for="head-marker"><meta name="dpu-head-patched" content="yes"></template>
+  </body>
+</html>

--- a/spikes/native-dpu/package-lock.json
+++ b/spikes/native-dpu/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "woge-native-dpu-spike",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "woge-native-dpu-spike",
+      "devDependencies": {
+        "@playwright/test": "1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/spikes/native-dpu/package.json
+++ b/spikes/native-dpu/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "woge-native-dpu-spike",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/spikes/native-dpu/playwright.config.js
+++ b/spikes/native-dpu/playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: true,
+  retries: 0,
+  reporter: "line",
+  use: { headless: true },
+  projects: [
+    {
+      name: "chromium-stable",
+      use: { browserName: "chromium" }
+    },
+    {
+      name: "chromium-experimental-html-streaming",
+      use: {
+        browserName: "chromium",
+        launchOptions: { args: ["--enable-experimental-web-platform-features"] }
+      }
+    }
+  ]
+});

--- a/spikes/native-dpu/tests/native-dpu.spec.js
+++ b/spikes/native-dpu/tests/native-dpu.spec.js
@@ -1,0 +1,141 @@
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "@playwright/test";
+
+const fixturePath = fileURLToPath(new URL("../fixtures/primitives.html", import.meta.url));
+const primitiveFixture = await readFile(fixturePath);
+
+let server;
+let origin;
+let activeStream;
+
+test.beforeAll(async () => {
+  server = createServer((request, response) => {
+    if (request.url === "/primitives") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" });
+      response.end(primitiveFixture);
+      return;
+    }
+
+    if (request.url === "/completion-order") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" });
+      response.flushHeaders();
+      response.write(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Completion order</title></head><body>
+        <main>
+          <section id="slow"><?start name="slow">Slow pending<?end></section>
+          <section id="fast"><?start name="fast">Fast pending<?end></section>
+        </main>`);
+      activeStream = response;
+      return;
+    }
+
+    if (request.url === "/active-content") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" });
+      response.end(`<!doctype html><html lang="en"><body>
+        <section id="active-content"><?start name="active-content">Pending<?end></section>
+        <template for="active-content">
+          <script>globalThis.__nativePatchScript = "executed"</script>
+          <img src="/missing-native-patch" alt="" onerror="globalThis.__nativePatchHandler = 'executed'">
+        </template>
+      </body></html>`);
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  origin = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterEach(() => {
+  if (activeStream && !activeStream.writableEnded) activeStream.end("</body></html>");
+  activeStream = undefined;
+});
+
+test.afterAll(async () => {
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+});
+
+test("applies marker replacement, range replacement and repeated append", async ({ page }) => {
+  await page.goto(`${origin}/primitives`);
+
+  await expect(page.locator("#marker")).toHaveText("Before Inserted After");
+  await expect(page.locator("#range")).toHaveText("Range ready");
+  await expect(page.locator("#items > li")).toHaveText(["One", "Two"]);
+  await expect(page.locator('head meta[name="dpu-head-patched"]')).toHaveAttribute("content", "yes");
+
+  const markerNode = await page.locator("#items").evaluate((element) => {
+    const node = [...element.childNodes].at(-1);
+    return { type: node.nodeType, name: node.nodeName, value: node.nodeValue };
+  });
+  expect(markerNode).toEqual({ type: 7, name: "marker", value: 'name="items"' });
+});
+
+test("keeps nested, parent and shadow tree scopes separate", async ({ page }) => {
+  await page.goto(`${origin}/primitives`);
+
+  await expect(page.locator("#local-target")).toHaveText("Local ready");
+  await expect(page.locator("#inner-range")).toHaveText("Inner ready");
+  await expect(page.locator("#light-target")).toHaveText("Light ready");
+  expect(await page.locator("#shadow-host").evaluate((host) => host.shadowRoot.querySelector("#shadow-target").textContent.trim())).toBe("Shadow ready");
+
+  await expect(page.locator("#cross-scope-target")).toHaveText("Cross-scope pending");
+  await expect(page.locator("#right-scope template[for='cross-scope']")).toHaveCount(1);
+});
+
+test("applies patches in server completion order", async ({ page }) => {
+  await page.goto(`${origin}/completion-order`, { waitUntil: "commit" });
+  await expect(page.locator("#fast")).toHaveText("Fast pending");
+  await expect.poll(() => Boolean(activeStream)).toBe(true);
+
+  activeStream.write('<template for="fast"><strong>Fast ready</strong></template>');
+  await expect(page.locator("#fast")).toHaveText("Fast ready");
+  await expect(page.locator("#slow")).toHaveText("Slow pending");
+
+  activeStream.end('<template for="slow"><strong>Slow ready</strong></template></body></html>');
+  await page.waitForLoadState("load");
+  await expect(page.locator("#slow")).toHaveText("Slow ready");
+});
+
+test("does not let a fragment parser patch the existing document", async ({ page }) => {
+  await page.goto(`${origin}/primitives`);
+
+  await page.locator("body").evaluate((body) => {
+    body.insertAdjacentHTML("beforeend", '<template for="dynamic-target"><strong>Fragment parser</strong></template>');
+  });
+
+  await expect(page.locator("#dynamic-target")).toHaveText("Dynamic pending");
+  await expect(page.locator("body > template[for='dynamic-target']")).toHaveCount(1);
+});
+
+test("experimental streaming parser can patch an existing descendant", async ({ page }) => {
+  await page.goto(`${origin}/primitives`);
+  const supported = await page.evaluate(() => "streamAppendHTMLUnsafe" in Element.prototype);
+  test.skip(!supported, "The script-initiated streaming HTML API is not enabled in this Chromium configuration");
+
+  await page.locator("body").evaluate(async (body) => {
+    const writer = body.streamAppendHTMLUnsafe().getWriter();
+    await writer.write('<template for="dynamic-target"><strong>Streaming parser</strong></template>');
+    await writer.close();
+  });
+
+  await expect(page.locator("#dynamic-target")).toHaveText("Streaming parser");
+});
+
+test("records that native parser patches execute active markup", async ({ page }) => {
+  await page.goto(`${origin}/active-content`);
+
+  await expect.poll(() => page.evaluate(() => globalThis.__nativePatchHandler)).toBe("executed");
+  expect(await page.evaluate(() => globalThis.__nativePatchScript)).toBe("executed");
+  await expect(page.locator("#active-content script")).toHaveCount(1);
+});
+
+test("exposes a detectable template-for capability", async ({ page }) => {
+  await page.goto(`${origin}/primitives`);
+
+  expect(await page.evaluate(() => "htmlFor" in HTMLTemplateElement.prototype)).toBe(true);
+});


### PR DESCRIPTION
## Outcome

- verifies current native `<template for>` behavior in Chrome for Testing 151
- proves marker/range replacement, repeated append, nested/parent/shadow scopes and body-to-head reach
- demonstrates deterministic completion-order streaming over a real HTTP response
- records fragment-parser and experimental Streaming HTML constraints
- captures the security-critical fact that native parser patches execute scripts and inline handlers
- accepts ADR 0015, limiting native DPU to an off-by-default Chrome 150+ initial-document optimization over transport-neutral Patch IR
- updates the living browser-support policy to reflect Chrome 150 stable shipment without weakening cross-browser guarantees

## Verification

- `npm test` — 13 passed; one expected stable-Chrome skip; all seven cases pass with experimental HTML streaming enabled
- `npm audit --audit-level=high` — 0 vulnerabilities
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`

Closes #3
