### PR TITLE
feat(server): add structured deferred regions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Describe a visible update with Patch IR](guides/patch-ir.md)
 - [Encode and decode fallback patch streams](guides/patch-stream-codec.md)
 - [Apply a patch stream in the browser](guides/browser-replace-runtime.md)
+- [Render independent page regions](guides/deferred-regions.md)
 
 ## Performance evidence
 

--- a/docs/adr/0026-structured-deferred-region-execution.md
+++ b/docs/adr/0026-structured-deferred-region-execution.md
@@ -1,0 +1,106 @@
+# ADR 0026: Execute deferred regions as bounded request children
+
+- Status: Accepted
+- Date: 2026-09-04
+- Decision owners: Woge maintainers
+- Related issues: [#22](https://github.com/christian-draeger/woge/issues/22), [#23](https://github.com/christian-draeger/woge/issues/23), [#65](https://github.com/christian-draeger/woge/issues/65), [#122](https://github.com/christian-draeger/woge/issues/122), [#124](https://github.com/christian-draeger/woge/issues/124)
+
+## Context
+
+A Woge page should make its useful shell visible before independent server work such as summaries,
+activity and tables completes. Those tasks may finish in a different order from their declaration,
+time out or fail individually. A browser disconnect, host timeout or application shutdown must still
+cancel all outstanding work.
+
+[ADR 0005](0005-server-host-use-case-ports.md) already assigns request lifetime to the host adapter and
+coroutine children to portable Woge/application work. [ADR 0022](0022-page-host-spi-contract.md)
+defines a cold document flow, while [ADR 0023](0023-minimal-replace-patch-ir.md) defines the visible
+replacement value. The missing boundary is the declaration and execution of independent regions. It
+must not couple application code to Reactor, Servlet async types, Ktor channels or one wire format.
+
+The asynchronous accessibility policy is not settled yet. Automatically adding live-region or busy
+attributes now could create repeated announcements or leave a stable region marked busy after its
+children are replaced.
+
+## Decision
+
+Portable page code declares a `DeferredRegion` in `woge-host-spi`. A declaration contains:
+
+- one explicit `PatchTarget` and initial target revision;
+- ordinary HTML DSL content for the immediate loading fallback;
+- suspending work that returns safe materialized `PatchHtml`;
+- a failure renderer that receives only `TIMED_OUT` or `FAILED`, never the original exception.
+
+Creating or rendering a declaration does not start its suspending work. `regionPlaceholder` writes a
+normal caller-selected HTML element containing the loading markup and the existing
+`data-woge-region` and `data-woge-revision` browser contract. Application classes, ARIA attributes
+and semantics remain ordinary HTML. Woge does not add an announcement or busy-state policy before
+[#120](https://github.com/christian-draeger/woge/issues/120) resolves it.
+
+`woge-server-runtime` provides one cold `DeferredRegionExecutor` flow. On collection it first rejects
+duplicate targets and mixed page epochs. It then launches one child coroutine per declaration under
+the collecting request scope. A semaphore limits active content work; the per-region timeout starts
+after a task obtains that permit, while the host request timeout still bounds queueing and total
+request lifetime. Updates are emitted in completion order rather than declaration order.
+
+The provisional policy allows eight active regions and thirty seconds per active region. Both values
+are configurable for a request/runtime. [#122](https://github.com/christian-draeger/woge/issues/122)
+will either adopt or supersede these defaults as part of the cross-layer resource budget.
+
+Normal content exceptions are isolated to their region. The executor renders controlled replacement
+HTML using only the public failure category and retains the exception separately for adapter-side
+diagnostics. Coroutine cancellation always propagates, including parent timeout and disconnect.
+JVM `Error` values and a failure-renderer exception are fail-stop because continuing after either is
+not a safe partial-recovery policy.
+
+The executor emits `DeferredRegionUpdate.Resolved` or `DeferredRegionUpdate.Failed`, not a
+`ReplacePatch` or encoded bytes. [#23](https://github.com/christian-draeger/woge/issues/23) owns patch
+ID generation, revision transition, framing and shell-plus-patch transport. This keeps scheduling and
+request lifetime independent from protocol encoding.
+
+## Alternatives considered
+
+- **Await regions in declaration order:** rejected because one slow earlier declaration would block a
+  later completed region and defeat the visible out-of-order goal.
+- **Start work in `GlobalScope` or an application executor:** rejected because disconnect, timeout and
+  shutdown cancellation would no longer own all children.
+- **Put patch encoding into the executor:** rejected because scheduling would become coupled to one
+  browser transport and would have to invent patch IDs and revisions.
+- **Pass the original exception to the HTML fallback:** rejected because rendering an exception
+  message makes accidental disclosure of backend details easy.
+- **Cancel every sibling after one region fails:** rejected because regions are declared independent
+  and each has controlled failure content.
+- **Add automatic `aria-live` and `aria-busy`:** deferred because the correct behavior depends on the
+  interaction and document-owned announcement policy, not merely asynchronous execution.
+
+## Consequences
+
+### Positive
+
+- The shell and its semantic loading content are renderable before any deferred work starts.
+- Active work is bounded and emits naturally in completion order.
+- Disconnect and request cancellation use standard structured concurrency without a Woge token.
+- One region failure does not discard unrelated completed content.
+- Application and test code stay independent from Spring, Reactor, Servlet and Ktor types.
+- Patch transport can evolve without changing the region scheduling contract.
+
+### Negative
+
+- The initial fallback and final patch content are separate explicit renderers.
+- Eight workers and thirty seconds are provisional defaults that require production evidence.
+- All declarations create lightweight child coroutines even when they are waiting for a permit.
+- Adapter diagnostics temporarily consume the retained cause directly until the semantic observation
+  port in [#123](https://github.com/christian-draeger/woge/issues/123) exists.
+- No-JavaScript final rendering and shell-plus-patch framing still require the following vertical
+  integration work.
+
+## Follow-up
+
+- Map updates to revisioned Replace patches and stream them after the shell in
+  [#23](https://github.com/christian-draeger/woge/issues/23).
+- Reuse lifecycle tests from the adapter TCK in [#65](https://github.com/christian-draeger/woge/issues/65).
+- Verify WebFlux disconnect and timeout behavior first in [#66](https://github.com/christian-draeger/woge/issues/66),
+  followed by MVC and Ktor parity.
+- Consolidate limits in [#122](https://github.com/christian-draeger/woge/issues/122), semantic events in
+  [#123](https://github.com/christian-draeger/woge/issues/123) and recovery categories in
+  [#124](https://github.com/christian-draeger/woge/issues/124).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0023](0023-minimal-replace-patch-ir.md) | Accepted | Keep Replace Patch IR semantic, explicit and closed |
 | [0024](0024-strict-bounded-patch-stream-codec.md) | Accepted | Validate bounded canonical patch frames before exposure |
 | [0025](0025-browser-replace-runtime-and-lifecycle.md) | Accepted | Apply Replace patches through a page-local DOM registry |
+| [0026](0026-structured-deferred-region-execution.md) | Accepted | Execute deferred regions as bounded request children |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,3 +21,6 @@ events, strict validation and host-adapter lifecycle.
 
 The [browser Replace runtime guide](browser-replace-runtime.md) starts from normal HTML and explains
 page-local regions, streamed application, delegated lifecycle events and safe failure behavior.
+
+The [deferred-region guide](deferred-regions.md) shows ordinary loading HTML, independently completing
+server work, bounded concurrency and request-owned cancellation.

--- a/docs/guides/deferred-regions.md
+++ b/docs/guides/deferred-regions.md
@@ -1,0 +1,92 @@
+# Render independent page regions when their data is ready
+
+A deferred region lets the browser receive useful page HTML while slower server work continues. The
+loading state is ordinary HTML, and the final content uses the same safe HTML writer.
+
+## Declare the region
+
+```kotlin
+val summary = deferredRegion(
+    target = projectSummaryTarget,
+    loading = {
+        element("p") { text("Loading project summary…") }
+    },
+    onFailure = { failure ->
+        patchHtml {
+            element("p") {
+                val message =
+                    if (failure == DeferredRegionFailure.TIMED_OUT) {
+                        "Summary timed out"
+                    } else {
+                        "Summary unavailable"
+                    }
+                text(message)
+            }
+        }
+    },
+    content = {
+        val project = projectRepository.load()
+        patchHtml {
+            element("p") { text("${project.openTasks} open tasks") }
+        }
+    },
+)
+```
+
+`content` is a suspending Kotlin function: it can wait for database or network work without owning a
+thread while it waits. Creating `summary` does not start that work.
+
+The failure renderer receives only a safe category. It cannot accidentally put a database exception
+or request value into the page.
+
+## Put normal fallback HTML in the shell
+
+```kotlin
+htmlPage {
+    element("main") {
+        regionPlaceholder(summary, elementName = "section") {
+            classes("project-summary")
+            aria("label", "Project summary")
+        }
+    }
+}
+```
+
+This initially renders HTML equivalent to:
+
+```html
+<section
+  class="project-summary"
+  aria-label="Project summary"
+  data-woge-region="summary-1"
+  data-woge-revision="0"
+>
+  <p>Loading project summary…</p>
+</section>
+```
+
+The element name, CSS class and accessibility label belong to the application. Woge adds only its
+opaque region ID and revision. The region ID is not a CSS selector and does not grant authorization.
+
+Do not add `aria-live` merely because content is deferred. Whether loading, success or failure should
+be announced depends on the interaction. Woge defines that shared policy before providing a generic
+announcement API.
+
+## Execute inside the request lifetime
+
+The shared server runtime collects declarations with `DeferredRegionExecutor`. Up to eight region
+tasks run at once by default. Each active task has a thirty-second timeout, and applications or host
+configuration can choose tighter values.
+
+Results arrive in completion order. A fast region declared after a slow region can therefore update
+the page first. A timeout or normal application exception becomes the region's controlled failure
+content; it does not cancel unrelated siblings. Cancelling collection cancels active and waiting
+children.
+
+The executor does not encode the HTTP response. The next integration layer assigns patch IDs and
+revisions, then maps each result to the browser patch stream. A no-JavaScript request must never be
+left permanently on loading HTML; the host integration either resolves final content for the normal
+document response or uses a complete normal navigation fallback.
+
+See [ADR 0026](../adr/0026-structured-deferred-region-execution.md) for the lifecycle and ownership
+decision.

--- a/docs/guides/server-host-spi.md
+++ b/docs/guides/server-host-spi.md
@@ -56,6 +56,12 @@ write failures are not converted into partial success.
 Keep each frame meaningful and reasonably bounded. A frame is not a network packet: proxies and TCP
 may split or combine bytes differently.
 
+When sibling page areas complete independently, declare a `DeferredRegion` instead of launching
+detached work or manually forcing declaration order. Its loading markup is part of the normal shell,
+and the shared executor keeps every task inside the collecting request scope. See the
+[deferred-region guide](deferred-regions.md) for the implemented lifecycle and the remaining
+shell-plus-patch integration boundary.
+
 ## Read request facts, then authorize
 
 `RequestContext` contains immutable snapshots such as method, language, request/correlation IDs,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinxCoroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ktlintGradlePlugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlintGradle" }

--- a/modules/woge-host-spi/api/woge-host-spi.api
+++ b/modules/woge-host-spi/api/woge-host-spi.api
@@ -168,6 +168,29 @@ public final class dev/woge/host/CsrfVerification : java/lang/Enum {
 	public static fun values ()[Ldev/woge/host/CsrfVerification;
 }
 
+public final class dev/woge/host/DeferredRegion {
+	public final fun getInitialRevision-UimE8lE ()J
+	public final fun getTarget ()Ldev/woge/protocol/PatchTarget;
+	public final fun renderContent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun renderFailure (Ldev/woge/host/DeferredRegionFailure;)Ldev/woge/protocol/PatchHtml;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/host/DeferredRegionFailure : java/lang/Enum {
+	public static final field FAILED Ldev/woge/host/DeferredRegionFailure;
+	public static final field TIMED_OUT Ldev/woge/host/DeferredRegionFailure;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/woge/host/DeferredRegionFailure;
+	public static fun values ()[Ldev/woge/host/DeferredRegionFailure;
+}
+
+public final class dev/woge/host/DeferredRegionKt {
+	public static final fun deferredRegion-IloEfL4 (Ldev/woge/protocol/PatchTarget;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/woge/host/DeferredRegion;
+	public static synthetic fun deferredRegion-IloEfL4$default (Ldev/woge/protocol/PatchTarget;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/woge/host/DeferredRegion;
+	public static final fun regionPlaceholder (Ldev/woge/html/HtmlWriter;Ldev/woge/host/DeferredRegion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun regionPlaceholder$default (Ldev/woge/html/HtmlWriter;Ldev/woge/host/DeferredRegion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
 public final class dev/woge/host/ExternalRedirectLocation : dev/woge/host/RedirectLocation {
 	public final fun getUrl-k-WF5Ao ()Ljava/lang/String;
 	public fun getValue ()Ljava/lang/String;

--- a/modules/woge-host-spi/src/main/kotlin/dev/woge/host/DeferredRegion.kt
+++ b/modules/woge-host-spi/src/main/kotlin/dev/woge/host/DeferredRegion.kt
@@ -1,0 +1,72 @@
+package dev.woge.host
+
+import dev.woge.html.Attributes
+import dev.woge.html.HtmlWriter
+import dev.woge.protocol.PatchHtml
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.TargetRevision
+
+/** Safe failure categories available while rendering a deferred region fallback. */
+public enum class DeferredRegionFailure {
+    TIMED_OUT,
+    FAILED,
+}
+
+/**
+ * One independently resolved region declared by portable page code.
+ *
+ * The loading content is ordinary server-rendered HTML. Deferred work starts only when the server
+ * runtime collects the region execution flow.
+ */
+public class DeferredRegion internal constructor(
+    public val target: PatchTarget,
+    public val initialRevision: TargetRevision,
+    private val loading: HtmlWriter.() -> Unit,
+    private val failure: (DeferredRegionFailure) -> PatchHtml,
+    private val content: suspend () -> PatchHtml,
+) {
+    /** Resolves the successful region content inside the current request coroutine. */
+    public suspend fun renderContent(): PatchHtml = content()
+
+    /** Renders client-safe replacement content for one controlled failure category. */
+    public fun renderFailure(failure: DeferredRegionFailure): PatchHtml = this.failure(failure)
+
+    internal fun renderLoading(writer: HtmlWriter) {
+        loading(writer)
+    }
+
+    override fun toString(): String =
+        "DeferredRegion(target=$target, initialRevision=${initialRevision.value}, renderers=<redacted>)"
+}
+
+/** Declares one deferred region without starting its [content] work. */
+public fun deferredRegion(
+    target: PatchTarget,
+    initialRevision: TargetRevision = TargetRevision.INITIAL,
+    loading: HtmlWriter.() -> Unit,
+    onFailure: (DeferredRegionFailure) -> PatchHtml,
+    content: suspend () -> PatchHtml,
+): DeferredRegion = DeferredRegion(target, initialRevision, loading, onFailure, content)
+
+/**
+ * Writes the stable region element and its useful loading fallback into the initial page shell.
+ *
+ * The caller chooses a normal HTML element and may add ordinary attributes. Woge reserves only the
+ * region and revision data attributes required by the fallback browser runtime.
+ */
+public fun HtmlWriter.regionPlaceholder(
+    region: DeferredRegion,
+    elementName: String = "div",
+    attributes: Attributes.() -> Unit = {},
+) {
+    element(
+        elementName,
+        attributes = {
+            data("woge-region", region.target.region.value)
+            data("woge-revision", region.initialRevision.value.toString())
+            attributes()
+        },
+    ) {
+        region.renderLoading(this)
+    }
+}

--- a/modules/woge-host-spi/src/test/kotlin/dev/woge/host/DeferredRegionTest.kt
+++ b/modules/woge-host-spi/src/test/kotlin/dev/woge/host/DeferredRegionTest.kt
@@ -1,0 +1,49 @@
+package dev.woge.host
+
+import dev.woge.html.renderHtml
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.patchHtml
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class DeferredRegionTest {
+    @Test
+    fun `placeholder renders ordinary loading HTML without starting deferred work`() {
+        var contentStarted = false
+        val target =
+            PatchTarget(
+                pageEpoch = PageEpoch.of("page-1"),
+                region = RegionTargetId.of("summary-1"),
+            )
+        val region =
+            deferredRegion(
+                target = target,
+                loading = { element("p") { text("Loading projects…") } },
+                onFailure = { patchHtml { element("p") { text("Projects are unavailable") } } },
+                content = {
+                    contentStarted = true
+                    patchHtml { element("p") { text("3 open projects") } }
+                },
+            )
+
+        val html =
+            renderHtml {
+                regionPlaceholder(region, elementName = "section") {
+                    classes("project-summary")
+                    aria("label", "Project summary")
+                }
+            }
+
+        assertEquals(
+            "<section data-woge-region=\"summary-1\" data-woge-revision=\"0\" " +
+                "class=\"project-summary\" aria-label=\"Project summary\">" +
+                "<p>Loading projects…</p></section>",
+            html,
+        )
+        assertEquals(target, region.target)
+        assertFalse(contentStarted)
+    }
+}

--- a/modules/woge-server-runtime/build.gradle.kts
+++ b/modules/woge-server-runtime/build.gradle.kts
@@ -8,4 +8,9 @@ dependencies {
     implementation(project(":woge-core"))
     implementation(project(":woge-protocol"))
     implementation(project(":woge-host-spi"))
+    implementation(libs.kotlinxCoroutinesCore)
+
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.kotlinxCoroutinesTest)
+    testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/DeferredRegionExecutor.kt
+++ b/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/DeferredRegionExecutor.kt
@@ -1,0 +1,113 @@
+package dev.woge.runtime
+
+import dev.woge.host.DeferredRegion
+import dev.woge.host.DeferredRegionFailure
+import dev.woge.protocol.PatchHtml
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Request-scoped concurrency and per-region timeout policy. */
+public data class DeferredRegionPolicy(
+    public val maxConcurrency: Int = DEFAULT_MAX_CONCURRENCY,
+    public val regionTimeout: Duration = DEFAULT_REGION_TIMEOUT,
+) {
+    init {
+        require(maxConcurrency > 0) { "Deferred region concurrency must be positive" }
+        require(regionTimeout.isFinite() && regionTimeout > Duration.ZERO) {
+            "Deferred region timeout must be positive and finite"
+        }
+    }
+
+    public companion object {
+        public const val DEFAULT_MAX_CONCURRENCY: Int = 8
+        public val DEFAULT_REGION_TIMEOUT: Duration = 30.seconds
+    }
+}
+
+/** One rendered region update, ready for a transport-specific patch mapper. */
+public sealed interface DeferredRegionUpdate {
+    public val region: DeferredRegion
+    public val html: PatchHtml
+
+    /** The deferred content completed normally. */
+    public class Resolved(
+        override val region: DeferredRegion,
+        override val html: PatchHtml,
+    ) : DeferredRegionUpdate
+
+    /** Deferred work failed, but the region supplied controlled replacement content. */
+    public class Failed(
+        override val region: DeferredRegion,
+        public val failure: DeferredRegionFailure,
+        override val html: PatchHtml,
+        public val cause: Exception?,
+    ) : DeferredRegionUpdate
+}
+
+/** Runs deferred regions as children of the collecting request scope. */
+public class DeferredRegionExecutor(
+    public val policy: DeferredRegionPolicy = DeferredRegionPolicy(),
+) {
+    /**
+     * Returns a cold flow that emits updates in completion order.
+     *
+     * Cancelling collection cancels active and waiting region children. A content failure is
+     * isolated to its region; failure-fallback rendering itself remains fail-stop.
+     */
+    public fun execute(regions: Iterable<DeferredRegion>): Flow<DeferredRegionUpdate> =
+        channelFlow {
+            val declaredRegions = regions.toList()
+            validateRegionSet(declaredRegions)
+            val concurrency = Semaphore(policy.maxConcurrency)
+
+            declaredRegions.forEach { region ->
+                launch {
+                    concurrency.withPermit {
+                        send(resolve(region))
+                    }
+                }
+            }
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun resolve(region: DeferredRegion): DeferredRegionUpdate =
+        try {
+            val content = withTimeoutOrNull(policy.regionTimeout) { region.renderContent() }
+            if (content == null) {
+                failed(region, DeferredRegionFailure.TIMED_OUT, cause = null)
+            } else {
+                DeferredRegionUpdate.Resolved(region, content)
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (cause: Exception) {
+            failed(region, DeferredRegionFailure.FAILED, cause)
+        }
+
+    private fun failed(
+        region: DeferredRegion,
+        failure: DeferredRegionFailure,
+        cause: Exception?,
+    ): DeferredRegionUpdate.Failed =
+        DeferredRegionUpdate.Failed(
+            region = region,
+            failure = failure,
+            html = region.renderFailure(failure),
+            cause = cause,
+        )
+}
+
+private fun validateRegionSet(regions: List<DeferredRegion>) {
+    val targets = regions.map { it.target }
+    require(targets.distinct().size == targets.size) { "Deferred region targets must be unique" }
+    require(targets.map { it.pageEpoch }.distinct().size <= 1) {
+        "Deferred regions in one execution must belong to the same page epoch"
+    }
+}

--- a/modules/woge-server-runtime/src/test/kotlin/dev/woge/runtime/DeferredRegionExecutorTest.kt
+++ b/modules/woge-server-runtime/src/test/kotlin/dev/woge/runtime/DeferredRegionExecutorTest.kt
@@ -1,0 +1,243 @@
+package dev.woge.runtime
+
+import dev.woge.host.DeferredRegion
+import dev.woge.host.DeferredRegionFailure
+import dev.woge.host.deferredRegion
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchHtml
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.patchHtml
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeferredRegionExecutorTest {
+    @Test
+    fun `completed regions are emitted in completion order`() =
+        runTest {
+            val slowContent = CompletableDeferred<PatchHtml>()
+            val fastContent = CompletableDeferred<PatchHtml>()
+            val collection =
+                async {
+                    DeferredRegionExecutor()
+                        .execute(
+                            listOf(
+                                region("slow") { slowContent.await() },
+                                region("fast") { fastContent.await() },
+                            ),
+                        ).toList()
+                }
+
+            runCurrent()
+            fastContent.complete(html("fast result"))
+            runCurrent()
+            slowContent.complete(html("slow result"))
+
+            val updates = collection.await()
+            assertEquals(listOf("fast", "slow"), updates.map { it.region.target.region.value })
+            assertEquals(listOf("fast result", "slow result"), updates.map { it.html.textContent() })
+            assertTrue(updates.all { it is DeferredRegionUpdate.Resolved })
+        }
+
+    @Test
+    fun `configured concurrency bounds active region work`() =
+        runTest {
+            val active = AtomicInteger()
+            val maximumActive = AtomicInteger()
+            val release = CompletableDeferred<Unit>()
+            val regions =
+                (1..4).map { index ->
+                    region("region-$index") {
+                        val activeNow = active.incrementAndGet()
+                        maximumActive.updateAndGet { current -> maxOf(current, activeNow) }
+                        try {
+                            release.await()
+                            html("region $index")
+                        } finally {
+                            active.decrementAndGet()
+                        }
+                    }
+                }
+            val collection =
+                async {
+                    DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency = 2)).execute(regions).toList()
+                }
+
+            runCurrent()
+            assertEquals(2, maximumActive.get())
+            release.complete(Unit)
+
+            assertEquals(4, collection.await().size)
+            assertEquals(2, maximumActive.get())
+        }
+
+    @Test
+    fun `timeout emits controlled failure content without cancelling siblings`() =
+        runTest {
+            val updates =
+                DeferredRegionExecutor(DeferredRegionPolicy(regionTimeout = 1.seconds))
+                    .execute(
+                        listOf(
+                            region("waiting") {
+                                awaitCancellation()
+                            },
+                            region("ready") { html("ready") },
+                        ),
+                    ).toList()
+
+            val failed = updates.filterIsInstance<DeferredRegionUpdate.Failed>().single()
+            assertEquals(DeferredRegionFailure.TIMED_OUT, failed.failure)
+            assertEquals("timed out", failed.html.textContent())
+            assertEquals(
+                "ready",
+                updates
+                    .filterIsInstance<DeferredRegionUpdate.Resolved>()
+                    .single()
+                    .html
+                    .textContent(),
+            )
+        }
+
+    @Test
+    fun `application failure is isolated and retains its cause for host diagnostics`() =
+        runTest {
+            val cause = IllegalStateException("database detail must not enter fallback HTML")
+            val updates =
+                DeferredRegionExecutor()
+                    .execute(
+                        listOf(
+                            region("failed") { throw cause },
+                            region("ready") { html("ready") },
+                        ),
+                    ).toList()
+
+            val failed = updates.filterIsInstance<DeferredRegionUpdate.Failed>().single()
+            assertEquals(DeferredRegionFailure.FAILED, failed.failure)
+            assertEquals(cause::class, failed.cause?.let { it::class })
+            assertEquals(cause.message, failed.cause?.message)
+            assertEquals("failed", failed.html.textContent())
+            assertFalse(failed.html.value.contains(cause.message.orEmpty()))
+            assertEquals(1, updates.count { it is DeferredRegionUpdate.Resolved })
+        }
+
+    @Test
+    fun `failure renderer exceptions stop the execution`() {
+        val fallbackFailure = IllegalArgumentException("invalid fallback")
+        val region =
+            deferredRegion(
+                target = PatchTarget(PageEpoch.of("page-1"), RegionTargetId.of("failed")),
+                loading = { text("loading") },
+                onFailure = { throw fallbackFailure },
+                content = { throw IllegalStateException("content failed") },
+            )
+
+        val thrown =
+            assertThrows(IllegalArgumentException::class.java) {
+                runBlocking { DeferredRegionExecutor().execute(listOf(region)).toList() }
+            }
+
+        assertEquals(fallbackFailure.message, thrown.message)
+    }
+
+    @Test
+    fun `collector cancellation cancels active region children`() =
+        runTest {
+            val started = CompletableDeferred<Unit>()
+            val cancelled = CompletableDeferred<Unit>()
+            val collector =
+                launch {
+                    DeferredRegionExecutor()
+                        .execute(
+                            listOf(
+                                region("waiting") {
+                                    started.complete(Unit)
+                                    try {
+                                        awaitCancellation()
+                                    } finally {
+                                        cancelled.complete(Unit)
+                                    }
+                                },
+                            ),
+                        ).toList()
+                }
+
+            started.await()
+            collector.cancelAndJoin()
+
+            assertTrue(cancelled.isCompleted)
+        }
+
+    @Test
+    fun `one execution rejects duplicate targets and mixed page epochs before work starts`() {
+        var started = false
+        val first =
+            region("summary") {
+                started = true
+                html("first")
+            }
+        val duplicate =
+            region("summary") {
+                started = true
+                html("duplicate")
+            }
+        val otherPage =
+            region("other", pageEpoch = "page-2") {
+                started = true
+                html("other")
+            }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { DeferredRegionExecutor().execute(listOf(first, duplicate)).toList() }
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { DeferredRegionExecutor().execute(listOf(first, otherPage)).toList() }
+        }
+        assertFalse(started)
+    }
+
+    @Test
+    fun `policy requires usable concurrency and timeout limits`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DeferredRegionPolicy(maxConcurrency = 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DeferredRegionPolicy(regionTimeout = Duration.ZERO)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DeferredRegionPolicy(regionTimeout = Duration.INFINITE)
+        }
+    }
+}
+
+private fun region(
+    id: String,
+    pageEpoch: String = "page-1",
+    content: suspend () -> PatchHtml,
+): DeferredRegion =
+    deferredRegion(
+        target = PatchTarget(PageEpoch.of(pageEpoch), RegionTargetId.of(id)),
+        loading = { element("p") { text("loading") } },
+        onFailure = { failure -> html(if (failure == DeferredRegionFailure.TIMED_OUT) "timed out" else "failed") },
+        content = content,
+    )
+
+private fun html(text: String): PatchHtml = patchHtml { element("p") { text(text) } }
+
+private fun PatchHtml.textContent(): String = value.removePrefix("<p>").removeSuffix("</p>")


### PR DESCRIPTION
## Summary

- add a host-neutral deferred-region declaration with ordinary loading HTML
- run region work as bounded children of the collecting request scope
- emit successful or controlled failure updates in completion order
- preserve cancellation while isolating normal region failures
- record the lifecycle and transport boundary in ADR 0026
- add a web-first guide and public ABI baseline

Patch IDs, revision transitions and shell-plus-patch framing remain explicitly owned by #23.

## Verification

- `./gradlew check`
- deterministic coroutine tests cover out-of-order completion, concurrency limits, virtual timeout, failure isolation, fail-stop fallback rendering and collection cancellation

Closes #22