### PR TITLE
Define the minimal transport-neutral Patch IR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Render safe HTML values](guides/safe-html-values.md)
 - [Buffer or stream HTML](guides/stream-html.md)
 - [Write a framework-neutral page use case](guides/server-host-spi.md)
+- [Describe a visible update with Patch IR](guides/patch-ir.md)
 
 ## Performance evidence
 

--- a/docs/adr/0023-minimal-replace-patch-ir.md
+++ b/docs/adr/0023-minimal-replace-patch-ir.md
@@ -1,0 +1,109 @@
+# ADR 0023: Keep Replace Patch IR semantic, explicit and closed
+
+- Status: Accepted
+- Date: 2026-09-04
+- Decision owners: Woge maintainers
+- Related issues: [#19](https://github.com/christian-draeger/woge/issues/19), [#20](https://github.com/christian-draeger/woge/issues/20), [#21](https://github.com/christian-draeger/woge/issues/21)
+
+## Context
+
+Woge needs one representation of a visible update before it can encode fallback streams, map to
+possible native browser syntax or apply updates to the DOM. That representation must preserve the
+identity and ordering rules from [ADR 0010](0010-identity-epochs-and-revisions.md) without exposing a
+CSS selector or one transport's frame format.
+
+Only atomic child replacement has executable evidence. Adding append, remove or announcement names
+without their ordering, focus, accessibility and recovery behavior would let callers request
+operations that no adapter can implement consistently.
+
+HTML content crosses two different safety boundaries. Contextual server-side escaping prevents
+ordinary strings from becoming markup. Separately, the browser patch sink must reject executable
+elements, inline handlers and active URL schemes. Calling all escaped HTML “trusted” would hide this
+second check.
+
+## Decision
+
+The version-1 semantic Patch IR is a sealed `Patch` interface with exactly one implementation:
+`ReplacePatch`. Its operation is explicitly `PatchOperation.REPLACE`. External modules cannot invent
+new implementations, and exhaustive consumers must handle every operation when Woge adds one.
+
+Every replace patch carries:
+
+- `PatchProtocolVersion`, currently version 1;
+- an opaque `PatchId`;
+- a `PatchTarget` combining the active `PageEpoch` and generated `RegionTargetId`;
+- the browser's `InteractionSequence`;
+- an exact contiguous `TargetRevisionStep` from base to base plus one;
+- one materialized `PatchHtml` payload.
+
+Opaque IDs permit only ASCII letters, digits, underscore and hyphen. This is safe in generated HTML
+attributes and deliberately excludes selector syntax such as `#id`, `.class`, brackets, spaces and
+path expressions. Parsing an ID proves syntax only. Epoch and target possession never grants
+authorization, implementing `WOGE-TARGET-001`.
+
+Interaction sequences and target revisions are non-negative 64-bit values. A revision step rejects
+duplicates, gaps and overflow during construction. Overflow requires a new page epoch rather than
+wrapping. Browser policy still decides whether an older interaction is ignored or a mismatch triggers
+resynchronization; the IR makes all required facts available without deciding against browser state.
+
+`patchHtml { ... }` renders through Woge's context-escaping HTML DSL and materializes exactly one
+patch payload. This does not buffer a complete page and matches the selected length-prefixed framing,
+which must know one payload's byte length before emitting its header. Direct construction from a raw
+string is not public Kotlin API. An explicit unsafe HTML opt-in inside the DSL remains possible for
+audited application code.
+
+`PatchHtml` is context-encoded, not automatically trusted or inert. The version-1 encoder and browser
+sink must still reject scripts, inline event handlers, `srcdoc` and dangerous active URL schemes
+before bytes are emitted or the DOM changes, implementing `WOGE-XSS-002`.
+
+The IR itself has no JSON, binary framing, DOM or native DPU API. Its fields are immutable primitive
+value objects in deterministic order. A canonical test-only JSON fixture proves that every field and
+the rendered payload can be serialized repeatably. The production metadata JSON mapping and golden
+wire bytes belong to [#20](https://github.com/christian-draeger/woge/issues/20), where changing field
+names becomes an explicit protocol decision.
+
+## Alternatives considered
+
+- **Use CSS selectors as targets:** rejected because they can over-match, couple updates to styling
+  and bypass generated page-local target ownership.
+- **Represent operations as a string:** rejected because an unknown spelling could travel until a
+  browser silently ignores it. A sealed model and enum force explicit support.
+- **Add append/remove/announce variants now:** rejected because their identity, ordering,
+  preservation and accessibility rules do not yet have vertical evidence.
+- **Store only target and HTML:** rejected because old documents, out-of-order interactions,
+  duplicates and revision gaps would be indistinguishable.
+- **Store a lazy HTML lambda:** rejected for patches because the selected frame header needs a known
+  payload length and the browser applies complete patch frames atomically.
+- **Annotate the model with one serialization library now:** rejected because it would make a codec
+  dependency part of the semantic API before the version-1 encoder owns canonical JSON behavior.
+- **Treat escaped HTML as safe to insert without inspection:** rejected because deliberate elements
+  and URL-bearing attributes can still be executable even when every dynamic string is correctly
+  escaped.
+
+## Consequences
+
+### Positive
+
+- Native and fallback transports can consume the same visible-update intent.
+- Missing epoch, interaction or revision facts cannot create a valid replace patch.
+- Selector injection and unsupported operation strings are absent from the public model.
+- Golden fixtures are deterministic without coupling application code to the wire codec.
+- HTML context encoding and active-content validation remain visible, separately testable controls.
+
+### Negative
+
+- One patch payload is materialized in memory and must be bounded by the encoder's 8 MiB limit.
+- Callers cannot request append, removal or announcements until those operations have complete
+  semantics.
+- Generated target IDs and cryptographic page epochs are not created by this module; later runtime
+  work must supply them.
+- The encoder performs a second active-content validation even for DSL-produced markup.
+
+## Follow-up
+
+- Encode canonical metadata and payload bytes with arbitrary-split golden tests in
+  [#20](https://github.com/christian-draeger/woge/issues/20).
+- Apply replace patches through the page-local registry and inert DOM parsing in
+  [#21](https://github.com/christian-draeger/woge/issues/21).
+- Generate opaque keyed region identities in [#25](https://github.com/christian-draeger/woge/issues/25).
+- Add append only with its source sequence, event identity, bounded gap and recovery behavior.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0020](0020-context-specific-html-values.md) | Accepted | Separate HTML value contexts and make active contexts explicit |
 | [0021](0021-synchronous-bounded-html-sinks.md) | Accepted | Keep HTML sinks synchronous, bounded and transport-neutral |
 | [0022](0022-page-host-spi-contract.md) | Accepted | Use one narrow typed page boundary with policy-checked outcomes |
+| [0023](0023-minimal-replace-patch-ir.md) | Accepted | Keep Replace Patch IR semantic, explicit and closed |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/architecture/identity-and-revisions.md
+++ b/docs/architecture/identity-and-revisions.md
@@ -1,6 +1,9 @@
 # Component identity, page epochs and revisions
 
-This document defines observable identity and ordering behavior before concrete Kotlin names are frozen. Identity locates a rendered instance; it never grants permission to read or mutate it.
+This document defines observable identity and ordering behavior. The first implemented protocol values
+are `PageEpoch`, `RegionTargetId`, `PatchTarget`, `InteractionSequence`, `TargetRevision` and
+`TargetRevisionStep`; generated component/region descriptor names remain follow-up work. Identity
+locates a rendered instance; it never grants permission to read or mutate it.
 
 ## Identity model
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -12,3 +12,6 @@ The [HTML sink guide](stream-html.md) explains when to buffer or stream the same
 
 The [server host SPI guide](server-host-spi.md) introduces typed page use cases, immutable request
 facts, streamed HTML frames, redirects and safe failures before the Spring and Ktor adapters land.
+
+The [Patch IR guide](patch-ir.md) explains the first transport-neutral replace operation and its
+page, target, interaction and revision checks in browser terms.

--- a/docs/guides/patch-ir.md
+++ b/docs/guides/patch-ir.md
@@ -1,0 +1,79 @@
+# Describe a visible update with Patch IR
+
+Patch IR describes what should change in an already open HTML document. It is not a DOM API and it is
+not the bytes sent over HTTP. Spring MVC, Spring WebFlux, Ktor and a future native browser path can all
+adapt the same value.
+
+Only one operation exists today: replace the children of one known Woge region.
+
+## Build a replace patch
+
+```kotlin
+val patch =
+    ReplacePatch(
+        patchId = PatchId.of("patch-42"),
+        target =
+            PatchTarget(
+                pageEpoch = PageEpoch.of("nM9yQ_2aB7"),
+                region = RegionTargetId.of("project-summary-7zA"),
+            ),
+        interactionSequence = InteractionSequence.of(12),
+        revision = TargetRevisionStep.after(TargetRevision.of(4)),
+        html =
+            patchHtml {
+                element("p") {
+                    text("3 open tasks")
+                }
+            },
+    )
+```
+
+This says: patch `patch-42` belongs to one document, targets one registered region, answers browser
+interaction 12, advances that region from revision 4 to 5 and replaces its children with the rendered
+paragraph.
+
+Most application code will not construct epochs and region IDs manually. Generated component and
+region references will do that later. The explicit example shows the complete browser contract and is
+useful in protocol tests.
+
+## Why the target is not a selector
+
+`RegionTargetId` accepts an opaque generated value, not `#summary`, `.card` or
+`[data-project="42"]`. CSS remains for styling and normal browser code. A patch target instead resolves
+through the active page's Woge region registry and must match exactly once.
+
+The page epoch prevents a response from an old navigation from updating the current document. Neither
+the epoch nor the target ID is a permission: every server request still performs authentication and
+domain authorization.
+
+## Why interaction and revision are separate
+
+The interaction sequence says which user intent is newest. Imagine a search for `ko` starts as 11,
+then a search for `kotlin` starts as 12. If 11 finishes last, the browser can ignore it.
+
+The target revision says which DOM state the result builds on. A replace patch must advance exactly
+from `base` to `base + 1`; duplicates, gaps and overflow fail while constructing or applying it. These
+numbers coordinate the view only. They are unrelated to database optimistic-lock versions.
+
+## HTML safety has two layers
+
+`patchHtml` uses the normal Woge HTML DSL. Dynamic text is escaped, so `text(userInput)` cannot close an
+element or inject markup. The result is materialized because one atomic length-prefixed patch frame
+needs to know its payload size.
+
+Context encoding does not make every deliberate HTML element safe for DOM insertion. The upcoming
+encoder and browser runtime also reject script elements, inline `on*` handlers, `srcdoc` and dangerous
+active URL schemes. An explicitly opted-in raw HTML value is still subject to that patch-sink policy.
+
+## What is deliberately missing
+
+There is no string operation name and no generic map of extra fields. Append, remove and live-region
+announcement will appear only after their ordering, focus, accessibility and recovery behavior is
+specified and tested.
+
+There is also no JSON or binary encoding in the IR. Issue #20 maps this semantic value to canonical
+metadata and the version-1 length-prefixed fallback stream. A checked-in golden fixture already proves
+the IR's field order and rendered content are deterministic; it is not yet the public wire format.
+
+See the executable [`PatchTest`](../../modules/woge-protocol/src/test/kotlin/dev/woge/protocol/PatchTest.kt)
+for valid values, invalid selectors, revision gaps, protocol mismatch and fixture serialization.

--- a/modules/woge-protocol/api/woge-protocol.api
+++ b/modules/woge-protocol/api/woge-protocol.api
@@ -6,3 +6,185 @@ public final class dev/woge/protocol/HtmlFrameKt {
 	public static final fun htmlFrame (Lkotlin/jvm/functions/Function1;)Ldev/woge/protocol/HtmlFrame;
 }
 
+public final class dev/woge/protocol/InteractionSequence {
+	public static final field Companion Ldev/woge/protocol/InteractionSequence$Companion;
+	public static final synthetic fun box-impl (J)Ldev/woge/protocol/InteractionSequence;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class dev/woge/protocol/InteractionSequence$Companion {
+	public final fun getINITIAL-_Y98rLg ()J
+	public final fun of-rf_4HM8 (J)J
+}
+
+public final class dev/woge/protocol/PageEpoch {
+	public static final field Companion Ldev/woge/protocol/PageEpoch$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/protocol/PageEpoch;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/PageEpoch$Companion {
+	public final fun of-jIBZJ30 (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class dev/woge/protocol/Patch {
+	public abstract fun getInteractionSequence-_Y98rLg ()J
+	public abstract fun getOperation ()Ldev/woge/protocol/PatchOperation;
+	public abstract fun getPatchId-9SDvvjQ ()Ljava/lang/String;
+	public abstract fun getProtocolVersion-JnwDiMo ()I
+	public abstract fun getRevision ()Ldev/woge/protocol/TargetRevisionStep;
+	public abstract fun getTarget ()Ldev/woge/protocol/PatchTarget;
+}
+
+public final class dev/woge/protocol/PatchHtml {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/PatchId {
+	public static final field Companion Ldev/woge/protocol/PatchId$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/protocol/PatchId;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/PatchId$Companion {
+	public final fun of-GSU-mag (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/PatchKt {
+	public static final fun patchHtml (Lkotlin/jvm/functions/Function1;)Ldev/woge/protocol/PatchHtml;
+}
+
+public final class dev/woge/protocol/PatchOperation : java/lang/Enum {
+	public static final field REPLACE Ldev/woge/protocol/PatchOperation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/woge/protocol/PatchOperation;
+	public static fun values ()[Ldev/woge/protocol/PatchOperation;
+}
+
+public final class dev/woge/protocol/PatchProtocolVersion {
+	public static final field Companion Ldev/woge/protocol/PatchProtocolVersion$Companion;
+	public static final synthetic fun box-impl (I)Ldev/woge/protocol/PatchProtocolVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class dev/woge/protocol/PatchProtocolVersion$Companion {
+	public final fun getCURRENT-JnwDiMo ()I
+	public final fun of-SpeMxaw (I)I
+}
+
+public final class dev/woge/protocol/PatchTarget {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-5npnCUI ()Ljava/lang/String;
+	public final fun component2-WW14DhI ()Ljava/lang/String;
+	public final fun copy-Lo2V4aE (Ljava/lang/String;Ljava/lang/String;)Ldev/woge/protocol/PatchTarget;
+	public static synthetic fun copy-Lo2V4aE$default (Ldev/woge/protocol/PatchTarget;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/woge/protocol/PatchTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPageEpoch-5npnCUI ()Ljava/lang/String;
+	public final fun getRegion-WW14DhI ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/RegionTargetId {
+	public static final field Companion Ldev/woge/protocol/RegionTargetId$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/protocol/RegionTargetId;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/RegionTargetId$Companion {
+	public final fun of-o4U952M (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/ReplacePatch : dev/woge/protocol/Patch {
+	public synthetic fun <init> (Ljava/lang/String;Ldev/woge/protocol/PatchTarget;JLdev/woge/protocol/TargetRevisionStep;Ldev/woge/protocol/PatchHtml;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ldev/woge/protocol/PatchTarget;JLdev/woge/protocol/TargetRevisionStep;Ldev/woge/protocol/PatchHtml;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHtml ()Ldev/woge/protocol/PatchHtml;
+	public fun getInteractionSequence-_Y98rLg ()J
+	public fun getOperation ()Ldev/woge/protocol/PatchOperation;
+	public fun getPatchId-9SDvvjQ ()Ljava/lang/String;
+	public fun getProtocolVersion-JnwDiMo ()I
+	public fun getRevision ()Ldev/woge/protocol/TargetRevisionStep;
+	public fun getTarget ()Ldev/woge/protocol/PatchTarget;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/TargetRevision {
+	public static final field Companion Ldev/woge/protocol/TargetRevision$Companion;
+	public static final synthetic fun box-impl (J)Ldev/woge/protocol/TargetRevision;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class dev/woge/protocol/TargetRevision$Companion {
+	public final fun getINITIAL-UimE8lE ()J
+	public final fun of-jBwYHRw (J)J
+}
+
+public final class dev/woge/protocol/TargetRevisionStep {
+	public static final field Companion Ldev/woge/protocol/TargetRevisionStep$Companion;
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UimE8lE ()J
+	public final fun component2-UimE8lE ()J
+	public final fun copy-Lp-Drb8 (JJ)Ldev/woge/protocol/TargetRevisionStep;
+	public static synthetic fun copy-Lp-Drb8$default (Ldev/woge/protocol/TargetRevisionStep;JJILjava/lang/Object;)Ldev/woge/protocol/TargetRevisionStep;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBase-UimE8lE ()J
+	public final fun getNext-UimE8lE ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/protocol/TargetRevisionStep$Companion {
+	public final fun after-dyqw_jc (J)Ldev/woge/protocol/TargetRevisionStep;
+}
+

--- a/modules/woge-protocol/src/main/kotlin/dev/woge/protocol/Patch.kt
+++ b/modules/woge-protocol/src/main/kotlin/dev/woge/protocol/Patch.kt
@@ -1,0 +1,187 @@
+package dev.woge.protocol
+
+import dev.woge.html.HtmlWriter
+import dev.woge.html.renderHtml
+
+/** Version of the semantic Woge patch contract. */
+@JvmInline
+public value class PatchProtocolVersion private constructor(
+    public val value: Int,
+) {
+    public companion object {
+        public val CURRENT: PatchProtocolVersion = PatchProtocolVersion(1)
+
+        /** Parses a positive version. Unsupported versions are rejected by concrete patch types. */
+        public fun of(value: Int): PatchProtocolVersion {
+            require(value > 0) { "Patch protocol version must be positive" }
+            return PatchProtocolVersion(value)
+        }
+    }
+}
+
+/** Opaque identifier for one patch, suitable for diagnostics and future deduplication. */
+@JvmInline
+public value class PatchId private constructor(
+    public val value: String,
+) {
+    public companion object {
+        public fun of(value: String): PatchId = PatchId(validateOpaqueId(value, "Patch ID"))
+    }
+}
+
+/** Opaque identity of one complete browser document. It is not an authorization capability. */
+@JvmInline
+public value class PageEpoch private constructor(
+    public val value: String,
+) {
+    public companion object {
+        /** Parses an already generated epoch; generation and integrity protection are runtime work. */
+        public fun of(value: String): PageEpoch = PageEpoch(validateOpaqueId(value, "Page epoch"))
+    }
+}
+
+/** Opaque generated region target. The value is never interpreted as a CSS selector. */
+@JvmInline
+public value class RegionTargetId private constructor(
+    public val value: String,
+) {
+    public companion object {
+        public fun of(value: String): RegionTargetId = RegionTargetId(validateOpaqueId(value, "Region target ID"))
+    }
+}
+
+/** Identifies one legal target inside one page epoch. Possession never grants authorization. */
+public data class PatchTarget(
+    public val pageEpoch: PageEpoch,
+    public val region: RegionTargetId,
+)
+
+/** Monotonic browser interaction ordering assigned when an enhanced interaction starts. */
+@JvmInline
+public value class InteractionSequence private constructor(
+    public val value: Long,
+) {
+    public companion object {
+        public val INITIAL: InteractionSequence = InteractionSequence(0)
+
+        public fun of(value: Long): InteractionSequence {
+            require(value >= 0) { "Interaction sequence must not be negative" }
+            return InteractionSequence(value)
+        }
+    }
+}
+
+/** Monotonic revision scoped to one [PatchTarget]. */
+@JvmInline
+public value class TargetRevision private constructor(
+    public val value: Long,
+) {
+    public companion object {
+        public val INITIAL: TargetRevision = TargetRevision(0)
+
+        public fun of(value: Long): TargetRevision {
+            require(value >= 0) { "Target revision must not be negative" }
+            return TargetRevision(value)
+        }
+    }
+}
+
+/** One exact contiguous revision transition. Gaps and overflow cannot form a valid patch. */
+public data class TargetRevisionStep(
+    public val base: TargetRevision,
+    public val next: TargetRevision,
+) {
+    init {
+        require(base.value < Long.MAX_VALUE && next.value == base.value + 1) {
+            "Next target revision must be exactly base revision + 1 without overflow"
+        }
+    }
+
+    public companion object {
+        public fun after(base: TargetRevision): TargetRevisionStep {
+            require(base.value < Long.MAX_VALUE) { "Target revision overflow requires a new page epoch" }
+            return TargetRevisionStep(base, TargetRevision.of(base.value + 1))
+        }
+    }
+}
+
+/**
+ * Materialized HTML owned by one patch.
+ *
+ * Instances are created by [patchHtml], so ordinary dynamic strings pass through Woge's contextual
+ * HTML escaping. Raw markup still requires the explicit unsafe HTML opt-in inside that DSL. The
+ * fallback browser sink additionally rejects executable patch content before DOM mutation.
+ */
+public class PatchHtml internal constructor(
+    public val value: String,
+) {
+    override fun equals(other: Any?): Boolean = other is PatchHtml && value == other.value
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = "PatchHtml(length=${value.length}, content=<redacted>)"
+}
+
+/** Renders one bounded patch payload through the safe HTML DSL. */
+public fun patchHtml(content: HtmlWriter.() -> Unit): PatchHtml = PatchHtml(renderHtml(content))
+
+/** Semantic patch operation. Only operations with implemented behavior are present. */
+public enum class PatchOperation {
+    REPLACE,
+}
+
+/** Transport-neutral visible update. Framing and native-browser syntax are separate adapters. */
+public sealed interface Patch {
+    public val protocolVersion: PatchProtocolVersion
+    public val operation: PatchOperation
+    public val patchId: PatchId
+    public val target: PatchTarget
+    public val interactionSequence: InteractionSequence
+    public val revision: TargetRevisionStep
+}
+
+/** Atomically replaces the child content of one known rendered region. */
+public class ReplacePatch(
+    override val patchId: PatchId,
+    override val target: PatchTarget,
+    override val interactionSequence: InteractionSequence,
+    override val revision: TargetRevisionStep,
+    public val html: PatchHtml,
+    override val protocolVersion: PatchProtocolVersion = PatchProtocolVersion.CURRENT,
+) : Patch {
+    override val operation: PatchOperation = PatchOperation.REPLACE
+
+    init {
+        require(protocolVersion == PatchProtocolVersion.CURRENT) {
+            "Unsupported patch protocol version: ${protocolVersion.value}"
+        }
+    }
+
+    override fun toString(): String =
+        "ReplacePatch(" +
+            "protocolVersion=${protocolVersion.value}, " +
+            "patchId=${patchId.value}, " +
+            "target=$target, " +
+            "interactionSequence=${interactionSequence.value}, " +
+            "revision=$revision, " +
+            "html=$html)"
+}
+
+private fun validateOpaqueId(
+    value: String,
+    label: String,
+): String {
+    require(value.length in 1..MAX_OPAQUE_ID_LENGTH && value.all(::isOpaqueIdCharacter)) {
+        "$label must contain only ASCII letters, digits, '_' or '-'"
+    }
+    return value
+}
+
+private fun isOpaqueIdCharacter(character: Char): Boolean =
+    character in 'a'..'z' ||
+        character in 'A'..'Z' ||
+        character in '0'..'9' ||
+        character == '_' ||
+        character == '-'
+
+private const val MAX_OPAQUE_ID_LENGTH: Int = 256

--- a/modules/woge-protocol/src/test/kotlin/dev/woge/protocol/PatchTest.kt
+++ b/modules/woge-protocol/src/test/kotlin/dev/woge/protocol/PatchTest.kt
@@ -1,0 +1,128 @@
+package dev.woge.protocol
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PatchTest {
+    @Test
+    fun `replace patch carries the complete semantic contract`() {
+        val patch = examplePatch()
+
+        assertEquals(PatchProtocolVersion.CURRENT, patch.protocolVersion)
+        assertEquals(PatchOperation.REPLACE, patch.operation)
+        assertEquals("patch-1", patch.patchId.value)
+        assertEquals("epoch-a", patch.target.pageEpoch.value)
+        assertEquals("summary-1", patch.target.region.value)
+        assertEquals(41, patch.interactionSequence.value)
+        assertEquals(7, patch.revision.base.value)
+        assertEquals(8, patch.revision.next.value)
+        assertEquals("<p>Tasks &lt;today&gt;</p>", patch.html.value)
+    }
+
+    @Test
+    fun `replace patch serializes deterministically for a golden fixture`() {
+        val expected =
+            checkNotNull(javaClass.getResource("/fixtures/replace-patch-v1.json"))
+                .readText()
+                .trim()
+
+        assertEquals(expected, serializeFixture(examplePatch()))
+    }
+
+    @Test
+    fun `target identity rejects CSS selectors and unsafe attribute text`() {
+        val invalidTargets = listOf("#summary", "[data-region]", ".summary", "summary value", "summary/child")
+
+        invalidTargets.forEach { value ->
+            assertThrows(IllegalArgumentException::class.java) {
+                RegionTargetId.of(value)
+            }
+        }
+    }
+
+    @Test
+    fun `revision step rejects duplicates gaps and overflow`() {
+        val revision = TargetRevision.of(7)
+
+        assertEquals(TargetRevision.of(8), TargetRevisionStep.after(revision).next)
+        assertThrows(IllegalArgumentException::class.java) {
+            TargetRevisionStep(revision, TargetRevision.of(7))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TargetRevisionStep(revision, TargetRevision.of(9))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TargetRevisionStep.after(TargetRevision.of(Long.MAX_VALUE))
+        }
+    }
+
+    @Test
+    fun `unknown protocol versions cannot form a replace patch`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            examplePatch(protocolVersion = PatchProtocolVersion.of(2))
+        }
+    }
+
+    @Test
+    fun `patch diagnostics redact rendered HTML`() {
+        val patch = examplePatch()
+
+        assertFalse(patch.toString().contains("Tasks"))
+        assertTrue(patch.toString().contains("content=<redacted>"))
+    }
+}
+
+private fun examplePatch(protocolVersion: PatchProtocolVersion = PatchProtocolVersion.CURRENT): ReplacePatch =
+    ReplacePatch(
+        patchId = PatchId.of("patch-1"),
+        target = PatchTarget(PageEpoch.of("epoch-a"), RegionTargetId.of("summary-1")),
+        interactionSequence = InteractionSequence.of(41),
+        revision = TargetRevisionStep(TargetRevision.of(7), TargetRevision.of(8)),
+        html =
+            patchHtml {
+                element("p") { text("Tasks <today>") }
+            },
+        protocolVersion = protocolVersion,
+    )
+
+private fun serializeFixture(patch: Patch): String =
+    when (patch) {
+        is ReplacePatch ->
+            "{" +
+                "\"protocolVersion\":${patch.protocolVersion.value}," +
+                "\"operation\":\"${patch.operation.fixtureName()}\"," +
+                "\"patchId\":${patch.patchId.value.asJsonString()}," +
+                "\"epoch\":${patch.target.pageEpoch.value.asJsonString()}," +
+                "\"target\":${patch.target.region.value.asJsonString()}," +
+                "\"interactionSequence\":${patch.interactionSequence.value}," +
+                "\"baseRevision\":${patch.revision.base.value}," +
+                "\"nextRevision\":${patch.revision.next.value}," +
+                "\"html\":${patch.html.value.asJsonString()}" +
+                "}"
+    }
+
+private fun PatchOperation.fixtureName(): String =
+    when (this) {
+        PatchOperation.REPLACE -> "replace"
+    }
+
+private fun String.asJsonString(): String =
+    buildString {
+        append('"')
+        this@asJsonString.forEach { character ->
+            when (character) {
+                '"' -> append("\\\"")
+                '\\' -> append("\\\\")
+                '\b' -> append("\\b")
+                '\u000c' -> append("\\f")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(character)
+            }
+        }
+        append('"')
+    }

--- a/modules/woge-protocol/src/test/resources/fixtures/replace-patch-v1.json
+++ b/modules/woge-protocol/src/test/resources/fixtures/replace-patch-v1.json
@@ -1,0 +1,1 @@
+{"protocolVersion":1,"operation":"replace","patchId":"patch-1","epoch":"epoch-a","target":"summary-1","interactionSequence":41,"baseRevision":7,"nextRevision":8,"html":"<p>Tasks &lt;today&gt;</p>"}


### PR DESCRIPTION
## Outcome

Defines the minimal transport-neutral Patch IR for one safe, deterministic replace operation without coupling application code to fallback framing, DOM APIs, or native browser syntax.

## Included

- sealed `Patch` model with exactly one supported `ReplacePatch` operation
- explicit protocol version, patch ID, page epoch, region target, interaction sequence, and contiguous revision step
- opaque selector-free identifier validation and revision overflow protection
- `patchHtml` payloads rendered through the existing context-safe HTML DSL
- redacted patch diagnostics and a canonical test-only JSON golden fixture
- exhaustive fixture serialization so future operations require an explicit mapping
- ABI snapshot, ADR 0023, identity-contract update, and web-first Patch IR guide

## Security contracts

- WOGE-TARGET-001: targets are opaque page-local IDs, never CSS selectors or authorization capabilities
- WOGE-XSS-002: contextual HTML encoding is explicit and separate from the active-content validation required in #20/#21

## Verification

- `./gradlew check`
- negative tests for selectors, revision duplicates/gaps/overflow, and unsupported protocol versions
- deterministic golden fixture for the complete Replace IR

Closes #19
