### PR TITLE
Materialize the M1 module graph

### DIFF
--- a/adapters/woge-ktor/build.gradle.kts
+++ b/adapters/woge-ktor/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Ktor transport adapter for Woge."
+
+dependencies {
+    api(project(":woge-core"))
+    api(project(":woge-protocol"))
+    api(project(":woge-host-spi"))
+    implementation(project(":woge-server-runtime"))
+}

--- a/adapters/woge-spring-mvc/build.gradle.kts
+++ b/adapters/woge-spring-mvc/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Spring MVC and Servlet transport adapter for Woge."
+
+dependencies {
+    api(project(":woge-core"))
+    api(project(":woge-protocol"))
+    api(project(":woge-host-spi"))
+    implementation(project(":woge-server-runtime"))
+}

--- a/adapters/woge-spring-webflux/build.gradle.kts
+++ b/adapters/woge-spring-webflux/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Spring WebFlux transport adapter for Woge."
+
+dependencies {
+    api(project(":woge-core"))
+    api(project(":woge-protocol"))
+    api(project(":woge-host-spi"))
+    implementation(project(":woge-server-runtime"))
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,11 @@ val validateModuleBoundaries = registerValidation(
     "Validates the machine-readable module boundary manifest.",
     "scripts/validate-module-boundaries.sh",
 )
+val testModuleBoundaries = registerValidation(
+    "testModuleBoundaries",
+    "Proves that invalid module graphs and framework leaks are rejected.",
+    "scripts/test-module-boundaries.sh",
+)
 val validateDocumentation = registerValidation(
     "validateDocumentation",
     "Validates local documentation links and executable snippet references.",
@@ -46,6 +51,7 @@ tasks.named("check") {
     dependsOn(
         validateAdrs,
         validateModuleBoundaries,
+        testModuleBoundaries,
         validateDocumentation,
         test,
         detekt,

--- a/client/woge-fallback-client/README.md
+++ b/client/woge-fallback-client/README.md
@@ -1,0 +1,10 @@
+# Woge fallback client
+
+This directory owns Woge's small browser-side adapter for the versioned patch protocol. It is not a
+JVM module and does not define component semantics, application state or a general client framework.
+
+Issues [#20](https://github.com/christian-draeger/woge/issues/20) and
+[#21](https://github.com/christian-draeger/woge/issues/21) introduce its production protocol fixtures,
+package metadata, JavaScript source and cross-browser tests. Until then, the executable M0 prototype
+remains evidence only in the
+[`fallback-patch-runtime` report](../../spikes/fallback-patch-runtime/evidence.md).

--- a/config/architecture/module-boundaries.tsv
+++ b/config/architecture/module-boundaries.tsv
@@ -1,5 +1,6 @@
 # module	role	exposure	path	dependencies	optional_dependencies
 woge-core	foundation	public	modules/woge-core	-	-
+woge-ui-headless	ui	public	modules/woge-ui-headless	woge-core	-
 woge-protocol	protocol	public	modules/woge-protocol	woge-core	-
 woge-host-spi	port	public	modules/woge-host-spi	woge-core,woge-protocol	-
 woge-server-runtime	runtime	internal	modules/woge-server-runtime	woge-core,woge-protocol,woge-host-spi	-

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ The documentation grows with executable product slices. Pages describing unimple
 
 ## Canonical architecture guidance
 
+- [M1 module and consumer graph](architecture/module-graph.md)
 - [Spring MVC and WebFlux support model](architecture/spring-support-model.md)
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)
 - [CSS authoring](architecture/css-authoring.md)

--- a/docs/adr/0006-initial-module-boundaries.md
+++ b/docs/adr/0006-initial-module-boundaries.md
@@ -1,6 +1,7 @@
 # ADR 0006: Enforce a small inward-pointing initial module graph
 
-- Status: Accepted
+- Status: Superseded
+- Superseded by: [ADR 0019](0019-materialized-m1-module-boundaries.md)
 - Date: 2026-09-03
 - Decision owners: Woge maintainers
 - Related issues: [#9](https://github.com/christian-draeger/woge/issues/9), [#18](https://github.com/christian-draeger/woge/issues/18), [#65](https://github.com/christian-draeger/woge/issues/65), [#66](https://github.com/christian-draeger/woge/issues/66), [#67](https://github.com/christian-draeger/woge/issues/67), [#68](https://github.com/christian-draeger/woge/issues/68), [#69](https://github.com/christian-draeger/woge/issues/69)

--- a/docs/adr/0018-hybrid-headless-and-source-owned-components.md
+++ b/docs/adr/0018-hybrid-headless-and-source-owned-components.md
@@ -57,7 +57,7 @@ Registry source/catalog and installer/update tooling are build concerns, not ser
 
 ## Follow-up
 
-- Add `woge-ui-headless` and component-manifest/build-tool boundaries to the M1 scaffold in [#13](https://github.com/christian-draeger/woge/issues/13).
+- Add `woge-ui-headless` and component-manifest/build-tool boundaries to the M1 module graph in [#14](https://github.com/christian-draeger/woge/issues/14).
 - Define the first accessibility-focused primitive set and shared TCK in [#80](https://github.com/christian-draeger/woge/issues/80).
 - Turn the spike manifest and update planner into supported tooling only after schema, signing/release provenance and Windows path tests are designed.
 - Apply the frontend performance budgets from [#46](https://github.com/christian-draeger/woge/issues/46) to each catalog component and optional asset.

--- a/docs/adr/0019-materialized-m1-module-boundaries.md
+++ b/docs/adr/0019-materialized-m1-module-boundaries.md
@@ -1,0 +1,103 @@
+# ADR 0019: Materialize the M1 module and consumer boundaries
+
+- Status: Accepted
+- Date: 2026-09-04
+- Decision owners: Woge maintainers
+- Related issues: [#14](https://github.com/christian-draeger/woge/issues/14), [#20](https://github.com/christian-draeger/woge/issues/20), [#21](https://github.com/christian-draeger/woge/issues/21), [#24](https://github.com/christian-draeger/woge/issues/24), [#80](https://github.com/christian-draeger/woge/issues/80)
+
+## Context
+
+[ADR 0006](0006-initial-module-boundaries.md) selected ten inward-pointing JVM modules before the
+M0 frontend and component investigations were complete. [ADR 0018](0018-hybrid-headless-and-source-owned-components.md)
+subsequently added a host-neutral `woge-ui-headless` binary boundary. The accepted fallback client
+and reference application also need visible ownership without pretending they are JVM libraries or
+allowing them to shape portable APIs.
+
+The Gradle build now exists, so a prose graph and a disconnected manifest are no longer sufficient.
+Project paths, declared dependencies and architectural checks must describe the same graph.
+
+## Decision
+
+The M1 production JVM graph consists of these eleven artifacts:
+
+| Module | Ownership | Exposure | Direct Woge dependencies |
+| --- | --- | --- | --- |
+| `woge-core` | HTML writer/component model and portable values | Public | None |
+| `woge-ui-headless` | Accessible, host- and styling-neutral UI behavior | Public | Core |
+| `woge-protocol` | Document, patch and live-frame values | Public | Core |
+| `woge-host-spi` | Page, action and live-update host ports | Public | Core, protocol |
+| `woge-server-runtime` | Shared dispatch and execution implementation | Internal | Core, protocol, host SPI |
+| `woge-adapter-tck` | Reusable server-adapter contract fixtures | Test support | Core, protocol, host SPI, runtime |
+| `woge-spring-mvc` | Spring MVC/Servlet transport translation | Public integration | Core, protocol, host SPI, runtime |
+| `woge-spring-webflux` | Spring WebFlux transport translation | Public integration | Core, protocol, host SPI, runtime |
+| `woge-ktor` | Ktor transport translation | Public integration | Core, protocol, host SPI, runtime |
+| `woge-spring-boot-autoconfigure` | Conditional adapter wiring and diagnostics | Public integration | Host SPI; optional MVC/WebFlux adapters |
+| `woge-spring-boot-starter` | Spring Boot dependency entry point | Public integration | Auto-configuration |
+
+The machine-readable [`module-boundaries.tsv`](../../config/architecture/module-boundaries.tsv)
+drives Gradle project inclusion and is the source of truth for project names, paths, roles, exposure,
+required dependencies and optional dependencies. Every module applies the same JVM library convention.
+Required project dependencies use `api` or `implementation`; optional adapter discovery uses
+`compileOnly`, so auto-configuration does not pull both Spring web stacks into an application.
+
+HTML authoring remains part of `woge-core`; it is a web-facing API, not a separate rendering engine.
+The optional `kotlinx.html` bridge remains deferred until the core sink has a real consumer. Headless
+UI depends only on core and cannot depend on a host adapter, CSS toolchain or browser runtime.
+
+The fallback browser adapter is owned by `client/woge-fallback-client` as an independently tested web
+artifact. The reference application is owned by `examples/reference-application` as a consumer of
+public artifacts with separate Spring MVC, WebFlux and Ktor launchers. Neither is a production JVM
+library in the module manifest.
+
+The boundary gate verifies manifest validity, allowed role direction, exact production project
+dependencies, optional dependency configuration, duplicate paths, cycles, MVC/WebFlux independence
+and the absence of Spring, Reactor, Servlet or Ktor references in portable production sources.
+Non-public artifacts are not connected to Maven publishing by the M1 build.
+
+WebSocket transport, Kotlin/Wasm and Kotlin/JS islands remain documented extension points only. They
+receive modules only after a concrete use case and ADR establish their API, lifecycle and fallback
+contract.
+
+This ADR supersedes [ADR 0006](0006-initial-module-boundaries.md) by carrying its constraints forward
+and adding the accepted headless-UI and non-JVM consumer boundaries.
+
+## Alternatives considered
+
+- **Keep the original ten modules:** rejected because it would ignore the accepted headless-component
+  boundary and invite primitives into core or application recipes.
+- **Make the browser client a Kotlin/JS module now:** rejected because the accepted runtime is a small
+  standards-native protocol adapter and no shared-Kotlin requirement has been demonstrated.
+- **Add the reference application to the production manifest:** rejected because examples consume and
+  verify public artifacts; they are not dependencies of those artifacts.
+- **Create modules now for WebSocket, Wasm, CSS compilation and `kotlinx.html`:** rejected because each
+  remains an optional extension with separate evidence and delivery work.
+- **Let every Gradle file declare an unchecked graph:** rejected because drift between the ADR,
+  manifest and executable build would be found only through accidental compilation failures.
+
+## Consequences
+
+### Positive
+
+- Spring MVC, WebFlux and Ktor can evolve independently around one portable host contract.
+- Headless components have a stable home without introducing styling or host dependencies.
+- The browser runtime and reference application are visible without contaminating the JVM graph.
+- Gradle and CI fail on undeclared dependencies, cycles and portable framework leakage.
+- Internal and test-support artifacts remain visibly distinct from promised public APIs.
+
+### Negative
+
+- Eleven mostly empty projects add build configuration before their implementation issues land.
+- A manifest and conventional dependency syntax must be maintained together.
+- Source scanning is intentionally stricter than public-signature scanning and may reject even an
+  internal host-framework reference in a portable module.
+- Browser-client and example build graphs need their own CI checks when they become executable.
+
+## Follow-up
+
+- Add JVM and browser matrices in [#15](https://github.com/christian-draeger/woge/issues/15).
+- Implement HTML/core behavior in [#16](https://github.com/christian-draeger/woge/issues/16) and
+  [#17](https://github.com/christian-draeger/woge/issues/17).
+- Add binary API validation when public declarations arrive in [#17](https://github.com/christian-draeger/woge/issues/17)
+  and [#18](https://github.com/christian-draeger/woge/issues/18).
+- Build and consume the adapter TCK in [#65](https://github.com/christian-draeger/woge/issues/65).
+- Implement the headless primitive contract in [#80](https://github.com/christian-draeger/woge/issues/80).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0003](0003-web-first-documentation-and-ai-dx.md) | Accepted | Use web-first documentation and compiler-guided AI DX |
 | [0004](0004-project-operations-reference-application.md) | Accepted | Use one project operations dashboard as the reference application |
 | [0005](0005-server-host-use-case-ports.md) | Accepted | Model server adapters as Woge use-case exchanges |
-| [0006](0006-initial-module-boundaries.md) | Accepted | Enforce a small inward-pointing initial module graph |
+| [0006](0006-initial-module-boundaries.md) | Superseded | Enforce a small inward-pointing initial module graph |
 | [0007](0007-browser-support-and-progressive-enhancement.md) | Accepted | Guarantee an HTML baseline before browser enhancement |
 | [0008](0008-security-trust-boundaries.md) | Accepted | Make native and enhanced paths share secure boundaries |
 | [0009](0009-frontend-extension-contract.md) | Accepted | Layer frontend extensions over semantic server HTML |
@@ -45,5 +45,10 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0016](0016-standards-native-css-authoring.md) | Accepted | Keep CSS standards-native with optional build-time scoping |
 | [0017](0017-optional-tailwind-build-adapter.md) | Accepted | Integrate Tailwind through an optional build adapter |
 | [0018](0018-hybrid-headless-and-source-owned-components.md) | Accepted | Combine binary headless primitives with source-owned component recipes |
+| [0019](0019-materialized-m1-module-boundaries.md) | Accepted | Materialize the M1 module and consumer boundaries |
 
-ADRs 0001–0018 are the complete accepted M0 decision set. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis; executable spikes are supporting evidence and do not override an accepted ADR. Issue [#12](https://github.com/christian-draeger/woge/issues/12) is exempt from a separate ADR because it indexes and assembles these decisions rather than adding one.
+ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
+decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;
+executable spikes are supporting evidence and do not override an accepted ADR. Issue
+[#12](https://github.com/christian-draeger/woge/issues/12) is exempt from a separate ADR because it
+indexes and assembles these decisions rather than adding one.

--- a/docs/architecture/module-graph.md
+++ b/docs/architecture/module-graph.md
@@ -1,0 +1,67 @@
+# M1 module and consumer graph
+
+Woge keeps portable web concepts at the center and translates them at the outer edges. The build reads
+the production JVM projects and allowed dependencies from
+[`module-boundaries.tsv`](../../config/architecture/module-boundaries.tsv). [ADR 0019](../adr/0019-materialized-m1-module-boundaries.md)
+owns the current boundary decision.
+
+```mermaid
+flowchart BT
+    UI[woge-ui-headless] --> Core[woge-core]
+    Protocol[woge-protocol] --> Core
+    SPI[woge-host-spi] --> Core
+    SPI --> Protocol
+    Runtime[woge-server-runtime<br/>internal] --> Core
+    Runtime --> Protocol
+    Runtime --> SPI
+    TCK[woge-adapter-tck<br/>test support] --> Core
+    TCK --> Protocol
+    TCK --> SPI
+    TCK --> Runtime
+    MVC[woge-spring-mvc] --> Core
+    MVC --> Protocol
+    MVC --> SPI
+    MVC --> Runtime
+    WebFlux[woge-spring-webflux] --> Core
+    WebFlux --> Protocol
+    WebFlux --> SPI
+    WebFlux --> Runtime
+    Ktor[woge-ktor] --> Core
+    Ktor --> Protocol
+    Ktor --> SPI
+    Ktor --> Runtime
+    Auto[woge-spring-boot-autoconfigure] --> SPI
+    Auto -. compileOnly .-> MVC
+    Auto -. compileOnly .-> WebFlux
+    Starter[woge-spring-boot-starter] --> Auto
+```
+
+Arrows point from a consumer to what it may depend on. MVC, WebFlux and Ktor are peers. In particular,
+the Spring adapters cannot depend on each other, and Ktor never wraps Spring concepts.
+
+## What lives where
+
+| Concern | Owner | Why |
+| --- | --- | --- |
+| HTML writer and familiar HTML DSL | `woge-core` | HTML is the central application-facing web API |
+| Accessible behavior without styling | `woge-ui-headless` | Components stay portable across hosts and CSS choices |
+| Patch and streaming values | `woge-protocol` | Hosts share one versioned wire vocabulary |
+| Page/action/live use cases | `woge-host-spi` | Application code sees Woge-owned ports, not server requests |
+| Shared execution machinery | `woge-server-runtime` | Adapters reuse implementation without making it public API |
+| Adapter parity fixtures | `woge-adapter-tck` | Every host proves the same observable contract |
+| Spring Boot setup | auto-configuration and starter | Spring is first-class without becoming the core abstraction |
+| Browser patch application | [`client/woge-fallback-client`](../../client/woge-fallback-client/README.md) | It is a small web artifact, not a JVM or component runtime |
+| Multi-host proof | [`examples/reference-application`](../../examples/reference-application/README.md) | It consumes public artifacts and never becomes their dependency |
+
+## Deferred boundaries
+
+- `woge-html-kotlinx` remains an optional future interop artifact; `kotlinx.html` types do not enter core.
+- WebSocket transport remains a future protocol/host adapter after a concrete transport contract exists.
+- Kotlin/JS and Kotlin/Wasm remain optional local-island choices, not application-wide runtimes.
+- CSS scoping, Tailwind build integration and the source-component registry remain build tooling, not
+  server or browser runtime dependencies.
+
+The boundary validator fails on missing modules, unknown or cyclic edges, Gradle/manifest drift,
+forbidden host references in portable production source and MVC/WebFlux cross-dependencies. Negative
+fixtures prove that those failures remain active. Run both layers directly with
+`./gradlew validateModuleBoundaries testModuleBoundaries` or as part of `./gradlew check`.

--- a/docs/development/build-and-test.md
+++ b/docs/development/build-and-test.md
@@ -20,6 +20,7 @@ The gate compiles the convention plugins, verifies explicit API mode, runs tests
 ./gradlew validateDocumentation
 ./gradlew validateAdrs
 ./gradlew validateModuleBoundaries
+./gradlew testModuleBoundaries
 ```
 
 `ktlintFormat` changes source files; the other commands are checks. Test reports are written below each project's `build/test-results` and `build/reports/tests` directories. Detekt writes machine-readable XML/SARIF and an HTML report below `build/reports/detekt`.
@@ -32,7 +33,10 @@ The gate compiles the convention plugins, verifies explicit API mode, runs tests
 - Executable documentation applications and snippets belong below [`examples`](../../examples/README.md) and participate in the root build once introduced.
 - Architecture experiments remain isolated below [`spikes`](../../spikes/README.md). Production code must not depend on them.
 
-The version catalog owns tool and dependency versions. Convention plugins in `build-logic` own shared compilation, quality and reporting behavior. A module build file should describe only that module's role and dependencies.
+The version catalog owns tool and dependency versions. Convention plugins in `build-logic` own shared
+compilation, quality and reporting behavior. A module build file should describe only that module's
+role and dependencies. The production projects and allowed edges are documented in the
+[M1 module and consumer graph](../architecture/module-graph.md).
 
 The scaffold contains no publishing credentials, automatic snapshots or template-specific release assumptions. Publication is added with its own threat and release review in the M3 release work.
 Its selectively adopted template patterns and deliberate omissions are recorded in

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 # Executable examples
 
-Maintained documentation examples live below this directory and are included in the production Gradle build. They use supported public APIs and compile in `./gradlew check`.
+Maintained documentation examples live below this directory and join the root verification build once
+they are executable. They use supported public APIs and compile in `./gradlew check`.
 
-Do not copy spike packages into examples. The first example is added by the M1 multi-host walking skeleton.
+Do not copy spike packages into examples. The first maintained consumer is the
+[multi-host reference application](reference-application/README.md).

--- a/examples/reference-application/README.md
+++ b/examples/reference-application/README.md
@@ -1,0 +1,9 @@
+# Reference application
+
+This directory is the maintained multi-host consumer of Woge's public modules. Its project-operations
+domain and journeys are defined in [ADR 0004](../../docs/adr/0004-project-operations-reference-application.md).
+
+The application will share framework-neutral page and domain code while keeping Spring MVC, Spring
+WebFlux and Ktor launchers at the outer edge. It is a build consumer and executable documentation, not
+a production Woge artifact. Issue [#24](https://github.com/christian-draeger/woge/issues/24) owns the
+complete walking-skeleton slice.

--- a/integrations/woge-spring-boot-autoconfigure/build.gradle.kts
+++ b/integrations/woge-spring-boot-autoconfigure/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Conditional Spring Boot wiring and diagnostics for the Woge server adapters."
+
+dependencies {
+    api(project(":woge-host-spi"))
+    compileOnly(project(":woge-spring-mvc"))
+    compileOnly(project(":woge-spring-webflux"))
+}

--- a/integrations/woge-spring-boot-starter/build.gradle.kts
+++ b/integrations/woge-spring-boot-starter/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Spring Boot dependency entry point for Woge applications."
+
+dependencies {
+    api(project(":woge-spring-boot-autoconfigure"))
+}

--- a/modules/woge-core/build.gradle.kts
+++ b/modules/woge-core/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Web-native HTML, component, and portable value APIs for Woge applications."

--- a/modules/woge-host-spi/build.gradle.kts
+++ b/modules/woge-host-spi/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Framework-neutral page, action, and live-update host ports."
+
+dependencies {
+    api(project(":woge-core"))
+    api(project(":woge-protocol"))
+}

--- a/modules/woge-protocol/build.gradle.kts
+++ b/modules/woge-protocol/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Host-neutral document, patch, and live-frame protocol values."
+
+dependencies {
+    api(project(":woge-core"))
+}

--- a/modules/woge-server-runtime/build.gradle.kts
+++ b/modules/woge-server-runtime/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Internal shared dispatch and execution implementation for server adapters."
+
+dependencies {
+    implementation(project(":woge-core"))
+    implementation(project(":woge-protocol"))
+    implementation(project(":woge-host-spi"))
+}

--- a/modules/woge-ui-headless/build.gradle.kts
+++ b/modules/woge-ui-headless/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Host- and styling-neutral accessible UI primitives for Woge applications."
+
+dependencies {
+    api(project(":woge-core"))
+}

--- a/scripts/test-module-boundaries.sh
+++ b/scripts/test-module-boundaries.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -u
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+scratch_root=$(mktemp -d)
+trap 'rm -rf "$scratch_root"' EXIT
+failure_count=0
+
+fail() {
+  printf 'Module-boundary tests: %s\n' "$1" >&2
+  failure_count=$((failure_count + 1))
+}
+
+prepare_fixture() {
+  local fixture_root=$1
+  mkdir -p "$fixture_root/scripts"
+  cp "$repository_root/scripts/validate-module-boundaries.sh" "$fixture_root/scripts/"
+  cp -R "$repository_root/config" "$fixture_root/"
+  cp -R "$repository_root/modules" "$fixture_root/"
+  cp -R "$repository_root/adapters" "$fixture_root/"
+  cp -R "$repository_root/integrations" "$fixture_root/"
+  cp -R "$repository_root/testing" "$fixture_root/"
+}
+
+expect_rejection() {
+  local fixture_root=$1
+  local expected_message=$2
+  local log_file="$fixture_root/validation.log"
+
+  if bash "$fixture_root/scripts/validate-module-boundaries.sh" >"$log_file" 2>&1; then
+    fail "fixture '$fixture_root' was accepted"
+    return
+  fi
+  if ! grep -Fq -- "$expected_message" "$log_file"; then
+    fail "fixture '$fixture_root' did not report '$expected_message'"
+  fi
+}
+
+cycle_fixture="$scratch_root/cycle"
+prepare_fixture "$cycle_fixture"
+awk -F '\t' -v OFS='\t' '
+  $1 == "woge-spring-boot-autoconfigure" { $6 = $6 ",woge-spring-boot-starter" }
+  { print }
+' "$cycle_fixture/config/architecture/module-boundaries.tsv" >"$cycle_fixture/module-boundaries.next"
+mv "$cycle_fixture/module-boundaries.next" "$cycle_fixture/config/architecture/module-boundaries.tsv"
+printf '\ndependencies {\n    compileOnly(project(":woge-spring-boot-starter"))\n}\n' \
+  >>"$cycle_fixture/integrations/woge-spring-boot-autoconfigure/build.gradle.kts"
+expect_rejection "$cycle_fixture" "contain a cycle"
+
+drift_fixture="$scratch_root/drift"
+prepare_fixture "$drift_fixture"
+grep -Fv 'api(project(":woge-core"))' \
+  "$drift_fixture/modules/woge-protocol/build.gradle.kts" >"$drift_fixture/protocol.next"
+mv "$drift_fixture/protocol.next" "$drift_fixture/modules/woge-protocol/build.gradle.kts"
+expect_rejection "$drift_fixture" "Gradle dependencies differ from the manifest"
+
+leak_fixture="$scratch_root/framework-leak"
+prepare_fixture "$leak_fixture"
+mkdir -p "$leak_fixture/modules/woge-core/src/main/kotlin/dev/woge/core"
+printf '%s\n' \
+  'package dev.woge.core' \
+  'import org.springframework.context.ApplicationContext' \
+  'public interface InvalidCoreApi { public val context: ApplicationContext }' \
+  >"$leak_fixture/modules/woge-core/src/main/kotlin/dev/woge/core/InvalidCoreApi.kt"
+expect_rejection "$leak_fixture" "references a host framework"
+
+adapter_fixture="$scratch_root/adapter-cross-dependency"
+prepare_fixture "$adapter_fixture"
+printf '\ndependencies {\n    testImplementation(project(":woge-spring-webflux"))\n}\n' \
+  >>"$adapter_fixture/adapters/woge-spring-mvc/build.gradle.kts"
+expect_rejection "$adapter_fixture" "woge-spring-mvc must not depend on woge-spring-webflux"
+
+if (( failure_count > 0 )); then
+  printf 'Module-boundary tests failed with %d problem(s).\n' "$failure_count" >&2
+  exit 1
+fi
+
+printf 'Module-boundary tests passed.\n'

--- a/scripts/validate-module-boundaries.sh
+++ b/scripts/validate-module-boundaries.sh
@@ -37,6 +37,7 @@ duplicate_paths=$(cut -f4 "$records" | sort | uniq -d)
 
 required_modules=(
   woge-core
+  woge-ui-headless
   woge-protocol
   woge-host-spi
   woge-server-runtime
@@ -56,6 +57,7 @@ done
 
 role_allows() {
   case "$1:$2" in
+    ui:foundation) return 0 ;;
     protocol:foundation|port:foundation|port:protocol|runtime:foundation|runtime:protocol|runtime:port) return 0 ;;
     adapter:foundation|adapter:protocol|adapter:port|adapter:runtime) return 0 ;;
     test-support:foundation|test-support:protocol|test-support:port|test-support:runtime) return 0 ;;
@@ -65,8 +67,15 @@ role_allows() {
 }
 
 while IFS=$'\t' read -r module role exposure source_path dependencies optional_dependencies; do
+  if [[ ! "$module" =~ ^woge-[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    fail "invalid module name '$module'"
+  fi
+  if [[ ! "$source_path" =~ ^(modules|adapters|integrations|testing)/${module}$ ]]; then
+    fail "$module has non-canonical source path '$source_path'"
+  fi
+
   case "$role" in
-    foundation|protocol|port|runtime|adapter|integration|test-support) ;;
+    foundation|ui|protocol|port|runtime|adapter|integration|test-support) ;;
     *) fail "$module has unknown role '$role'" ;;
   esac
 
@@ -74,6 +83,42 @@ while IFS=$'\t' read -r module role exposure source_path dependencies optional_d
     public|internal|support) ;;
     *) fail "$module has unknown exposure '$exposure'" ;;
   esac
+
+  module_directory="$repository_root/$source_path"
+  build_file="$module_directory/build.gradle.kts"
+  if [[ ! -d "$module_directory" ]]; then
+    fail "$module has no source directory at '$source_path'"
+  elif [[ ! -f "$build_file" ]]; then
+    fail "$module has no build.gradle.kts at '$source_path'"
+  else
+    expected_dependencies=$(
+      if [[ "$dependencies" != "-" ]]; then
+        printf '%s\n' "$dependencies" | tr ',' '\n' | sort -u
+      fi
+    )
+    actual_dependencies=$(
+      sed -nE 's/^[[:space:]]*(api|implementation|runtimeOnly)\(project\(":([^"]+)"\)\).*$/\2/p' "$build_file" | sort -u
+    )
+    if [[ "$actual_dependencies" != "$expected_dependencies" ]]; then
+      fail "$module Gradle dependencies differ from the manifest (expected: '${dependencies}'; actual: '$(printf '%s' "$actual_dependencies" | tr '\n' ',')')"
+    fi
+
+    expected_optional_dependencies=$(
+      if [[ "$optional_dependencies" != "-" ]]; then
+        printf '%s\n' "$optional_dependencies" | tr ',' '\n' | sort -u
+      fi
+    )
+    actual_optional_dependencies=$(
+      sed -nE 's/^[[:space:]]*compileOnly\(project\(":([^"]+)"\)\).*$/\1/p' "$build_file" | sort -u
+    )
+    if [[ "$actual_optional_dependencies" != "$expected_optional_dependencies" ]]; then
+      fail "$module optional Gradle dependencies differ from the manifest (expected: '${optional_dependencies}'; actual: '$(printf '%s' "$actual_optional_dependencies" | tr '\n' ',')')"
+    fi
+
+    if [[ "$exposure" != "public" ]] && grep -Eq '(^|[^A-Za-z-])maven-publish([^A-Za-z-]|$)' "$build_file"; then
+      fail "$module is '$exposure' but applies Maven publishing"
+    fi
+  fi
 
   all_dependencies="$dependencies,$optional_dependencies"
   all_dependencies=${all_dependencies//-,/}
@@ -96,23 +141,36 @@ while IFS=$'\t' read -r module role exposure source_path dependencies optional_d
   done
 done < "$records"
 
-if [[ -s "$edges" ]] && ! tsort "$edges" >/dev/null 2>&1; then
-  fail "the declared project dependencies contain a cycle"
+if [[ -s "$edges" ]]; then
+  tsort_output=$(LC_ALL=C tsort "$edges" 2>&1)
+  tsort_status=$?
+  if (( tsort_status != 0 )) || grep -Eiq '(cycle|loop)' <<<"$tsort_output"; then
+    fail "the declared project dependencies contain a cycle"
+  fi
 fi
 
-for module in woge-core woge-protocol woge-host-spi woge-server-runtime; do
+for module in woge-core woge-ui-headless woge-protocol woge-host-spi woge-server-runtime; do
   source_path=$(awk -F '\t' -v name="$module" '$1 == name { print $4; exit }' "$records")
   [[ -n "$source_path" ]] || continue
   [[ -d "$repository_root/$source_path" ]] || continue
+  main_source_path="$repository_root/$source_path/src/main"
+  [[ -d "$main_source_path" ]] || continue
 
-  forbidden_imports='^[[:space:]]*import[[:space:]]+(org\.springframework|reactor\.|jakarta\.servlet|javax\.servlet|io\.ktor)'
+  forbidden_types='(org\.springframework|reactor\.|jakarta\.servlet|javax\.servlet|io\.ktor)'
   if command -v rg >/dev/null 2>&1; then
-    matches=$(rg -n --glob '*.kt' "$forbidden_imports" "$repository_root/$source_path" || true)
+    matches=$(rg -n --glob '*.kt' --glob '*.java' "$forbidden_types" "$main_source_path" || true)
   else
-    matches=$(grep -R -n -E --include='*.kt' "$forbidden_imports" "$repository_root/$source_path" || true)
+    matches=$(grep -R -n -E --include='*.kt' --include='*.java' "$forbidden_types" "$main_source_path" 2>/dev/null || true)
   fi
-  [[ -z "$matches" ]] || fail "$module imports a host framework:\n$matches"
+  [[ -z "$matches" ]] || fail "$module references a host framework in production source:\n$matches"
 done
+
+if grep -Eq 'project\(":woge-spring-webflux"\)' "$repository_root/adapters/woge-spring-mvc/build.gradle.kts"; then
+  fail "woge-spring-mvc must not depend on woge-spring-webflux"
+fi
+if grep -Eq 'project\(":woge-spring-mvc"\)' "$repository_root/adapters/woge-spring-webflux/build.gradle.kts"; then
+  fail "woge-spring-webflux must not depend on woge-spring-mvc"
+fi
 
 if (( failure_count > 0 )); then
   printf 'Module-boundary validation failed with %d problem(s).\n' "$failure_count" >&2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,16 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
+
+file("config/architecture/module-boundaries.tsv")
+    .readLines()
+    .asSequence()
+    .filterNot { it.isBlank() || it.startsWith("#") }
+    .forEach { row ->
+        val columns = row.split('\t')
+        require(columns.size == 6) { "Invalid module-boundary row: $row" }
+
+        val moduleName = columns[0]
+        include(":$moduleName")
+        project(":$moduleName").projectDir = file(columns[3])
+    }

--- a/testing/woge-adapter-tck/build.gradle.kts
+++ b/testing/woge-adapter-tck/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Reusable framework-neutral contract fixtures for Woge server adapters."
+
+dependencies {
+    api(project(":woge-core"))
+    api(project(":woge-protocol"))
+    api(project(":woge-host-spi"))
+    implementation(project(":woge-server-runtime"))
+}


### PR DESCRIPTION
Closes #14

## Summary
- materialize the inward-pointing JVM graph from the architecture manifest
- add the `woge-ui-headless` extension accepted in ADR 0018
- keep the fallback browser client and reference application as explicit non-library consumers
- verify exact Gradle/manifest edges, cycles, portable framework leakage, publishing boundaries, and MVC/WebFlux independence
- add negative architecture fixtures for cycle, drift, framework leak, and cross-adapter failures

## Architecture
ADR 0019 supersedes ADR 0006 by preserving its ports-and-adapters graph while adding the accepted headless UI module and explicit non-JVM consumer boundaries. Future WebSocket, Kotlin/JS, and Kotlin/Wasm modules remain documentation-only.

The Spring Boot auto-configuration sees MVC and WebFlux only through `compileOnly`; the starter runtime classpath contains neither adapter.

## Verification
- `./gradlew projects check`
- `./gradlew check`
- `./gradlew check` from a fresh local clone
- `./gradlew :woge-spring-boot-starter:dependencies --configuration runtimeClasspath :woge-spring-boot-autoconfigure:dependencies --configuration runtimeClasspath`
- `./scripts/test-module-boundaries.sh`