### PR TITLE
feat(core): add context-safe HTML values

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,10 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Build and test Woge](development/build-and-test.md)
 - [Repository scaffold provenance](development/scaffold-provenance.md)
 
+## Implemented API guides
+
+- [Render safe HTML values](guides/safe-html-values.md)
+
 ## Executable M0 evidence
 
 The spikes below justify accepted decisions. Their code is evidence, not a production API or a second source of current guidance.

--- a/docs/adr/0020-context-specific-html-values.md
+++ b/docs/adr/0020-context-specific-html-values.md
@@ -1,0 +1,101 @@
+# ADR 0020: Separate HTML value contexts and make active contexts explicit
+
+- Status: Accepted
+- Date: 2026-09-04
+- Decision owners: Woge maintainers
+- Related issues: [#16](https://github.com/christian-draeger/woge/issues/16), [#42](https://github.com/christian-draeger/woge/issues/42), [#88](https://github.com/christian-draeger/woge/issues/88)
+
+## Context
+
+[ADR 0012](0012-html-writer-and-kotlinx-interop.md) chose a small streaming writer and an explicit
+raw-content type, but left the exact value boundaries to M1. HTML text, quoted attributes, URLs,
+`srcdoc`, CSS and raw-text elements do not share one browser parsing context. Treating them all as a
+string operation would make a safe-looking call change meaning when moved to another context.
+
+Woge must also remain open to custom elements and attributes and to HTML features added after a Woge
+release. A closed enum of all platform vocabulary would improve completion temporarily but would
+prevent web developers from using the evolving platform.
+
+## Decision
+
+`woge-core` provides distinct operations for HTML text, quoted attribute data, Boolean presence,
+validated URL values and deliberately unescaped content:
+
+- `text(value)` encodes data for HTML text parsing;
+- `attribute(name, value)` always emits a quoted, attribute-encoded value;
+- `boolean(name, present)` emits presence or absence and never serializes `true` or `false`;
+- `data`, `aria`, `classes` and `styles` preserve ordinary web strings and deterministic source order;
+- `url(name, value)` accepts only an `HtmlUrl` created by a validating factory;
+- `raw(UnsafeHtml)`, `srcdoc(UnsafeHtml)`, `unsafeUrl` and `unsafeAttribute` are explicit escape hatches.
+
+Unsafe value factories and consumers require Kotlin opt-in at error level. The type records that the
+application, not Woge, audited or sanitized the value for the exact browser context; it is not a
+sanitizer and carries no automatic trust between contexts.
+
+Text and attribute encoders are separate even where their current escape sets overlap. Both replace
+NUL and unpaired UTF-16 surrogates with U+FFFD. Text encodes `&`, `<` and `>`; quoted attributes also
+encode both quote characters and carriage return. Attribute names reject HTML syntax delimiters,
+control characters, whitespace and unpaired surrogates before any start tag is written. Duplicate
+names are rejected case-insensitively.
+
+Known URL-bearing, Boolean, `srcdoc` and inline-event names cannot pass through the ordinary attribute
+method. This is a guard for current platform vocabulary, not a permanent allowlist. A future or custom
+URL-bearing attribute can use `url(name, HtmlUrl)` immediately, while an ordinary future/custom
+attribute can use `attribute`. Inline event handlers remain unsafe even if their name is new.
+
+`applicationUrl` accepts a non-empty relative reference with no scheme, authority, control,
+whitespace, backslash, bidirectional control or malformed URI syntax. `externalUrl` accepts absolute
+`http`, `https`, `mailto` and `tel` references; HTTP(S) requires an authority and rejects embedded
+user-info. Callers percent-encode dynamic path and query components before constructing either value.
+Multi-URL syntax and intentionally active schemes require `UnsafeHtmlUrl`; ordinary control and
+Unicode checks still apply so source review remains reliable.
+
+Class names, Tailwind utilities, CSS declarations and custom properties remain ordered strings. HTML
+attribute encoding prevents a declaration string from breaking out of `style="..."`; it does not make
+untrusted CSS safe or prevent CSS from loading resources. Applications compose only application-owned
+declarations until a separately reviewed CSS value boundary exists.
+
+The normal element writer rejects void elements and HTML raw-text elements used through the wrong
+operation. Dedicated style, script and other raw-text APIs are deferred rather than pretending that
+HTML text encoding is valid in those parser states.
+
+## Alternatives considered
+
+- **One HTML-escape function for every value:** rejected because HTML text, attribute, URL, CSS and
+  raw-text parser states have different rules.
+- **Sanitize arbitrary HTML inside `raw`:** rejected because sanitization policy depends on the
+  application and must not be confused with output encoding.
+- **Accept URL attributes as strings and strip suspicious prefixes:** rejected because browser URL
+  parsing is subtle and a distinct Kotlin type makes the security decision visible at the call site.
+- **Allow only a fixed catalog of attributes:** rejected because it would make Woge lag custom
+  elements and new web standards.
+- **Parse class lists or CSS into a Woge-owned model:** rejected because it would constrain Tailwind,
+  custom properties and current CSS without improving HTML-context safety.
+
+## Consequences
+
+### Positive
+
+- Ordinary model text cannot become markup by changing its contents.
+- Kotlin rejects a plain string at raw-HTML and validated-URL boundaries before an application runs.
+- Reviewers and coding models can distinguish safe defaults from deliberate escape hatches by type
+  and opt-in annotation.
+- Custom elements, Tailwind classes, new CSS and future attributes remain usable without waiting for a
+  Woge release.
+- Attribute order and class/style composition are deterministic for tests and generated output.
+
+### Negative
+
+- Woge maintains escaping, current active-attribute knowledge and URL-policy tests.
+- A generic future attribute cannot be classified before browsers define its semantics; developers
+  must select `url` or an unsafe boundary when that new attribute enters an active context.
+- The strict URL factories require callers to compose and percent-encode dynamic components first.
+- `UnsafeHtml` and `UnsafeHtmlUrl` are audit markers, not proof that content is safe.
+- Safe CSS value composition and raw-text element authoring need later context-specific APIs.
+
+## Follow-up
+
+- Add common tag/attribute wrappers and generated diagnostics in [#73](https://github.com/christian-draeger/woge/issues/73).
+- Add the CSS language-injection and style-block boundary in [#88](https://github.com/christian-draeger/woge/issues/88).
+- Run the broader browser XSS corpus and patch-insertion checks in [#42](https://github.com/christian-draeger/woge/issues/42).
+- Keep the compiled examples aligned with the public DSL while implementing [#17](https://github.com/christian-draeger/woge/issues/17) and [#24](https://github.com/christian-draeger/woge/issues/24).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0017](0017-optional-tailwind-build-adapter.md) | Accepted | Integrate Tailwind through an optional build adapter |
 | [0018](0018-hybrid-headless-and-source-owned-components.md) | Accepted | Combine binary headless primitives with source-owned component recipes |
 | [0019](0019-materialized-m1-module-boundaries.md) | Accepted | Materialize the M1 module and consumer boundaries |
+| [0020](0020-context-specific-html-values.md) | Accepted | Separate HTML value contexts and make active contexts explicit |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,3 +3,7 @@
 Task-oriented, web-first guides live here. The first executable Spring Boot guide is delivered with the M1 walking skeleton.
 
 Canonical Kotlin examples belong in the root [`examples`](../../examples/README.md) build. Guides link to those sources instead of maintaining a second uncompiled copy.
+
+The first implemented low-level guide is [safe HTML values](safe-html-values.md). Its temporary
+canonical example is compiled with `woge-core`; it moves into the reference application once that
+consumer build exists.

--- a/docs/guides/safe-html-values.md
+++ b/docs/guides/safe-html-values.md
@@ -1,0 +1,96 @@
+# Render safe HTML values
+
+Woge renders ordinary text and attributes as data, even when their contents look like markup. Use a
+different API only when the browser will parse the value in a different context, such as a URL.
+
+The API on this page is available from `woge-core`. The common `div`, `a` and `input` wrappers planned
+for M1 are not implemented yet, so this guide shows the lower-level `element` and `voidElement`
+fallbacks.
+
+## Render text and attributes
+
+The compiled example renders a project card with familiar HTML attributes:
+
+<!-- snippet: modules/woge-core/src/test/kotlin/dev/woge/html/SafeHtmlValuesGuideTest.kt -->
+
+```kotlin
+val html = renderHtml {
+    element(
+        "article",
+        attributes = {
+            classes("project-card", "grid gap-3", "md:grid-cols-[1fr_auto]")
+            data("project-id", "woge-7")
+            aria("busy", "false")
+            styles("container-type: inline-size;", "--accent: oklch(62% 0.2 250);")
+        },
+    ) {
+        element("h2") { text("Woge <preview>") }
+        element("a", attributes = { url("href", applicationUrl("/projects/woge-7")) }) {
+            text("Open & inspect")
+        }
+    }
+}
+```
+
+`text(...)` is the important default: the browser receives `&lt;preview&gt;` and displays
+`Woge <preview>` as text. The value cannot create another element. Attributes are always quoted and
+encoded separately.
+
+The Kotlin block after `element(...)` is its child content. The `attributes = { ... }` block describes
+the start tag. Named arguments make those two lambdas unambiguous for readers who are new to Kotlin.
+
+## Keep HTML attribute semantics
+
+HTML Boolean attributes use presence, not the strings `"true"` and `"false"`:
+
+```kotlin
+voidElement("input", attributes = { boolean("disabled", formIsLocked) })
+```
+
+When `formIsLocked` is false, Woge omits `disabled`. Enumerated attributes such as
+`contenteditable="plaintext-only"` remain ordinary string attributes. ARIA values are strings too, so
+use `aria("busy", "false")` rather than treating `aria-busy` as Boolean presence.
+
+Repeated `classes(...)` or `styles(...)` calls append non-empty contributors in source order. Woge
+does not interpret Tailwind utilities, CSS custom properties or new CSS syntax. This keeps browser and
+toolchain behavior intact.
+
+## Use a URL type for URL attributes
+
+Pass a validated URL value instead of a string:
+
+```kotlin
+url("href", applicationUrl("/projects/woge-7?tab=activity"))
+url("href", externalUrl("https://docs.example.org/woge"))
+```
+
+`applicationUrl` is for relative links within the application. `externalUrl` currently permits
+`http`, `https`, `mailto` and `tel`. Both reject controls and ambiguous input. Encode dynamic path or
+query components before composing the URL; HTML escaping is not URL percent-encoding.
+
+Use `url(...)` for a future or custom URL attribute too. Known URL attributes cannot accidentally use
+the ordinary `attribute(...)` path.
+
+## Treat escape hatches as code-review boundaries
+
+Raw HTML is intentionally noisy:
+
+```kotlin
+@OptIn(UnsafeWogeHtmlApi::class)
+fun HtmlWriter.auditedContent(htmlFromApprovedSanitizer: String) {
+    raw(unsafeHtml(htmlFromApprovedSanitizer))
+}
+```
+
+The opt-in says that application code audited the source and the exact browser context. It does not
+sanitize the string. Keep the conversion close to the sanitizer or trusted source; do not convert a
+request, form field or database value merely to satisfy the compiler.
+
+The same rule applies to `unsafeUrl`, `srcdoc` and `unsafeAttribute`. Normal script, style and other
+raw-text element APIs are intentionally absent until their own context rules are implemented.
+
+Finally, `styles(...)` only keeps the value inside the quoted HTML attribute. Do not pass untrusted
+CSS declarations: CSS can still reference external resources and has its own parsing rules.
+
+See [ADR 0020](../adr/0020-context-specific-html-values.md) for the complete boundary and the
+[threat model](../security/threat-model.md) for the wider browser/server assumptions.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,8 +1,8 @@
 # Woge threat model
 
-This living document turns Woge's web-native architecture into concrete security assumptions, defaults and test ownership. It covers the planned core, server adapters, generated descriptors, streamed patches and browser runtime. It does not claim that the current M0 spike is deployable.
+This living document turns Woge's web-native architecture into concrete security assumptions, defaults and test ownership. It covers the M1 core work and the planned server adapters, generated descriptors, streamed patches and browser runtime. The current implementation is not yet a deployable application stack.
 
-Last review: 2026-09-03.
+Last review: 2026-09-04.
 
 ## Scope and assumptions
 
@@ -58,7 +58,7 @@ The numbered trust boundaries are:
 | ID | Threat and attack | Required default/control | Verification owner |
 | --- | --- | --- | --- |
 | WOGE-XSS-001 | Hostile text closes an element/attribute or injects markup | Context-aware text and quoted-attribute encoding; typed URL handling; hostile Unicode fixtures | [#16](https://github.com/christian-draeger/woge/issues/16), [#42](https://github.com/christian-draeger/woge/issues/42) |
-| WOGE-XSS-002 | Raw HTML or a patch introduces script, `on*` handlers or active URLs | Raw HTML requires an explicit unsafe/trusted value; ordinary patches reject executable elements/attributes and dangerous URL schemes; no `eval` or inline runtime requirement | [#21](https://github.com/christian-draeger/woge/issues/21), [#42](https://github.com/christian-draeger/woge/issues/42), [#43](https://github.com/christian-draeger/woge/issues/43) |
+| WOGE-XSS-002 | Raw HTML or a patch introduces script, `on*` handlers or active URLs | Raw HTML requires an explicit unsafe/trusted value; ordinary patches reject executable elements/attributes and dangerous URL schemes; no `eval` or inline runtime requirement | [#16](https://github.com/christian-draeger/woge/issues/16), [#21](https://github.com/christian-draeger/woge/issues/21), [#42](https://github.com/christian-draeger/woge/issues/42), [#43](https://github.com/christian-draeger/woge/issues/43) |
 | WOGE-CSRF-001 | A cross-site request triggers a native or enhanced mutation | Unsafe methods fail closed without adapter-verified CSRF; forms and enhanced requests carry the same token; SameSite cookies and Fetch Metadata may add defense in depth, not replace a token where required | [#30](https://github.com/christian-draeger/woge/issues/30), [#31](https://github.com/christian-draeger/woge/issues/31), [#34](https://github.com/christian-draeger/woge/issues/34) |
 | WOGE-AUTH-001 | A registered action, page or stream is treated as authorized | Domain authorization executes for every resource/action/subscription before response commit; adapter annotations only supply authenticated facts | [#18](https://github.com/christian-draeger/woge/issues/18), [#28](https://github.com/christian-draeger/woge/issues/28), [#30](https://github.com/christian-draeger/woge/issues/30), [#38](https://github.com/christian-draeger/woge/issues/38) |
 | WOGE-TARGET-001 | A forged target updates another region or arbitrary selector | Opaque generated instance/region IDs resolve only in the active page registry; no raw selector patch operation; duplicate/unknown IDs fail closed | [#19](https://github.com/christian-draeger/woge/issues/19), [#21](https://github.com/christian-draeger/woge/issues/21), [#25](https://github.com/christian-draeger/woge/issues/25), [#41](https://github.com/christian-draeger/woge/issues/41) |

--- a/modules/woge-core/build.gradle.kts
+++ b/modules/woge-core/build.gradle.kts
@@ -3,3 +3,21 @@ plugins {
 }
 
 description = "Web-native HTML, component, and portable value APIs for Woge applications."
+
+dependencies {
+    testImplementation(gradleTestKit())
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.test {
+    dependsOn(tasks.named("jar"))
+    systemProperty("woge.repository.root", rootProject.layout.projectDirectory.asFile.absolutePath)
+    systemProperty(
+        "woge.core.jar",
+        layout.buildDirectory
+            .file("libs/${project.name}-${project.version}.jar")
+            .get()
+            .asFile.absolutePath,
+    )
+}

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlSink.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlSink.kt
@@ -1,0 +1,7 @@
+package dev.woge.html
+
+/** Receives serialized HTML fragments in write order without implying network frame boundaries. */
+public fun interface HtmlSink {
+    /** Writes one serialized fragment or propagates the downstream failure unchanged. */
+    public fun write(value: String)
+}

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlUrl.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlUrl.kt
@@ -1,0 +1,145 @@
+package dev.woge.html
+
+import java.net.URI
+import java.net.URISyntaxException
+import java.util.Locale
+
+/** A URL validated for an HTML URL-bearing attribute. */
+public sealed interface HtmlUrl {
+    /** The already composed URL; dynamic path/query pieces must already be percent-encoded. */
+    public val value: String
+}
+
+/** A relative, same-application URL with no authority or scheme. */
+@JvmInline
+public value class ApplicationUrl internal constructor(
+    public override val value: String,
+) : HtmlUrl
+
+/** An absolute URL using an explicitly supported non-script scheme. */
+@JvmInline
+public value class ExternalUrl internal constructor(
+    public override val value: String,
+) : HtmlUrl
+
+/** An explicitly audited URL-like value that bypasses Woge's scheme allowlist. */
+@JvmInline
+public value class UnsafeHtmlUrl internal constructor(
+    internal val value: String,
+)
+
+/**
+ * Validates a relative URL such as `/projects/42`, `tasks/7`, `?filter=open`, or `#details`.
+ *
+ * The value cannot contain a scheme, authority, backslash, whitespace, control character, malformed
+ * percent escape, or unpaired UTF-16 surrogate. Encode dynamic path and query pieces before calling.
+ */
+public fun applicationUrl(value: String): ApplicationUrl {
+    requireUrlScalarValue(value, allowAsciiSpace = false)
+    require('\\' !in value) { "Application URL must not contain a backslash" }
+
+    val parsed = parseUri(value, "application URL")
+    require(!parsed.isAbsolute) { "Application URL must not contain a scheme" }
+    require(parsed.rawAuthority == null && !value.startsWith("//")) {
+        "Application URL must not contain an authority"
+    }
+    return ApplicationUrl(value)
+}
+
+/**
+ * Validates an absolute `http`, `https`, `mailto`, or `tel` URL.
+ *
+ * HTTP(S) URLs require an authority and cannot contain user-info credentials. Dynamic URL components
+ * must already be percent-encoded.
+ */
+public fun externalUrl(value: String): ExternalUrl {
+    requireUrlScalarValue(value, allowAsciiSpace = false)
+    require('\\' !in value) { "External URL must not contain a backslash" }
+
+    val parsed = parseUri(value, "external URL")
+    require(parsed.isAbsolute) { "External URL must contain a scheme" }
+    val scheme = parsed.scheme.lowercase(Locale.ROOT)
+    require(scheme in SAFE_EXTERNAL_SCHEMES) {
+        "External URL scheme '$scheme' is not supported"
+    }
+    if (scheme == "http" || scheme == "https") {
+        require(!parsed.rawAuthority.isNullOrEmpty()) { "HTTP(S) URL must contain an authority" }
+        require(parsed.rawUserInfo == null) { "HTTP(S) URL must not contain user-info credentials" }
+    } else {
+        require(!parsed.rawSchemeSpecificPart.isNullOrEmpty()) { "$scheme URL must contain a value" }
+    }
+    return ExternalUrl(value)
+}
+
+/**
+ * Creates a URL-like value after an explicit application audit.
+ *
+ * This escape hatch permits active or multi-URL syntax, but still rejects controls, invalid Unicode,
+ * and line breaks that make source review unreliable.
+ */
+@UnsafeWogeHtmlApi
+public fun unsafeHtmlUrl(value: String): UnsafeHtmlUrl {
+    requireUrlScalarValue(value, allowAsciiSpace = true)
+    return UnsafeHtmlUrl(value)
+}
+
+private val SAFE_EXTERNAL_SCHEMES: Set<String> = setOf("http", "https", "mailto", "tel")
+
+private fun parseUri(
+    value: String,
+    kind: String,
+): URI =
+    try {
+        URI(value)
+    } catch (exception: URISyntaxException) {
+        throw IllegalArgumentException("Invalid $kind: ${exception.reason}", exception)
+    }
+
+private fun requireUrlScalarValue(
+    value: String,
+    allowAsciiSpace: Boolean,
+) {
+    require(value.isNotEmpty()) { "URL must not be empty" }
+    var index = 0
+    while (index < value.length) {
+        val character = value[index]
+        if (character.isHighSurrogate()) {
+            require(index + 1 < value.length && value[index + 1].isLowSurrogate()) {
+                "URL must not contain an unpaired UTF-16 surrogate"
+            }
+            index += 2
+            continue
+        }
+
+        require(!character.isLowSurrogate()) { "URL must not contain an unpaired UTF-16 surrogate" }
+        require(character.code >= C0_CONTROL_END_EXCLUSIVE && character.code != DELETE_CONTROL) {
+            "URL must not contain control characters"
+        }
+        require(!character.isWhitespace() || (allowAsciiSpace && character == ' ')) {
+            "URL must not contain whitespace; percent-encode it"
+        }
+        require(character !in BIDI_CONTROL_CHARACTERS) {
+            "URL must not contain bidirectional control characters"
+        }
+        index += 1
+    }
+}
+
+private const val C0_CONTROL_END_EXCLUSIVE: Int = 0x20
+private const val DELETE_CONTROL: Int = 0x7f
+
+private val BIDI_CONTROL_CHARACTERS: Set<Char> =
+    setOf(
+        '\u061c',
+        '\u200e',
+        '\u200f',
+        '\u202a',
+        '\u202b',
+        '\u202c',
+        '\u202d',
+        '\u202e',
+        '\u2066',
+        '\u2067',
+        '\u2068',
+        '\u2069',
+    )

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlValues.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlValues.kt
@@ -1,0 +1,33 @@
+package dev.woge.html
+
+/** Marks the nested receivers used while writing HTML. */
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.BINARY)
+public annotation class WogeHtmlDsl
+
+/**
+ * Marks APIs that bypass normal HTML or URL safety boundaries.
+ *
+ * Opting in records that the caller, rather than Woge, audited the value for its exact browser
+ * context. It does not sanitize or make untrusted input safe.
+ */
+@RequiresOptIn(
+    message = "This value bypasses normal Woge HTML safety. Audit its source and browser context.",
+    level = RequiresOptIn.Level.ERROR,
+)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+public annotation class UnsafeWogeHtmlApi
+
+/** HTML markup that will be emitted without text escaping. */
+@JvmInline
+public value class UnsafeHtml internal constructor(
+    internal val value: String,
+)
+
+/**
+ * Marks [value] as deliberately unescaped HTML after an application-specific audit or sanitization.
+ */
+@UnsafeWogeHtmlApi
+public fun unsafeHtml(value: String): UnsafeHtml = UnsafeHtml(value)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlWriter.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlWriter.kt
@@ -1,0 +1,351 @@
+package dev.woge.html
+
+import dev.woge.html.internal.escapeHtmlAttribute
+import dev.woge.html.internal.escapeHtmlText
+
+/** Writes standards-shaped HTML directly to a sink without building an in-memory DOM. */
+@WogeHtmlDsl
+public class HtmlWriter(
+    public val sink: HtmlSink,
+) {
+    /** Writes [value] as HTML text. Markup characters are escaped rather than interpreted. */
+    public fun text(value: String) {
+        sink.write(escapeHtmlText(value))
+    }
+
+    /** Writes deliberately unescaped HTML. Ordinary strings cannot cross this boundary. */
+    @UnsafeWogeHtmlApi
+    public fun raw(value: UnsafeHtml) {
+        sink.write(value.value)
+    }
+
+    /** Writes a normal start tag, nested [content], and matching end tag. */
+    public fun element(
+        name: String,
+        attributes: Attributes.() -> Unit = {},
+        content: HtmlWriter.() -> Unit = {},
+    ) {
+        val normalizedName = requireElementName(name)
+        require(normalizedName !in VOID_ELEMENTS) {
+            "HTML void element '$name' must use voidElement(...)"
+        }
+        require(normalizedName !in UNSUPPORTED_RAW_TEXT_ELEMENTS) {
+            "HTML raw-text element '$name' requires a context-specific API"
+        }
+        val resolvedAttributes = Attributes().apply(attributes)
+
+        sink.write("<$name")
+        resolvedAttributes.writeTo(sink)
+        sink.write(">")
+        content()
+        sink.write("</$name>")
+    }
+
+    /** Writes a start tag without content or an end tag. */
+    public fun voidElement(
+        name: String,
+        attributes: Attributes.() -> Unit = {},
+    ) {
+        requireElementName(name)
+        val resolvedAttributes = Attributes().apply(attributes)
+
+        sink.write("<$name")
+        resolvedAttributes.writeTo(sink)
+        sink.write(">")
+    }
+}
+
+/** Renders a small HTML fragment to a string using the same streaming writer contract. */
+public fun renderHtml(block: HtmlWriter.() -> Unit): String {
+    val output = StringBuilder()
+    HtmlWriter(HtmlSink { value -> output.append(value) }).block()
+    return output.toString()
+}
+
+/** Collects one start tag's attributes in deterministic insertion order. */
+@WogeHtmlDsl
+public class Attributes internal constructor() {
+    private val values: MutableAttributes = MutableAttributes()
+
+    /**
+     * Adds an ordinary quoted attribute.
+     *
+     * Known Boolean, URL, inline-event and `srcdoc` attributes require their context-specific method.
+     */
+    public fun attribute(
+        name: String,
+        value: String,
+    ) {
+        val normalizedName = requireAttributeName(name)
+        require(normalizedName !in BOOLEAN_ATTRIBUTES) {
+            "Boolean HTML attribute '$name' must use boolean(...)"
+        }
+        require(normalizedName !in URL_ATTRIBUTES) {
+            "URL-bearing HTML attribute '$name' must use url(...)"
+        }
+        require(normalizedName != "srcdoc") { "HTML attribute 'srcdoc' must use srcdoc(...)" }
+        require(!normalizedName.startsWith("on")) {
+            "Inline event attribute '$name' requires unsafeAttribute(...)"
+        }
+        values.putUnique(name, normalizedName, AttributeValue.Text(value))
+    }
+
+    /** Emits [name] with no value when [present] is true, and omits it otherwise. */
+    public fun boolean(
+        name: String,
+        present: Boolean = true,
+    ) {
+        val normalizedName = requireAttributeName(name)
+        if (present) {
+            values.putUnique(name, normalizedName, AttributeValue.Present)
+        } else {
+            values.remove(normalizedName)
+        }
+    }
+
+    /** Adds a `data-*` attribute without restricting application-defined suffixes to a catalog. */
+    public fun data(
+        name: String,
+        value: String,
+    ) {
+        requireAttributeSuffix(name, "data")
+        attribute("data-$name", value)
+    }
+
+    /** Adds an `aria-*` attribute while preserving its string-valued web semantics. */
+    public fun aria(
+        name: String,
+        value: String,
+    ) {
+        requireAttributeSuffix(name, "aria")
+        attribute("aria-$name", value)
+    }
+
+    /** Adds ordered CSS class contributors without parsing Tailwind or framework-specific tokens. */
+    public fun classes(vararg contributors: String) {
+        values.appendContributor("class", contributors.asIterable())
+    }
+
+    /** Adds ordered CSS declaration-list contributors without parsing CSS properties. */
+    public fun styles(vararg declarationLists: String) {
+        values.appendContributor("style", declarationLists.asIterable())
+    }
+
+    /** Adds a quoted URL attribute after scheme and structure validation by an [HtmlUrl] factory. */
+    public fun url(
+        name: String,
+        value: HtmlUrl,
+    ) {
+        val normalizedName = requireAttributeName(name)
+        requireSafeUrlAttributeName(name, normalizedName)
+        values.putUnique(name, normalizedName, AttributeValue.Text(value.value))
+    }
+
+    /** Writes an audited URL-like value, including active or multi-URL syntax, as a quoted attribute. */
+    @UnsafeWogeHtmlApi
+    public fun unsafeUrl(
+        name: String,
+        value: UnsafeHtmlUrl,
+    ) {
+        val normalizedName = requireAttributeName(name)
+        requireSafeUrlAttributeName(name, normalizedName)
+        values.putUnique(name, normalizedName, AttributeValue.Text(value.value))
+    }
+
+    /** Bypasses context restrictions for an explicitly audited attribute value. */
+    @UnsafeWogeHtmlApi
+    public fun unsafeAttribute(
+        name: String,
+        value: String,
+    ) {
+        val normalizedName = requireAttributeName(name)
+        values.putUnique(name, normalizedName, AttributeValue.Text(value))
+    }
+
+    internal fun writeTo(sink: HtmlSink) {
+        values.writeTo(sink)
+    }
+}
+
+/** Writes audited HTML into an iframe `srcdoc` attribute after outer attribute escaping. */
+@UnsafeWogeHtmlApi
+public fun Attributes.srcdoc(value: UnsafeHtml) {
+    unsafeAttribute("srcdoc", value.value)
+}
+
+private class MutableAttributes {
+    private val entries: LinkedHashMap<String, AttributeEntry> = linkedMapOf()
+
+    fun putUnique(
+        name: String,
+        normalizedName: String,
+        value: AttributeValue,
+    ) {
+        require(normalizedName !in entries) { "Duplicate HTML attribute '$name'" }
+        entries[normalizedName] = AttributeEntry(name, value)
+    }
+
+    fun remove(normalizedName: String) {
+        entries.remove(normalizedName)
+    }
+
+    fun writeTo(sink: HtmlSink) {
+        entries.values.forEach { entry ->
+            sink.write(" ${entry.name}")
+            when (val value = entry.value) {
+                AttributeValue.Present -> Unit
+                is AttributeValue.Text -> {
+                    sink.write("=\"")
+                    sink.write(escapeHtmlAttribute(value.value))
+                    sink.write("\"")
+                }
+            }
+        }
+    }
+
+    fun appendContributor(
+        name: String,
+        contributors: Iterable<String>,
+    ) {
+        val addition = contributors.map { it.trim() }.filter(String::isNotEmpty).joinToString(" ")
+        if (addition.isEmpty()) return
+
+        val existing = entries[name]
+        if (existing == null) {
+            entries[name] = AttributeEntry(name, AttributeValue.Text(addition))
+            return
+        }
+        val existingText =
+            existing.value as? AttributeValue.Text
+                ?: throw IllegalArgumentException("Cannot compose a value-less '$name' attribute")
+        existing.value = AttributeValue.Text("${existingText.value} $addition")
+    }
+}
+
+private data class AttributeEntry(
+    val name: String,
+    var value: AttributeValue,
+)
+
+private sealed interface AttributeValue {
+    data object Present : AttributeValue
+
+    data class Text(
+        val value: String,
+    ) : AttributeValue
+}
+
+private val ELEMENT_NAME: Regex = Regex("[A-Za-z][A-Za-z0-9._:-]*")
+private val ATTRIBUTE_SUFFIX: Regex = Regex("[a-z][a-z0-9._-]*")
+
+private fun requireElementName(value: String): String {
+    require(ELEMENT_NAME.matches(value)) { "Invalid HTML element name '$value'" }
+    return value.lowercase()
+}
+
+private fun requireAttributeName(value: String): String {
+    require(value.isNotEmpty()) { "HTML attribute name must not be empty" }
+    require(value.none(::isInvalidAttributeNameCharacter)) { "Invalid HTML attribute name '$value'" }
+    return value.lowercase()
+}
+
+private fun requireAttributeSuffix(
+    value: String,
+    prefix: String,
+) {
+    require(ATTRIBUTE_SUFFIX.matches(value)) { "Invalid $prefix-* attribute suffix '$value'" }
+}
+
+private fun requireSafeUrlAttributeName(
+    name: String,
+    normalizedName: String,
+) {
+    require(normalizedName !in BOOLEAN_ATTRIBUTES) {
+        "Boolean HTML attribute '$name' cannot contain a URL"
+    }
+    require(normalizedName != "srcdoc") { "HTML attribute 'srcdoc' must use srcdoc(...)" }
+    require(!normalizedName.startsWith("on")) {
+        "Inline event attribute '$name' requires unsafeAttribute(...)"
+    }
+}
+
+private fun isInvalidAttributeNameCharacter(character: Char): Boolean =
+    character.isWhitespace() ||
+        character.isISOControl() ||
+        character in INVALID_ATTRIBUTE_NAME_CHARACTERS ||
+        character.isSurrogate()
+
+private val INVALID_ATTRIBUTE_NAME_CHARACTERS: Set<Char> = setOf('<', '>', '/', '=', '"', '\'')
+
+private val VOID_ELEMENTS: Set<String> =
+    setOf(
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "source",
+        "track",
+        "wbr",
+    )
+
+private val UNSUPPORTED_RAW_TEXT_ELEMENTS: Set<String> =
+    setOf("iframe", "noembed", "noframes", "plaintext", "script", "style", "xmp")
+
+private val BOOLEAN_ATTRIBUTES: Set<String> =
+    setOf(
+        "allowfullscreen",
+        "async",
+        "autofocus",
+        "autoplay",
+        "checked",
+        "controls",
+        "default",
+        "defer",
+        "disabled",
+        "formnovalidate",
+        "inert",
+        "ismap",
+        "itemscope",
+        "loop",
+        "multiple",
+        "muted",
+        "nomodule",
+        "novalidate",
+        "open",
+        "playsinline",
+        "readonly",
+        "required",
+        "reversed",
+        "selected",
+    )
+
+private val URL_ATTRIBUTES: Set<String> =
+    setOf(
+        "action",
+        "archive",
+        "background",
+        "cite",
+        "classid",
+        "codebase",
+        "data",
+        "formaction",
+        "href",
+        "icon",
+        "imagesrcset",
+        "itemid",
+        "longdesc",
+        "manifest",
+        "ping",
+        "poster",
+        "profile",
+        "src",
+        "srcset",
+        "usemap",
+        "xlink:href",
+    )

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/internal/HtmlEscaping.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/internal/HtmlEscaping.kt
@@ -1,0 +1,54 @@
+package dev.woge.html.internal
+
+internal fun escapeHtmlText(value: String): String = escapeHtml(value, attribute = false)
+
+internal fun escapeHtmlAttribute(value: String): String = escapeHtml(value, attribute = true)
+
+private fun escapeHtml(
+    value: String,
+    attribute: Boolean,
+): String =
+    buildString(value.length) {
+        var index = 0
+        while (index < value.length) {
+            val character = value[index]
+            if (character.isHighSurrogate()) {
+                index += appendSurrogatePair(value, index)
+            } else {
+                appendEscaped(character, attribute)
+            }
+            index += 1
+        }
+    }
+
+private fun StringBuilder.appendSurrogatePair(
+    value: String,
+    index: Int,
+): Int {
+    val highSurrogate = value[index]
+    val lowSurrogate = value.getOrNull(index + 1)
+    if (lowSurrogate?.isLowSurrogate() == true) {
+        append(highSurrogate)
+        append(lowSurrogate)
+        return 1
+    }
+
+    append('\uFFFD')
+    return 0
+}
+
+private fun StringBuilder.appendEscaped(
+    character: Char,
+    attribute: Boolean,
+) {
+    when {
+        character == '\u0000' || character.isLowSurrogate() -> append('\uFFFD')
+        character == '&' -> append("&amp;")
+        character == '<' -> append("&lt;")
+        character == '>' -> append("&gt;")
+        attribute && character == '"' -> append("&quot;")
+        attribute && character == '\'' -> append("&#39;")
+        attribute && character == '\r' -> append("&#13;")
+        else -> append(character)
+    }
+}

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlCompilerBoundaryTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlCompilerBoundaryTest.kt
@@ -1,0 +1,84 @@
+package dev.woge.html
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class HtmlCompilerBoundaryTest {
+    @TempDir
+    lateinit var projectDirectory: Path
+
+    @Test
+    fun `WOGE-XSS-001 ordinary strings cannot cross the raw HTML boundary`() {
+        assertFixtureFails("raw-string", "UnsafeHtml")
+    }
+
+    @Test
+    fun `WOGE-XSS-002 ordinary strings cannot cross the validated URL boundary`() {
+        assertFixtureFails("url-string", "HtmlUrl")
+    }
+
+    private fun assertFixtureFails(
+        name: String,
+        expectedType: String,
+    ) {
+        val fixtureDirectory = projectDirectory.resolve(name).createDirectories()
+        val repositoryRoot = Path.of(requireNotNull(System.getProperty("woge.repository.root")))
+        val coreJar = Path.of(requireNotNull(System.getProperty("woge.core.jar")))
+
+        fixtureDirectory.resolve("settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                includeBuild("${repositoryRoot.resolve("build-logic").asKotlinString()}")
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+
+            rootProject.name = "html-$name-negative-fixture"
+            """.trimIndent(),
+        )
+        fixtureDirectory.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("dev.woge.kotlin-jvm-library")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation(files("${coreJar.asKotlinString()}"))
+            }
+            """.trimIndent(),
+        )
+
+        val sourceDirectory = fixtureDirectory.resolve("src/main/kotlin/fixture").createDirectories()
+        val fixtureSource =
+            requireNotNull(javaClass.getResource("/compiler-fixtures/$name.kt"))
+                .toURI()
+                .let(Path::of)
+                .readText()
+        sourceDirectory.resolve("Fixture.kt").writeText(fixtureSource)
+
+        val result =
+            GradleRunner
+                .create()
+                .withProjectDir(fixtureDirectory.toFile())
+                .withArguments("compileKotlin", "--stacktrace", "--no-configuration-cache")
+                .buildAndFail()
+
+        assertTrue(result.output.contains("Argument type mismatch"), result.output)
+        assertTrue(result.output.contains("String"), result.output)
+        assertTrue(result.output.contains(expectedType), result.output)
+    }
+}
+
+private fun Path.asKotlinString(): String = toAbsolutePath().toString().replace("\\", "\\\\").replace("\"", "\\\"")

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlWriterTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlWriterTest.kt
@@ -1,0 +1,228 @@
+package dev.woge.html
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HtmlWriterTest {
+    @Test
+    fun `text and quoted attributes use separate escaping contexts`() {
+        val html =
+            renderHtml {
+                element(
+                    "p",
+                    attributes = {
+                        attribute("title", "5 < 7 & \"yes\" 'ok'\r")
+                    },
+                ) {
+                    text("\u0000<script>alert('x')</script> & 😀")
+                }
+            }
+
+        assertEquals(
+            "<p title=\"5 &lt; 7 &amp; &quot;yes&quot; &#39;ok&#39;&#13;\">" +
+                "�&lt;script&gt;alert('x')&lt;/script&gt; &amp; 😀</p>",
+            html,
+        )
+    }
+
+    @Test
+    fun `invalid UTF-16 code units become replacement characters`() {
+        val html =
+            renderHtml {
+                element("p", attributes = { attribute("title", "high=\uD800 low=\uDC00") }) {
+                    text("a\uD800b\uDC00c")
+                }
+            }
+
+        assertEquals("<p title=\"high=� low=�\">a�b�c</p>", html)
+    }
+
+    @Test
+    fun `boolean attributes use presence rather than string truthiness`() {
+        assertEquals(
+            "<input disabled>",
+            renderHtml { voidElement("input", attributes = { boolean("disabled", present = true) }) },
+        )
+        assertEquals(
+            "<input>",
+            renderHtml { voidElement("input", attributes = { boolean("disabled", present = false) }) },
+        )
+    }
+
+    @Test
+    fun `classes styles data aria and enumerated values preserve source order`() {
+        val html =
+            renderHtml {
+                element(
+                    "woge-card",
+                    attributes = {
+                        attribute("id", "card-7")
+                        classes("task-card", "grid gap-3", "md:grid-cols-[1fr_auto]")
+                        styles("--accent: oklch(62% 0.2 250);", "container-type: inline-size;")
+                        data("state", "pending")
+                        aria("busy", "true")
+                        attribute("contenteditable", "plaintext-only")
+                    },
+                )
+            }
+
+        assertEquals(
+            "<woge-card id=\"card-7\" class=\"task-card grid gap-3 md:grid-cols-[1fr_auto]\" " +
+                "style=\"--accent: oklch(62% 0.2 250); container-type: inline-size;\" " +
+                "data-state=\"pending\" aria-busy=\"true\" contenteditable=\"plaintext-only\"></woge-card>",
+            html,
+        )
+    }
+
+    @Test
+    fun `multiple class contributors compose with an existing ordinary class attribute`() {
+        val html =
+            renderHtml {
+                element(
+                    "div",
+                    attributes = {
+                        attribute("class", "application-owned")
+                        classes("woge-region", "is-loading")
+                    },
+                )
+            }
+
+        assertEquals("<div class=\"application-owned woge-region is-loading\"></div>", html)
+    }
+
+    @Test
+    fun `invalid or duplicate syntax fails before the start tag is written`() {
+        val chunks = mutableListOf<String>()
+        val writer = HtmlWriter(HtmlSink(chunks::add))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            writer.element("div", attributes = { attribute("x\" onclick", "bad") })
+        }
+        assertTrue(chunks.isEmpty())
+
+        assertThrows(IllegalArgumentException::class.java) {
+            writer.element(
+                "div",
+                attributes = {
+                    attribute("id", "first")
+                    attribute("ID", "second")
+                },
+            )
+        }
+        assertTrue(chunks.isEmpty())
+    }
+
+    @Test
+    fun `validated application and external URLs remain ordinary quoted HTML`() {
+        val html =
+            renderHtml {
+                element("a", attributes = { url("href", applicationUrl("/search?q=Kotlin&sort=new")) }) {
+                    text("Search")
+                }
+                voidElement("img", attributes = { url("src", externalUrl("https://cdn.example/image.svg")) })
+                element("a", attributes = { url("href", externalUrl("mailto:web@example.com")) }) {
+                    text("Email")
+                }
+            }
+
+        assertEquals(
+            "<a href=\"/search?q=Kotlin&amp;sort=new\">Search</a>" +
+                "<img src=\"https://cdn.example/image.svg\">" +
+                "<a href=\"mailto:web@example.com\">Email</a>",
+            html,
+        )
+    }
+
+    @Test
+    fun `URL factories reject active ambiguous and review-hostile values`() {
+        listOf(
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "https://example.com",
+            "//example.com/path",
+            "\\\\example.com\\path",
+            "/line\nbreak",
+            "/malformed%escape",
+            "/visual\u202Espoof",
+            "/unpaired\uD800",
+        ).forEach { value ->
+            assertThrows(IllegalArgumentException::class.java) { applicationUrl(value) }
+        }
+
+        listOf(
+            "javascript:alert(1)",
+            "data:text/html,hello",
+            "ftp://example.com/file",
+            "https://user:password@example.com/",
+            "https://example.com/line\nbreak",
+        ).forEach { value ->
+            assertThrows(IllegalArgumentException::class.java) { externalUrl(value) }
+        }
+    }
+
+    @Test
+    fun `ordinary attributes cannot silently enter active browser contexts`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            renderHtml { element("a", attributes = { attribute("href", "javascript:alert(1)") }) }
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            renderHtml { voidElement("input", attributes = { attribute("disabled", "false") }) }
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            renderHtml { element("button", attributes = { attribute("onclick", "alert(1)") }) }
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            renderHtml { element("woge-frame", attributes = { attribute("srcdoc", "<script>x()</script>") }) }
+        }
+    }
+
+    @OptIn(UnsafeWogeHtmlApi::class)
+    @Test
+    fun `unsafe HTML and URL paths remain explicit and still quote their outer attribute`() {
+        val html =
+            renderHtml {
+                raw(unsafeHtml("<strong>audited</strong>"))
+                element("a", attributes = { unsafeUrl("href", unsafeHtmlUrl("javascript:audited()")) }) {
+                    text("Audited action")
+                }
+                voidElement(
+                    "img",
+                    attributes = { unsafeUrl("srcset", unsafeHtmlUrl("small.png 1x, large.png 2x")) },
+                )
+                element(
+                    "woge-frame",
+                    attributes = { srcdoc(unsafeHtml("<p title=\"inner\">Audited</p>")) },
+                )
+            }
+
+        assertEquals(
+            "<strong>audited</strong>" +
+                "<a href=\"javascript:audited()\">Audited action</a>" +
+                "<img srcset=\"small.png 1x, large.png 2x\">" +
+                "<woge-frame srcdoc=\"&lt;p title=&quot;inner&quot;&gt;Audited&lt;/p&gt;\"></woge-frame>",
+            html,
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            unsafeHtmlUrl("small.png 1x,\nlarge.png 2x")
+        }
+    }
+
+    @Test
+    fun `known void and raw-text elements require their correct context`() {
+        assertThrows(IllegalArgumentException::class.java) { renderHtml { element("img") } }
+        assertThrows(IllegalArgumentException::class.java) { renderHtml { element("script") } }
+    }
+
+    @Test
+    fun `validated URL values support future URL attribute names`() {
+        assertEquals(
+            "<woge-link future-url=\"/safe\"></woge-link>",
+            renderHtml {
+                element("woge-link", attributes = { url("future-url", applicationUrl("/safe")) })
+            },
+        )
+    }
+}

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/SafeHtmlValuesGuideTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/SafeHtmlValuesGuideTest.kt
@@ -1,0 +1,36 @@
+package dev.woge.html
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SafeHtmlValuesGuideTest {
+    @Test
+    fun `project card example remains executable`() {
+        val html =
+            renderHtml {
+                element(
+                    "article",
+                    attributes = {
+                        classes("project-card", "grid gap-3", "md:grid-cols-[1fr_auto]")
+                        data("project-id", "woge-7")
+                        aria("busy", "false")
+                        styles("container-type: inline-size;", "--accent: oklch(62% 0.2 250);")
+                    },
+                ) {
+                    element("h2") { text("Woge <preview>") }
+                    element("a", attributes = { url("href", applicationUrl("/projects/woge-7")) }) {
+                        text("Open & inspect")
+                    }
+                }
+            }
+
+        assertEquals(
+            "<article class=\"project-card grid gap-3 md:grid-cols-[1fr_auto]\" " +
+                "data-project-id=\"woge-7\" aria-busy=\"false\" " +
+                "style=\"container-type: inline-size; --accent: oklch(62% 0.2 250);\">" +
+                "<h2>Woge &lt;preview&gt;</h2>" +
+                "<a href=\"/projects/woge-7\">Open &amp; inspect</a></article>",
+            html,
+        )
+    }
+}

--- a/modules/woge-core/src/test/resources/compiler-fixtures/raw-string.kt
+++ b/modules/woge-core/src/test/resources/compiler-fixtures/raw-string.kt
@@ -1,0 +1,8 @@
+package fixture
+
+import dev.woge.html.HtmlWriter
+
+// WOGE-XSS-001: ordinary strings must not become unescaped HTML.
+public fun renderInvalidRawHtml(writer: HtmlWriter) {
+    writer.raw("<script>alert('x')</script>")
+}

--- a/modules/woge-core/src/test/resources/compiler-fixtures/url-string.kt
+++ b/modules/woge-core/src/test/resources/compiler-fixtures/url-string.kt
@@ -1,0 +1,8 @@
+package fixture
+
+import dev.woge.html.Attributes
+
+// WOGE-XSS-002: ordinary strings must not enter validated URL-bearing attributes.
+public fun renderInvalidUrl(attributes: Attributes) {
+    attributes.url("href", "javascript:alert('x')")
+}


### PR DESCRIPTION
## Outcome

Adds the first production `woge-core` HTML value boundary: streamed, standards-shaped output with separate text and quoted-attribute encoding, predictable web attributes, typed URLs, and compiler-visible unsafe escape hatches.

## Included

- `HtmlSink`, `HtmlWriter`, generic current/future element fallbacks and deterministic attributes
- Boolean, enumerated, `data-*`, `aria-*`, class, modern CSS and Tailwind-compatible string composition
- `ApplicationUrl` / `ExternalUrl` validation plus explicit audited URL and raw-HTML paths
- Unicode, XSS, active-context, ordering and custom/future vocabulary tests
- real compiler-negative fixtures for WOGE-XSS-001 and WOGE-XSS-002
- ADR 0020, security-model update and a compiled web-first guide

## Verification

- `./gradlew check`

Closes #16