### PR TITLE
feat(core): add bounded HTML sinks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.api text eol=lf whitespace=-blank-at-eof

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.tasks.Exec
 
 plugins {
     base
+    alias(libs.plugins.kotlinJvm) apply false
 }
 
 group = providers.gradleProperty("wogeGroup").get()

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,11 @@ The documentation grows with executable product slices. Pages describing unimple
 ## Implemented API guides
 
 - [Render safe HTML values](guides/safe-html-values.md)
+- [Buffer or stream HTML](guides/stream-html.md)
+
+## Performance evidence
+
+- [HTML sink baseline](performance/html-sinks-baseline.md)
 
 ## Executable M0 evidence
 

--- a/docs/adr/0021-synchronous-bounded-html-sinks.md
+++ b/docs/adr/0021-synchronous-bounded-html-sinks.md
@@ -1,0 +1,104 @@
+# ADR 0021: Keep HTML sinks synchronous, bounded and transport-neutral
+
+- Status: Accepted
+- Date: 2026-09-04
+- Decision owners: Woge maintainers
+- Related issues: [#17](https://github.com/christian-draeger/woge/issues/17), [#18](https://github.com/christian-draeger/woge/issues/18), [#65](https://github.com/christian-draeger/woge/issues/65)
+
+## Context
+
+[ADR 0012](0012-html-writer-and-kotlinx-interop.md) assigned buffering, incremental output and failure
+behavior to `HtmlSink`. [ADR 0005](0005-server-host-use-case-ports.md) separately assigns asynchronous
+waiting, backpressure and request cancellation to cold coroutine `Flow` exchanges collected by a host
+adapter. The production sink contract must connect these layers without making every HTML tag a
+suspending function, building a page-sized string or exposing Servlet, Reactor or Ktor output types.
+
+The initial value implementation also exposed a writer's sink publicly. That would let component code
+bypass escaping with an ordinary string, so the rendering entry point needs to preserve the unsafe
+boundary established by [ADR 0020](0020-context-specific-html-values.md).
+
+## Decision
+
+`HtmlSink.write` remains a small synchronous operation. One render step is CPU-bound serialization;
+deferred application work and asynchronous transport readiness remain outside it. The contract does
+not assign network-frame meaning to an invocation and does not own response close or host flush.
+
+Application/component code enters rendering through `renderHtml`, `writeHtml` or `streamHtml`.
+`HtmlWriter` remains a public receiver type for reusable component functions, but its constructor and
+sink are not public. An ordinary component therefore cannot call the raw sink as a shortcut around
+`text` and `UnsafeHtml`.
+
+`BufferedHtmlSink` retains the complete fragment in a `StringBuilder` and exposes a stable snapshot.
+It is the implementation behind `renderHtml` and is suitable for unit tests, small fragments and
+responses that deliberately do not stream.
+
+`StreamingHtmlSink` coalesces the writer's small calls and forwards ordered chunks to another
+`HtmlSink`. It retains at most `maxChunkChars` UTF-16 code units in normal operation. A supplementary
+Unicode character is never split; when the configured limit is one character, one two-code-unit chunk
+is permitted. The default bound is 8 Ki characters. `streamHtml` flushes the final partial chunk only
+after a successful render. Callers using the sink directly flush at an explicit render or protocol
+boundary.
+
+The streaming sink is fail-stop. It never catches and translates a downstream failure or cancellation
+signal. It records the original throwable, rethrows that exact instance and rejects every later write
+or flush with the same failure. A render failure after earlier chunks were sent remains partial output;
+the trailing buffered content is not emitted and the host adapter owns post-commit diagnostics.
+
+Cancellation does not introduce a Woge token. A coroutine-based adapter captures its request child
+job in the downstream writer and checks that job before host writes; a blocking host propagates its
+disconnect/write exception. The sink preserves either signal unchanged. Adapter integration and
+real-disconnect timing are verified by the TCK rather than simulated as transport behavior in core.
+
+Element nesting is structural through Kotlin receiver blocks. Attributes are completed and validated
+before a start tag is sent, and known void/raw-text misuse fails before output. There is no public
+open-tag/close-tag state machine whose ordering a caller can corrupt.
+
+JMH fixtures compile as part of `check` and compare buffered and 8-Ki-character streaming sinks at 32
+and 512 representative rows. Benchmark execution remains an explicit developer task, not a noisy CI
+performance assertion. Results record throughput and normalized allocation with the GC profiler.
+The first public `woge-core` declarations are also committed as a Kotlin ABI dump and checked by the
+standard build gate.
+
+## Alternatives considered
+
+- **Make every sink write and HTML DSL method `suspend`:** rejected because a render step has no
+  asynchronous work of its own, it would spread transport concerns through every component, and the
+  host exchange already owns suspension and backpressure.
+- **Keep the writer's sink public:** rejected because it provides an unannotated raw-HTML bypass from
+  ordinary component code.
+- **Always render a complete string before host output:** rejected because it prevents shell-first and
+  bounded-memory output for large fragments.
+- **Emit every tiny writer token directly:** rejected as the only streaming helper because host write
+  overhead dominates useful work; direct `HtmlSink` implementations remain possible when required.
+- **Own `OutputStream`, Servlet, Reactor or Ktor adapters in core:** rejected because character
+  encoding, transport readiness and response lifecycle belong to the host adapter.
+- **Recover and continue after a downstream write failure:** rejected because the host may have
+  accepted an unknown prefix and retrying could duplicate or corrupt output.
+
+## Consequences
+
+### Positive
+
+- Buffered tests and bounded incremental output use the same HTML component functions.
+- Core remains free of server-framework and coroutine runtime dependencies.
+- Backpressure, cancellation and response commit remain at their existing architectural owner.
+- Downstream failures cannot silently become a successful truncated document.
+- The safe writer no longer exposes an ordinary-string route to its raw sink.
+- Benchmarks make allocation/throughput changes measurable without flaky CI thresholds.
+- Public sink and writer signature changes become visible in normal code review and CI.
+
+### Negative
+
+- A host adapter must bridge its own asynchronous output mechanism to a synchronous render step.
+- Cancellation is observed at downstream writes, so detection latency depends on chunk size and host
+  behavior.
+- Character chunks still require encoding/allocation in the adapter before network bytes are written.
+- A failure after the first emitted chunk cannot change the already committed HTTP status.
+- The default chunk size needs validation through the real Spring MVC, WebFlux and Ktor adapters.
+
+## Follow-up
+
+- Exercise the sink from the framework-neutral host SPI in [#18](https://github.com/christian-draeger/woge/issues/18).
+- Verify real connection backpressure, disconnects and post-commit failures in [#65](https://github.com/christian-draeger/woge/issues/65), [#66](https://github.com/christian-draeger/woge/issues/66), [#67](https://github.com/christian-draeger/woge/issues/67) and [#68](https://github.com/christian-draeger/woge/issues/68).
+- Re-run and compare the [sink baseline](../performance/html-sinks-baseline.md) when sink allocation,
+  default chunking or escaping behavior changes materially.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0018](0018-hybrid-headless-and-source-owned-components.md) | Accepted | Combine binary headless primitives with source-owned component recipes |
 | [0019](0019-materialized-m1-module-boundaries.md) | Accepted | Materialize the M1 module and consumer boundaries |
 | [0020](0020-context-specific-html-values.md) | Accepted | Separate HTML value contexts and make active contexts explicit |
+| [0021](0021-synchronous-bounded-html-sinks.md) | Accepted | Keep HTML sinks synchronous, bounded and transport-neutral |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/development/build-and-test.md
+++ b/docs/development/build-and-test.md
@@ -21,9 +21,20 @@ The gate compiles the convention plugins, verifies explicit API mode, runs tests
 ./gradlew validateAdrs
 ./gradlew validateModuleBoundaries
 ./gradlew testModuleBoundaries
+./gradlew :woge-core:checkKotlinAbi
+./gradlew :woge-core:jmh
 ```
 
 `ktlintFormat` changes source files; the other commands are checks. Test reports are written below each project's `build/test-results` and `build/reports/tests` directories. Detekt writes machine-readable XML/SARIF and an HTML report below `build/reports/detekt`.
+
+The JMH command is an explicit performance measurement rather than a pass/fail check. `check` compiles
+the benchmark fixture but does not execute it. HTML sink results are written below
+`modules/woge-core/build/results/jmh` and interpreted in the
+[recorded baseline](../performance/html-sinks-baseline.md).
+
+Public core declarations are tracked by Kotlin's built-in ABI validator. `checkKotlinAbi` compares the
+current declarations with the committed dump. Run `./gradlew :woge-core:updateKotlinAbi` only after
+reviewing and accepting an intentional public API change.
 
 ## Source ownership
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,3 +7,5 @@ Canonical Kotlin examples belong in the root [`examples`](../../examples/README.
 The first implemented low-level guide is [safe HTML values](safe-html-values.md). Its temporary
 canonical example is compiled with `woge-core`; it moves into the reference application once that
 consumer build exists.
+
+The [HTML sink guide](stream-html.md) explains when to buffer or stream the same component functions.

--- a/docs/guides/stream-html.md
+++ b/docs/guides/stream-html.md
@@ -1,0 +1,71 @@
+# Buffer or stream HTML
+
+Use the same Woge component functions for a stable test string or for bounded incremental output.
+Choose the sink at the edge where the application already knows whether it is writing a small fragment
+or a server response.
+
+## Render a string for a test
+
+`renderHtml` uses `BufferedHtmlSink` and returns the complete fragment:
+
+```kotlin
+val html = renderHtml {
+    element("p") { text("Hello & goodbye") }
+}
+```
+
+The result is `<p>Hello &amp; goodbye</p>`. Use this path for assertions and intentionally buffered
+responses, not for a large page that should become visible incrementally.
+
+## Write directly to another sink
+
+`writeHtml` performs no page-sized buffering:
+
+```kotlin
+writeHtml(responseSink) {
+    element("main") {
+        projectHeader(project)
+        projectTasks(tasks)
+    }
+}
+```
+
+`responseSink` is an `HtmlSink` supplied by the host adapter. Component code receives `HtmlWriter`, not
+the sink itself, so normal values still pass through `text`, quoted attributes and validated URLs.
+
+## Coalesce small writes into bounded chunks
+
+HTML serialization naturally produces small pieces such as `<main`, one attribute and `>`. Use
+`streamHtml` to avoid one host call per piece while retaining only a bounded character buffer:
+
+<!-- snippet: modules/woge-core/src/test/kotlin/dev/woge/html/HtmlSinksTest.kt -->
+
+```kotlin
+streamHtml(responseSink, maxChunkChars = 8 * 1024) {
+    element("main") {
+        projectHeader(project)
+        projectTasks(tasks)
+    }
+}
+```
+
+The default is 8 Ki characters. This is a character bound, not a network packet, byte frame or promise
+that a proxy/browser displays each callback immediately. The host still controls UTF-8 encoding,
+response flushing, compression and proxy configuration.
+
+A supplementary Unicode character is never divided between chunks. With the artificial edge case
+`maxChunkChars = 1`, a two-code-unit chunk is allowed to keep that character intact.
+
+## Let failures end the render
+
+If the downstream sink reports a disconnect, cancellation or write failure, Woge rethrows the same
+failure. It does not retry and cannot replace an already streamed prefix with an error page. The host
+adapter decides whether the response was committed and records a safe diagnostic.
+
+`streamHtml` flushes its final partial chunk only when the render completes normally. When using
+`StreamingHtmlSink` directly, call `flush()` at a render or protocol boundary. `flush()` does not flush
+or close the HTTP response itself.
+
+See [ADR 0021](../adr/0021-synchronous-bounded-html-sinks.md) for lifecycle ownership and the
+[first benchmark baseline](../performance/html-sinks-baseline.md) for current allocation/throughput
+evidence.

--- a/docs/performance/html-sinks-baseline.md
+++ b/docs/performance/html-sinks-baseline.md
@@ -1,0 +1,47 @@
+# HTML sink performance baseline
+
+This baseline makes changes to buffering and streaming allocation measurable. It is not a release
+budget and should not be compared across machines as though the numbers were absolute.
+
+## Fixture
+
+[`HtmlSinkBenchmark.java`](../../modules/woge-core/src/jmh/java/dev/woge/html/HtmlSinkBenchmark.java)
+writes the same pre-encoded three-fragment row to:
+
+- `BufferedHtmlSink`, including the final complete `String` snapshot;
+- `StreamingHtmlSink` with an 8-Ki-character bound and a counting downstream sink.
+
+The 32-row case represents a small fragment. The 512-row case forces multiple streamed chunks and
+represents a larger region. JMH compiles during `./gradlew check`; execution is explicit:
+
+```shell
+./gradlew :woge-core:jmh
+```
+
+The build enables JMH's GC profiler and writes machine-readable output to
+`modules/woge-core/build/results/jmh/results.json`.
+
+## Initial local result
+
+- Date: 2026-09-04
+- Revision: working tree for issue #17 after `d98b0fc`
+- Platform: macOS 26.6.1, arm64
+- Benchmark JVM: OpenJDK 21.0.6
+- JMH: 1.37; one fork; two 250 ms warmups; three 250 ms measurements; one thread
+
+| Sink | Rows | Throughput (operations/second) | Allocation (bytes/operation) |
+| --- | ---: | ---: | ---: |
+| Buffered | 32 | 2,401,557 | 10,656 |
+| Streaming | 32 | 1,453,128 | 10,800 |
+| Buffered | 512 | 147,857 | 172,000 |
+| Streaming | 512 | 121,607 | 48,304 |
+
+On this short local run, buffering is faster for both sizes. The streaming path reduces normalized
+allocation by about 72% for 512 rows because it does not retain and copy a complete final document;
+for 32 rows it allocates slightly more. This supports the API split: buffer small fragments and choose
+bounded streaming for incrementality or larger output. The confidence interval for the small
+streaming case is wide, so these numbers are a starting point, not a regression threshold.
+
+Future comparisons must use the same fixture parameters and record JVM, operating system, hardware,
+JMH settings and revision. A release performance budget belongs to the end-to-end adapter/proxy
+benchmarks after the walking skeleton exists.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,11 +2,13 @@
 detekt = "1.23.8"
 junit = "5.13.4"
 junitPlatform = "1.13.4"
+jmhGradle = "0.7.3"
 kotlin = "2.4.10"
 ktlintGradle = "14.2.0"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+jmh = { id = "me.champeau.jmh", version.ref = "jmhGradle" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
 

--- a/modules/woge-core/api/woge-core.api
+++ b/modules/woge-core/api/woge-core.api
@@ -1,0 +1,125 @@
+public final class dev/woge/html/ApplicationUrl : dev/woge/html/HtmlUrl {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/html/ApplicationUrl;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/html/Attributes {
+	public final fun aria (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun attribute (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun boolean (Ljava/lang/String;Z)V
+	public static synthetic fun boolean$default (Ldev/woge/html/Attributes;Ljava/lang/String;ZILjava/lang/Object;)V
+	public final fun classes ([Ljava/lang/String;)V
+	public final fun data (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun styles ([Ljava/lang/String;)V
+	public final fun unsafeAttribute (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun unsafeUrl-G4S142U (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun url (Ljava/lang/String;Ldev/woge/html/HtmlUrl;)V
+}
+
+public final class dev/woge/html/BufferedHtmlSink : dev/woge/html/HtmlSink {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun content ()Ljava/lang/String;
+	public final fun getLength ()I
+	public fun write (Ljava/lang/String;)V
+}
+
+public final class dev/woge/html/ExternalUrl : dev/woge/html/HtmlUrl {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/html/ExternalUrl;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public abstract interface class dev/woge/html/HtmlSink {
+	public abstract fun write (Ljava/lang/String;)V
+}
+
+public final class dev/woge/html/HtmlSinksKt {
+	public static final field DEFAULT_HTML_CHUNK_CHARS I
+	public static final fun streamHtml (Ldev/woge/html/HtmlSink;ILkotlin/jvm/functions/Function1;)V
+	public static synthetic fun streamHtml$default (Ldev/woge/html/HtmlSink;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public abstract interface class dev/woge/html/HtmlUrl {
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class dev/woge/html/HtmlUrlKt {
+	public static final fun applicationUrl (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun externalUrl (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun unsafeHtmlUrl (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class dev/woge/html/HtmlValuesKt {
+	public static final fun unsafeHtml (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class dev/woge/html/HtmlWriter {
+	public final fun element (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun element$default (Ldev/woge/html/HtmlWriter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun raw-WmHVnZ8 (Ljava/lang/String;)V
+	public final fun text (Ljava/lang/String;)V
+	public final fun voidElement (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun voidElement$default (Ldev/woge/html/HtmlWriter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class dev/woge/html/HtmlWriterKt {
+	public static final fun renderHtml (Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
+	public static final fun srcdoc-mHIzVm8 (Ldev/woge/html/Attributes;Ljava/lang/String;)V
+	public static final fun writeHtml (Ldev/woge/html/HtmlSink;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class dev/woge/html/StreamingHtmlSink : dev/woge/html/HtmlSink {
+	public fun <init> (Ldev/woge/html/HtmlSink;I)V
+	public synthetic fun <init> (Ldev/woge/html/HtmlSink;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun flush ()V
+	public final fun getMaxChunkChars ()I
+	public fun write (Ljava/lang/String;)V
+}
+
+public final class dev/woge/html/UnsafeHtml {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/html/UnsafeHtml;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/html/UnsafeHtmlUrl {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/html/UnsafeHtmlUrl;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public abstract interface annotation class dev/woge/html/UnsafeWogeHtmlApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class dev/woge/html/WogeHtmlDsl : java/lang/annotation/Annotation {
+}
+

--- a/modules/woge-core/build.gradle.kts
+++ b/modules/woge-core/build.gradle.kts
@@ -1,8 +1,16 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     id("dev.woge.kotlin-jvm-library")
+    alias(libs.plugins.jmh)
 }
 
 description = "Web-native HTML, component, and portable value APIs for Woge applications."
+
+kotlin {
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation()
+}
 
 dependencies {
     testImplementation(gradleTestKit())
@@ -20,4 +28,14 @@ tasks.test {
             .get()
             .asFile.absolutePath,
     )
+}
+
+jmh {
+    jmhVersion.set("1.37")
+    profilers.set(listOf("gc"))
+    resultFormat.set("JSON")
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("jmhClasses"))
 }

--- a/modules/woge-core/src/jmh/java/dev/woge/html/HtmlSinkBenchmark.java
+++ b/modules/woge-core/src/jmh/java/dev/woge/html/HtmlSinkBenchmark.java
@@ -1,0 +1,62 @@
+package dev.woge.html;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 250, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 250, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+public class HtmlSinkBenchmark {
+    private static final String ROW_START = "<li class=\"task-row grid gap-2\">";
+    private static final String ROW_TEXT = "Escaped project task &amp; current status";
+    private static final String ROW_END = "</li>";
+
+    @Param({"32", "512"})
+    public int rows;
+
+    @Benchmark
+    public String buffered() {
+        var sink = new BufferedHtmlSink(256);
+        writeRows(sink);
+        return sink.content();
+    }
+
+    @Benchmark
+    public long streaming() {
+        var downstream = new CountingSink();
+        var sink = new StreamingHtmlSink(downstream, 8 * 1024);
+        writeRows(sink);
+        sink.flush();
+        return downstream.characters;
+    }
+
+    private void writeRows(HtmlSink sink) {
+        for (int index = 0; index < rows; index++) {
+            sink.write(ROW_START);
+            sink.write(ROW_TEXT);
+            sink.write(ROW_END);
+        }
+    }
+
+    private static final class CountingSink implements HtmlSink {
+        private long characters;
+
+        @Override
+        public void write(String value) {
+            characters += value.length();
+        }
+    }
+}

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlSink.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlSink.kt
@@ -1,6 +1,11 @@
 package dev.woge.html
 
-/** Receives serialized HTML fragments in write order without implying network frame boundaries. */
+/**
+ * Receives serialized HTML fragments in write order without implying network frame boundaries.
+ *
+ * Calls are synchronous and may contain arbitrarily small pieces. Implementations must propagate
+ * downstream failures and cancellation signals instead of converting them to partial HTML.
+ */
 public fun interface HtmlSink {
     /** Writes one serialized fragment or propagates the downstream failure unchanged. */
     public fun write(value: String)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlSinks.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlSinks.kt
@@ -1,0 +1,118 @@
+package dev.woge.html
+
+/** Default upper bound for characters retained by [StreamingHtmlSink] between downstream writes. */
+public const val DEFAULT_HTML_CHUNK_CHARS: Int = 8 * 1024
+
+/** A deterministic in-memory sink intended for tests, small fragments and non-streaming responses. */
+public class BufferedHtmlSink(
+    initialCapacity: Int = DEFAULT_INITIAL_HTML_CAPACITY,
+) : HtmlSink {
+    private val buffer: StringBuilder
+
+    init {
+        require(initialCapacity >= 0) { "HTML buffer initial capacity must not be negative" }
+        buffer = StringBuilder(initialCapacity)
+    }
+
+    /** Number of UTF-16 code units currently held by this sink. */
+    public val length: Int
+        get() = buffer.length
+
+    override fun write(value: String) {
+        buffer.append(value)
+    }
+
+    /** Returns a stable snapshot of the rendered HTML. */
+    public fun content(): String = buffer.toString()
+}
+
+/**
+ * Coalesces small writer calls into bounded chunks and forwards them synchronously to [downstream].
+ *
+ * Call [flush] at a meaningful render or transport boundary. This sink never closes or flushes the
+ * host response itself. A downstream failure makes the sink terminal and is rethrown unchanged.
+ */
+public class StreamingHtmlSink(
+    private val downstream: HtmlSink,
+    public val maxChunkChars: Int = DEFAULT_HTML_CHUNK_CHARS,
+) : HtmlSink {
+    private val buffer: StringBuilder
+    private var failure: Throwable? = null
+
+    init {
+        require(maxChunkChars > 0) { "HTML chunk size must be greater than zero" }
+        buffer = StringBuilder(maxChunkChars)
+    }
+
+    override fun write(value: String) {
+        rethrowFailure()
+        if (value.isEmpty()) return
+
+        var offset = 0
+        while (offset < value.length) {
+            if (buffer.length == maxChunkChars) emitBufferedChunk()
+
+            val capacity = maxChunkChars - buffer.length
+            var end = minOf(offset + capacity, value.length)
+            if (splitsSurrogatePair(value, offset, end)) {
+                end = if (buffer.isEmpty() && capacity == 1) end + 1 else end - 1
+            }
+            if (end == offset) {
+                emitBufferedChunk()
+                continue
+            }
+
+            buffer.append(value, offset, end)
+            offset = end
+            if (buffer.length >= maxChunkChars) emitBufferedChunk()
+        }
+    }
+
+    /** Emits the currently buffered characters, if any, without touching host transport lifecycle. */
+    public fun flush() {
+        rethrowFailure()
+        emitBufferedChunk()
+    }
+
+    private fun emitBufferedChunk() {
+        if (buffer.isEmpty()) return
+
+        val chunk = buffer.toString()
+        buffer.setLength(0)
+        val outcome = runCatching { downstream.write(chunk) }
+        failure = outcome.exceptionOrNull()
+        outcome.getOrThrow()
+    }
+
+    private fun rethrowFailure() {
+        failure?.let { throw it }
+    }
+}
+
+/**
+ * Renders through a bounded [StreamingHtmlSink] and flushes its final chunk on normal completion.
+ *
+ * If rendering or downstream writing fails, the original exception propagates and no trailing chunk
+ * is emitted after the failure.
+ */
+public fun streamHtml(
+    downstream: HtmlSink,
+    maxChunkChars: Int = DEFAULT_HTML_CHUNK_CHARS,
+    block: HtmlWriter.() -> Unit,
+) {
+    val sink = StreamingHtmlSink(downstream, maxChunkChars)
+    writeHtml(sink, block)
+    sink.flush()
+}
+
+private fun splitsSurrogatePair(
+    value: String,
+    offset: Int,
+    end: Int,
+): Boolean =
+    end > offset &&
+        end < value.length &&
+        value[end - 1].isHighSurrogate() &&
+        value[end].isLowSurrogate()
+
+private const val DEFAULT_INITIAL_HTML_CAPACITY: Int = 256

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlWriter.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlWriter.kt
@@ -5,8 +5,8 @@ import dev.woge.html.internal.escapeHtmlText
 
 /** Writes standards-shaped HTML directly to a sink without building an in-memory DOM. */
 @WogeHtmlDsl
-public class HtmlWriter(
-    public val sink: HtmlSink,
+public class HtmlWriter internal constructor(
+    private val sink: HtmlSink,
 ) {
     /** Writes [value] as HTML text. Markup characters are escaped rather than interpreted. */
     public fun text(value: String) {
@@ -55,12 +55,17 @@ public class HtmlWriter(
     }
 }
 
-/** Renders a small HTML fragment to a string using the same streaming writer contract. */
-public fun renderHtml(block: HtmlWriter.() -> Unit): String {
-    val output = StringBuilder()
-    HtmlWriter(HtmlSink { value -> output.append(value) }).block()
-    return output.toString()
+/** Writes one HTML fragment directly to [sink]. */
+public fun writeHtml(
+    sink: HtmlSink,
+    block: HtmlWriter.() -> Unit,
+) {
+    HtmlWriter(sink).block()
 }
+
+/** Renders a small HTML fragment to a deterministic in-memory string. */
+public fun renderHtml(block: HtmlWriter.() -> Unit): String =
+    BufferedHtmlSink().also { sink -> writeHtml(sink, block) }.content()
 
 /** Collects one start tag's attributes in deterministic insertion order. */
 @WogeHtmlDsl

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlSinksTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlSinksTest.kt
@@ -1,0 +1,104 @@
+package dev.woge.html
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.util.concurrent.CancellationException
+
+class HtmlSinksTest {
+    @Test
+    fun `buffered sink produces stable snapshots`() {
+        val sink = BufferedHtmlSink(initialCapacity = 1)
+
+        writeHtml(sink) {
+            element("p", attributes = { attribute("lang", "en") }) {
+                text("Hello & goodbye")
+            }
+        }
+
+        assertEquals("<p lang=\"en\">Hello &amp; goodbye</p>", sink.content())
+        assertEquals(sink.content().length, sink.length)
+    }
+
+    @Test
+    fun `streaming sink emits before rendering completes`() {
+        val chunks = mutableListOf<String>()
+        var observedDuringRender = false
+
+        streamHtml(HtmlSink(chunks::add), maxChunkChars = 8) {
+            element("main") {
+                text("first")
+                observedDuringRender = chunks.isNotEmpty()
+                text("-second")
+            }
+        }
+
+        assertTrue(observedDuringRender)
+        assertEquals("<main>first-second</main>", chunks.joinToString(separator = ""))
+        assertTrue(chunks.size > 1)
+        assertTrue(chunks.all { it.length <= 8 })
+    }
+
+    @Test
+    fun `large writes remain bounded and never split a surrogate pair`() {
+        val chunks = mutableListOf<String>()
+        val content = "ab😀cd".repeat(100)
+
+        streamHtml(HtmlSink(chunks::add), maxChunkChars = 3) {
+            element("p") { text(content) }
+        }
+
+        assertEquals("<p>$content</p>", chunks.joinToString(separator = ""))
+        assertTrue(chunks.all { it.length <= 4 })
+        assertFalse(chunks.any { it.last().isHighSurrogate() })
+        assertFalse(chunks.any { it.first().isLowSurrogate() })
+    }
+
+    @Test
+    fun `downstream failure propagates unchanged and makes the sink terminal`() {
+        val failure = IOException("client disconnected")
+        val sink =
+            StreamingHtmlSink(
+                downstream = HtmlSink { throw failure },
+                maxChunkChars = 1,
+            )
+
+        assertSame(failure, assertThrows(IOException::class.java) { sink.write("content") })
+        assertSame(failure, assertThrows(IOException::class.java) { sink.write("more") })
+        assertSame(failure, assertThrows(IOException::class.java) { sink.flush() })
+    }
+
+    @Test
+    fun `cancellation propagates unchanged`() {
+        val cancellation = CancellationException("request cancelled")
+
+        val thrown =
+            assertThrows(CancellationException::class.java) {
+                streamHtml(HtmlSink { throw cancellation }, maxChunkChars = 1) {
+                    element("p") { text("never completed") }
+                }
+            }
+
+        assertSame(cancellation, thrown)
+    }
+
+    @Test
+    fun `render failure does not flush trailing buffered content`() {
+        val chunks = mutableListOf<String>()
+
+        assertThrows(IllegalStateException::class.java) {
+            streamHtml(HtmlSink(chunks::add), maxChunkChars = 8) {
+                element("main") {
+                    text("first")
+                    error("render failed")
+                }
+            }
+        }
+
+        assertEquals(listOf("<main>fi"), chunks)
+    }
+}

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlWriterTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlWriterTest.kt
@@ -95,21 +95,24 @@ class HtmlWriterTest {
     @Test
     fun `invalid or duplicate syntax fails before the start tag is written`() {
         val chunks = mutableListOf<String>()
-        val writer = HtmlWriter(HtmlSink(chunks::add))
 
         assertThrows(IllegalArgumentException::class.java) {
-            writer.element("div", attributes = { attribute("x\" onclick", "bad") })
+            writeHtml(HtmlSink(chunks::add)) {
+                element("div", attributes = { attribute("x\" onclick", "bad") })
+            }
         }
         assertTrue(chunks.isEmpty())
 
         assertThrows(IllegalArgumentException::class.java) {
-            writer.element(
-                "div",
-                attributes = {
-                    attribute("id", "first")
-                    attribute("ID", "second")
-                },
-            )
+            writeHtml(HtmlSink(chunks::add)) {
+                element(
+                    "div",
+                    attributes = {
+                        attribute("id", "first")
+                        attribute("ID", "second")
+                    },
+                )
+            }
         }
         assertTrue(chunks.isEmpty())
     }


### PR DESCRIPTION
## Outcome

Adds deterministic buffered rendering and bounded incremental HTML output behind the same safe component API. Sink failures and cancellation signals remain terminal and propagate unchanged.

## Included

- `BufferedHtmlSink`, `StreamingHtmlSink`, `writeHtml` and `streamHtml`
- internal writer construction/sink access so ordinary component code cannot bypass escaping
- bounded chunking that preserves supplementary Unicode characters
- incremental-output, terminal-failure, cancellation and partial-render tests
- ADR 0021 and a web-first buffering/streaming guide
- JMH throughput/allocation fixture plus recorded baseline
- Kotlin built-in ABI validation and the first committed `woge-core` dump

## Evidence

- `./gradlew check`
- `./gradlew :woge-core:jmh` (JMH 1.37 with GC profiler)
- local 512-row allocation: 172,000 B/op buffered vs 48,304 B/op streaming

Closes #17