### PR TITLE
Publish the MVP boundary

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Validate architecture decisions
         run: ./scripts/validate-adrs.sh
       - name: Validate module boundaries

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Woge is an HTML-first Kotlin framework for typed, server-driven and progressively enhanced web applications.
 
-The project is in its architecture and product-validation phase. It is not ready for application use yet.
+The M0 architecture and product-validation baseline is complete. Implementation begins with the M1 walking skeleton; Woge is not ready for application use yet.
 
 ## Direction
 
@@ -16,6 +16,7 @@ The project is in its architecture and product-validation phase. It is not ready
 ## Project documentation
 
 - [Documentation index](docs/README.md)
+- [MVP boundary](docs/mvp-boundary.md)
 - [Architecture decisions](docs/adr/README.md)
 - [Documentation style guide](docs/documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](docs/ai-dx/evaluation.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,12 @@ The documentation grows with executable product slices. Pages describing unimple
 ## Start here
 
 - [Project direction](../README.md)
-- [Architecture decision records](adr/README.md)
+- [MVP boundary and definition of done](mvp-boundary.md)
 - [Reference application](product/reference-application.md)
-- [Hand-written Spring HTML baseline](../spikes/spring-html-htmx-baseline/evidence.md)
+- [Architecture decision records](adr/README.md)
+
+## Canonical architecture guidance
+
 - [Spring MVC and WebFlux support model](architecture/spring-support-model.md)
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)
 - [CSS authoring](architecture/css-authoring.md)
@@ -15,6 +18,16 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Component distribution](architecture/component-distribution.md)
 - [Frontend extensibility and complex-screen acceptance](architecture/frontend-extensibility.md)
 - [Component identity, page epochs and revisions](architecture/identity-and-revisions.md)
+- [Threat model](security/threat-model.md)
+- [Documentation style guide](documentation/style-guide.md)
+- [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
+- [AI-DX evaluation corpus](ai-dx/corpus-v0.1.md)
+
+## Executable M0 evidence
+
+The spikes below justify accepted decisions. Their code is evidence, not a production API or a second source of current guidance.
+
+- [Hand-written Spring HTML baseline](../spikes/spring-html-htmx-baseline/evidence.md)
 - [Typed web-reference spike](../spikes/typed-reference-model/evidence.md)
 - [HTML writer strategy spike](../spikes/html-writer-strategy/evidence.md)
 - [Patch framing spike](../spikes/patch-framing/evidence.md)
@@ -23,10 +36,6 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Standards-native CSS authoring spike](../spikes/css-authoring/evidence.md)
 - [Tailwind with Kotlin templates spike](../spikes/tailwind-kotlin/evidence.md)
 - [Component distribution spike](../spikes/component-distribution/evidence.md)
-- [Threat model](security/threat-model.md)
-- [Documentation style guide](documentation/style-guide.md)
-- [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
-- [AI-DX evaluation corpus](ai-dx/corpus-v0.1.md)
 
 ## Planned documentation layers
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,3 +45,5 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0016](0016-standards-native-css-authoring.md) | Accepted | Keep CSS standards-native with optional build-time scoping |
 | [0017](0017-optional-tailwind-build-adapter.md) | Accepted | Integrate Tailwind through an optional build adapter |
 | [0018](0018-hybrid-headless-and-source-owned-components.md) | Accepted | Combine binary headless primitives with source-owned component recipes |
+
+ADRs 0001–0018 are the complete accepted M0 decision set. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis; executable spikes are supporting evidence and do not override an accepted ADR. Issue [#12](https://github.com/christian-draeger/woge/issues/12) is exempt from a separate ADR because it indexes and assembles these decisions rather than adding one.

--- a/docs/mvp-boundary.md
+++ b/docs/mvp-boundary.md
@@ -1,0 +1,87 @@
+# Woge MVP boundary
+
+This is the short, reviewable source of truth for what Woge will deliver as its MVP. It assembles the accepted M0 decisions; it does not introduce a new architecture decision.
+
+The MVP spans **M1 through M3**. M1 builds the walking skeleton, M2 completes reactive actions, and M3 hardens and releases the result. M4 is the broader version 1.0 product, not hidden MVP scope.
+
+## Product promise
+
+Woge is an HTML-first Kotlin library for typed, server-driven and progressively enhanced web applications. Web developers keep using HTML elements, URLs, links, forms, HTTP, CSS, browser APIs and normal developer tools. Kotlin adds type-safe references, exhaustive state and compiler feedback; it does not replace the web platform with a Compose-style UI model.
+
+Core navigation and mutations work as useful server-rendered pages without JavaScript. A small browser runtime can apply authorized, revision-checked patches for faster actions and streamed content. The server remains authoritative.
+
+## MVP capabilities
+
+By the end of M3, the MVP includes:
+
+- framework-neutral Kotlin APIs for pages, components, regions, actions and patch outcomes;
+- generated typed page URLs, action registrations, component/region references and form commands;
+- escaped buffered and streaming HTML with an explicit `kotlinx.html` interop boundary;
+- structured deferred regions and a length-framed, transport-neutral patch protocol;
+- a small owned cross-browser runtime for replace, append, remove and announce operations;
+- ordinary links and Post/Redirect/Get forms plus enhanced form requests, validation and multi-region updates;
+- page epochs, target revisions, stable keyed identity and focus/dirty-control preservation;
+- authorized Server-Sent Events (SSE), cancellation, backpressure and reconnect diagnostics;
+- first-class Spring MVC, Spring WebFlux and Ktor adapters behind one host SPI and adapter TCK;
+- Spring Boot starter/auto-configuration as the primary setup and documentation path;
+- ordinary current CSS, IDE-recognized CSS literals and optional deterministic build-time scoping;
+- optional Tailwind build integration with explicit Kotlin/generated/registry source discovery;
+- an accessible binary headless UI primitive foundation that applications style with ordinary CSS or Tailwind;
+- strict output, CSRF, authorization, CSP, accessibility, browser and performance hardening;
+- published JVM artifacts, coherent Gradle tasks and executable web-first documentation;
+- compile-verified examples and scored AI-DX checks using the same supported public APIs as humans.
+
+The optional native Declarative Partial Updates encoder may appear in M3 only as an off-by-default Chrome 150+ initial-document optimization. The cross-browser runtime remains the supported path, and the MVP may ship with no native encoder enabled.
+
+## Host support and parity
+
+| Host | MVP status | Promise |
+| --- | --- | --- |
+| Spring Boot + Spring MVC | First-class; primary getting-started path | Full page, action, patch and live-update semantics through the shared TCK |
+| Spring Boot + Spring WebFlux | First-class; primary reactive Spring path | The same Woge semantics and TCK, with non-blocking execution and explicit isolation for blocking work |
+| Ktor | First-class Kotlin alternative | The same portable application/component API and TCK; secondary, host-specific setup documentation |
+
+Parity means equivalent Woge-visible status, headers, HTML/patch meaning, validation, authorization, ordering and cancellation outcomes. It does not mean identical framework APIs, threads, buffering, memory use or throughput. Spring and Ktor types never enter the portable core. A Spring Boot application selects exactly one Spring web adapter and fails clearly when both are ambiguous.
+
+## Explicit MVP non-goals
+
+- No client-rendered SPA core, virtual DOM, application-wide hydration or mandatory JavaScript.
+- No Compose-style HTML abstraction, comprehensive Kotlin CSS-property DSL or typed Tailwind utility clone.
+- No Kotlin/JS or Kotlin/Wasm island runtime ships in the MVP. The optional, bounded island target is decided in [#53](https://github.com/christian-draeger/woge/issues/53) for M4.
+- No enhanced page-navigation runtime in the MVP. Real links remain the baseline; enhancement is [#51](https://github.com/christian-draeger/woge/issues/51) in M4.
+- No WebSocket transport in the MVP. SSE is the supported live transport; optional WebSocket work is [#57](https://github.com/christian-draeger/woge/issues/57) in M4.
+- No source-owned registry or broad MUI-style packaged visual library in the MVP. M3 establishes accessible headless primitives; the registry [#81](https://github.com/christian-draeger/woge/issues/81), styled catalog and complex theme land in M4.
+- No `kotlinx.rpc` or RPC-shaped public application model. Typed HTTP pages, forms, actions and streams are the chosen boundary; a future RPC adapter would require separate evidence and an ADR.
+- No built-in database, ORM, identity provider or authorization policy. Applications retain those decisions; Woge adapters carry the required typed context.
+- No stable native-DPU dependency or Chromium-only product behavior.
+
+## MVP definition of done
+
+The MVP is releasable only when all three gates pass:
+
+1. **M1 — walking skeleton:** one shared application streams its shell and deferred region through Spring MVC, Spring WebFlux and Ktor; adapter TCK, browser/JVM CI, executable newcomer guide and first scored AI-DX consumer run pass.
+2. **M2 — reactive actions:** the reference CRUD journey covers typed routes/forms/actions, validation, multi-region patches, revisions and authorized SSE with useful HTML-only fallbacks; optional Tailwind produces the same semantics as plain CSS.
+3. **M3 — hardening and release:** stable-browser/no-JavaScript, accessibility, XSS/CSRF/CSP, malformed-frame, cancellation/proxy, performance/bundle, Spring Boot production and publication checks pass with recorded environments and limits.
+
+Documentation is part of the product gate. Canonical examples compile in CI, start from visible web behavior, introduce Kotlin only when needed, and show real diagnostics and escape hatches. AI evaluation uses those same examples and APIs; AI-only aliases or undocumented conventions do not count as success.
+
+## Owned risks
+
+| Risk | Backlog owner |
+| --- | --- |
+| Public APIs or module edges harden before a real consumer exists | Scaffold and graph [#13](https://github.com/christian-draeger/woge/issues/13), [#14](https://github.com/christian-draeger/woge/issues/14); consumer AI-DX run [#93](https://github.com/christian-draeger/woge/issues/93) |
+| MVC, WebFlux and Ktor drift or hide lifecycle differences | Shared TCK [#65](https://github.com/christian-draeger/woge/issues/65), cancellation/proxy evidence [#45](https://github.com/christian-draeger/woge/issues/45), Spring production hardening [#58](https://github.com/christian-draeger/woge/issues/58) |
+| Stream/parser/HTML boundaries permit injection or ambiguous failure | Fuzzing [#41](https://github.com/christian-draeger/woge/issues/41), XSS hardening [#42](https://github.com/christian-draeger/woge/issues/42), CSP/Trusted Types [#43](https://github.com/christian-draeger/woge/issues/43) |
+| Patches break focus, dirty fields or cross-browser behavior | Preservation [#36](https://github.com/christian-draeger/woge/issues/36), browser conformance [#39](https://github.com/christian-draeger/woge/issues/39), accessibility audit [#44](https://github.com/christian-draeger/woge/issues/44) |
+| Styling or component convenience compromises web-native ownership | Asset contract [#78](https://github.com/christian-draeger/woge/issues/78), Tailwind adapter [#79](https://github.com/christian-draeger/woge/issues/79), headless primitives [#80](https://github.com/christian-draeger/woge/issues/80) |
+| Convenience adds unmeasured runtime/build cost | Performance and bundle budgets [#46](https://github.com/christian-draeger/woge/issues/46), coherent build tasks [#47](https://github.com/christian-draeger/woge/issues/47) |
+| Documentation, diagnostics or generated APIs work only for maintainers | Executable guide [#73](https://github.com/christian-draeger/woge/issues/73), examples/diagnostics [#74](https://github.com/christian-draeger/woge/issues/74), design-partner release [#50](https://github.com/christian-draeger/woge/issues/50) |
+
+## M0 exit review
+
+- The project-operations reference application and measurable complex-screen contract are fixed.
+- All other [M0 milestone issues](https://github.com/christian-draeger/woge/milestone/1?closed=1) are closed with evidence.
+- ADRs 0001–0018 are accepted and listed in the [decision index](adr/README.md).
+- Canonical guidance is separated from executable spike evidence in the [documentation index](README.md).
+- Host, browser, security, protocol, CSS, Tailwind, component, documentation and AI-DX boundaries have implementation backlog owners.
+- Closing [#12](https://github.com/christian-draeger/woge/issues/12) completes M0; changes to these boundaries require the normal ADR lifecycle.


### PR DESCRIPTION
Closes #12

## Result
- defines M1 through M3 as the MVP and M4 as the broader 1.0 scope
- lists MVP capabilities, explicit non-goals, and exact timing for Kotlin/Wasm islands, enhanced navigation, WebSocket, native DPU, and the source component registry
- makes Spring Boot the primary setup path while keeping MVC, WebFlux, and Ktor first-class under one semantic TCK
- assigns architecture, parity, security, browser, styling, performance, documentation, and AI-DX risks to concrete backlog issues
- separates canonical architecture guidance from executable spike evidence

## ADR exemption
No new ADR is added: this PR only indexes and synthesizes ADRs 0001-0018, as explicitly allowed by #12. Future changes to those boundaries still require the normal ADR lifecycle.

## Validation
- `./scripts/validate-adrs.sh`
- `./scripts/validate-module-boundaries.sh`
- `git diff --check`