### PR TITLE
Add the Spring WebFlux streaming adapter

### DIFF
--- a/adapters/woge-spring-webflux/README.md
+++ b/adapters/woge-spring-webflux/README.md
@@ -1,0 +1,7 @@
+# Woge Spring WebFlux adapter
+
+This module maps framework-neutral Woge page and deferred-region use cases to Spring WebFlux
+functional handlers. Reactor and response-lifecycle details remain inside the adapter.
+
+Start with [Run a Woge page with Spring WebFlux](../../docs/guides/spring-webflux-adapter.md). The
+Spring Boot starter and complete executable reference application are the next M1a slices.

--- a/adapters/woge-spring-webflux/api/woge-spring-webflux.api
+++ b/adapters/woge-spring-webflux/api/woge-spring-webflux.api
@@ -1,0 +1,25 @@
+public final class dev/woge/spring/webflux/DefaultWebFluxRequestContextFactory : dev/woge/spring/webflux/WebFluxRequestContextFactory {
+	public static final field INSTANCE Ldev/woge/spring/webflux/DefaultWebFluxRequestContextFactory;
+	public fun create (Lorg/springframework/web/reactive/function/server/ServerRequest;)Ldev/woge/host/RequestContext;
+}
+
+public abstract interface class dev/woge/spring/webflux/WebFluxPageInput {
+	public abstract fun decode (Lorg/springframework/web/reactive/function/server/ServerRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/woge/spring/webflux/WebFluxRequestContextFactory {
+	public abstract fun create (Lorg/springframework/web/reactive/function/server/ServerRequest;)Ldev/woge/host/RequestContext;
+}
+
+public final class dev/woge/spring/webflux/WogeWebFluxDeferredHandler {
+	public synthetic fun <init> (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun handle (Lorg/springframework/web/reactive/function/server/ServerRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/woge/spring/webflux/WogeWebFluxPageHandler {
+	public fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;)V
+	public synthetic fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun handle (Lorg/springframework/web/reactive/function/server/ServerRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/adapters/woge-spring-webflux/build.gradle.kts
+++ b/adapters/woge-spring-webflux/build.gradle.kts
@@ -1,12 +1,32 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     id("dev.woge.kotlin-jvm-library")
 }
 
 description = "Spring WebFlux transport adapter for Woge."
 
+kotlin {
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation()
+}
+
 dependencies {
+    api(platform(libs.springBootDependencies))
     api(project(":woge-core"))
     api(project(":woge-protocol"))
     api(project(":woge-host-spi"))
+    api(libs.springWebflux)
+
     implementation(project(":woge-server-runtime"))
+    implementation(libs.kotlinxCoroutinesReactor)
+
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.reactorNettyHttp)
+    testImplementation(libs.springContext)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("checkKotlinAbi"))
 }

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxPageInput.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxPageInput.kt
@@ -1,0 +1,8 @@
+package dev.woge.spring.webflux
+
+import org.springframework.web.reactive.function.server.ServerRequest
+
+/** Decodes route-specific page input at the WebFlux adapter boundary. */
+public fun interface WebFluxPageInput<Input : Any> {
+    public suspend fun decode(request: ServerRequest): Input
+}

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxRequestContextFactory.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxRequestContextFactory.kt
@@ -1,0 +1,80 @@
+package dev.woge.spring.webflux
+
+import dev.woge.host.CorrelationId
+import dev.woge.host.HttpHeader
+import dev.woge.host.LanguageTag
+import dev.woge.host.RequestContext
+import dev.woge.host.RequestCookies
+import dev.woge.host.RequestHeaders
+import dev.woge.host.RequestId
+import dev.woge.host.RequestMethod
+import dev.woge.host.RequestTrace
+import dev.woge.host.httpHeader
+import dev.woge.host.requestCookie
+import org.springframework.web.reactive.function.server.ServerRequest
+import java.util.Locale
+import java.util.UUID
+
+/** Maps adapter-owned WebFlux request state to an immutable Woge request snapshot. */
+public fun interface WebFluxRequestContextFactory {
+    public fun create(request: ServerRequest): RequestContext
+}
+
+/**
+ * Safe default context mapping for GET, HEAD and OPTIONS page endpoints.
+ *
+ * It creates request-local trace IDs, copies non-sensitive headers and parsed cookies, and marks the
+ * caller anonymous. Applications using authentication or unsafe methods must install a factory that
+ * translates their Spring Security and CSRF decisions explicitly.
+ */
+public object DefaultWebFluxRequestContextFactory : WebFluxRequestContextFactory {
+    override fun create(request: ServerRequest): RequestContext {
+        val method = RequestMethod.of(request.method().name())
+        require(method in SAFE_METHODS) {
+            "The default WebFlux context supports safe page methods only; install an explicit security context factory"
+        }
+        val traceValue = UUID.randomUUID().toString()
+        val headers =
+            buildList<HttpHeader> {
+                request.headers().asHttpHeaders().forEach { name, values ->
+                    if (name.lowercase(Locale.ROOT) !in SENSITIVE_REQUEST_HEADERS) {
+                        values.forEach { value -> add(httpHeader(name, value)) }
+                    }
+                }
+            }
+        val cookies =
+            request.cookies().values.flatten().map { cookie ->
+                requestCookie(cookie.name, cookie.value)
+            }
+        val language =
+            request
+                .headers()
+                .acceptLanguage()
+                .firstOrNull()
+                ?.range
+                .orEmpty()
+
+        return RequestContext(
+            method = method,
+            trace = RequestTrace(RequestId.of(traceValue), CorrelationId.of(traceValue)),
+            language =
+                if (language.isEmpty() || language == "*") {
+                    LanguageTag.UNDETERMINED
+                } else {
+                    LanguageTag.of(language)
+                },
+            headers = RequestHeaders.of(headers),
+            cookies = RequestCookies.of(cookies),
+        )
+    }
+}
+
+private val SAFE_METHODS: Set<RequestMethod> = setOf(RequestMethod.GET, RequestMethod.HEAD, RequestMethod.OPTIONS)
+private val SENSITIVE_REQUEST_HEADERS: Set<String> =
+    setOf(
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+        "x-csrf-token",
+        "x-xsrf-token",
+    )

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxResponses.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxResponses.kt
@@ -1,0 +1,121 @@
+package dev.woge.spring.webflux
+
+import dev.woge.host.PageResult
+import dev.woge.host.ResponseCookie
+import dev.woge.host.ResponseMetadata
+import dev.woge.host.SameSite
+import dev.woge.html.DEFAULT_HTML_CHUNK_CHARS
+import dev.woge.html.HtmlSink
+import dev.woge.html.StreamingHtmlSink
+import dev.woge.protocol.HtmlFrame
+import dev.woge.protocol.PatchStreamV1
+import dev.woge.runtime.EncodedPatchChunk
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.reactive.asPublisher
+import kotlinx.coroutines.reactor.awaitSingle
+import org.reactivestreams.Publisher
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.web.reactive.function.BodyInserter
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Flux
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.time.Duration as JavaDuration
+import org.springframework.http.ResponseCookie as SpringResponseCookie
+
+internal suspend fun PageResult.toWebFluxResponse(): ServerResponse =
+    when (this) {
+        is PageResult.Document ->
+            responseBuilder(metadata)
+                .body(documentBody(this))
+                .awaitSingle()
+
+        is PageResult.Redirect ->
+            responseBuilder(metadata)
+                .location(URI.create(location.value))
+                .build()
+                .awaitSingle()
+
+        is PageResult.Failure ->
+            responseBuilder(metadata)
+                .build()
+                .awaitSingle()
+    }
+
+internal suspend fun Flow<EncodedPatchChunk>.toWebFluxPatchResponse(): ServerResponse =
+    ServerResponse
+        .ok()
+        .contentType(MediaType.parseMediaType(PatchStreamV1.MEDIA_TYPE))
+        .header("Cache-Control", "no-store")
+        .body(patchBody(this))
+        .awaitSingle()
+
+private fun responseBuilder(metadata: ResponseMetadata): ServerResponse.BodyBuilder {
+    val builder = ServerResponse.status(HttpStatusCode.valueOf(metadata.status.code))
+    metadata.contentType?.let { builder.contentType(MediaType.parseMediaType(it.value)) }
+    metadata.headers.forEach { header -> builder.header(header.name.value, header.value.value) }
+    metadata.cookies.forEach { cookie -> builder.cookie(cookie.toSpringCookie()) }
+    return builder
+}
+
+private fun ResponseCookie.toSpringCookie(): SpringResponseCookie {
+    val builder =
+        SpringResponseCookie
+            .from(name.value, value.value)
+            .path(path.value)
+            .secure(secure)
+            .httpOnly(httpOnly)
+            .sameSite(sameSite.httpValue)
+    maxAgeSeconds?.let { builder.maxAge(JavaDuration.ofSeconds(it)) }
+    return builder.build()
+}
+
+private val SameSite.httpValue: String
+    get() = name.lowercase().replaceFirstChar(Char::uppercase)
+
+private fun documentBody(document: PageResult.Document): BodyInserter<Unit, ServerHttpResponse> =
+    flushingBody { response -> document.flushGroups(response) }
+
+private fun patchBody(chunks: Flow<EncodedPatchChunk>): BodyInserter<Unit, ServerHttpResponse> =
+    flushingBody { response ->
+        chunks
+            .map { chunk -> Flux.just(response.bufferFactory().wrap(chunk.bytes)) }
+            .asPublisher()
+    }
+
+private fun flushingBody(
+    groups: (ServerHttpResponse) -> Publisher<out Publisher<out DataBuffer>>,
+): BodyInserter<Unit, ServerHttpResponse> = BodyInserter { response, _ -> response.writeAndFlushWith(groups(response)) }
+
+private fun PageResult.Document.flushGroups(response: ServerHttpResponse): Publisher<out Publisher<out DataBuffer>> =
+    frames
+        .map { frame ->
+            Flux
+                .fromIterable(frame.renderChunks())
+                .map { bytes -> response.bufferFactory().wrap(bytes) }
+        }.asPublisher()
+
+private suspend fun HtmlFrame.renderChunks(): List<ByteArray> {
+    val context = currentCoroutineContext()
+    val chunks = mutableListOf<ByteArray>()
+    val sink =
+        StreamingHtmlSink(
+            downstream =
+                HtmlSink { value ->
+                    context.ensureActive()
+                    chunks += value.toByteArray(StandardCharsets.UTF_8)
+                },
+            maxChunkChars = DEFAULT_HTML_CHUNK_CHARS,
+        )
+    context.ensureActive()
+    writeTo(sink)
+    context.ensureActive()
+    sink.flush()
+    return chunks
+}

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxDeferredHandler.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxDeferredHandler.kt
@@ -1,0 +1,36 @@
+package dev.woge.spring.webflux
+
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageRequest
+import dev.woge.protocol.PatchId
+import dev.woge.runtime.DeferredRegionExecutor
+import dev.woge.runtime.DeferredRegionPolicy
+import dev.woge.runtime.encodeDeferredPatchStream
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Executes page-scoped deferred work and streams patches through a WebFlux functional route. */
+public class WogeWebFluxDeferredHandler<Input : Any>(
+    private val regions: DeferredRegionsUseCase<Input>,
+    private val input: WebFluxPageInput<Input>,
+    private val contexts: WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory,
+    maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
+    regionTimeout: Duration = 30.seconds,
+) {
+    private val executor = DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency, regionTimeout))
+
+    /** Re-authorizes the request before returning an incrementally flushed patch response. */
+    public suspend fun handle(request: ServerRequest): ServerResponse {
+        val pageRequest = PageRequest(input.decode(request), contexts.create(request))
+        val declaredRegions = regions.regions(pageRequest).toList()
+        var patchNumber = 0
+        val chunks =
+            executor.execute(declaredRegions).encodeDeferredPatchStream {
+                patchNumber += 1
+                PatchId.of("deferred-$patchNumber")
+            }
+        return chunks.toWebFluxPatchResponse()
+    }
+}

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxPageHandler.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxPageHandler.kt
@@ -1,0 +1,19 @@
+package dev.woge.spring.webflux
+
+import dev.woge.host.PageRequest
+import dev.woge.host.PageUseCase
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+
+/** Executes one portable [PageUseCase] from a WebFlux functional route. */
+public class WogeWebFluxPageHandler<Input : Any>(
+    private val page: PageUseCase<Input>,
+    private val input: WebFluxPageInput<Input>,
+    private val contexts: WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory,
+) {
+    /** Decodes, executes and maps the page without an application-owned controller. */
+    public suspend fun handle(request: ServerRequest): ServerResponse {
+        val pageRequest = PageRequest(input.decode(request), contexts.create(request))
+        return page.open(pageRequest).toWebFluxResponse()
+    }
+}

--- a/adapters/woge-spring-webflux/src/test/kotlin/dev/woge/spring/webflux/WogeWebFluxAdapterTest.kt
+++ b/adapters/woge-spring-webflux/src/test/kotlin/dev/woge/spring/webflux/WogeWebFluxAdapterTest.kt
@@ -1,0 +1,363 @@
+package dev.woge.spring.webflux
+
+import dev.woge.host.DeferredRegion
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.FailureCategory
+import dev.woge.host.HeaderName
+import dev.woge.host.PageRequest
+import dev.woge.host.PageResult
+import dev.woge.host.PageUseCase
+import dev.woge.host.RequestContext
+import dev.woge.host.RequestMethod
+import dev.woge.host.ResponseHeaders
+import dev.woge.host.ResponseMetadata
+import dev.woge.host.ResponseStatus
+import dev.woge.host.deferredRegion
+import dev.woge.host.failure
+import dev.woge.host.htmlPage
+import dev.woge.host.httpHeader
+import dev.woge.host.redirect
+import dev.woge.host.responseCookie
+import dev.woge.host.streamingHtmlPage
+import dev.woge.html.applicationUrl
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchStreamEvent
+import dev.woge.protocol.PatchStreamV1
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.htmlFrame
+import dev.woge.protocol.patchHtml
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.server.ResponseStatusException
+import reactor.netty.DisposableServer
+import reactor.netty.http.server.HttpServer
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import kotlin.time.Duration.Companion.seconds
+
+class WogeWebFluxAdapterTest {
+    @Test
+    fun `one shared application object backs both HTML and patch routes`() =
+        runBlocking {
+            val application = SharedProjectPage()
+            val input = WebFluxPageInput<String> { it.pathVariable("project") }
+            val pageHandler = WogeWebFluxPageHandler(application, input)
+            val deferredHandler = WogeWebFluxDeferredHandler(application, input)
+            val routes =
+                coRouter {
+                    GET("/projects/{project}", pageHandler::handle)
+                    GET("/projects/{project}/patches", deferredHandler::handle)
+                }
+
+            TestWebFluxServer(routes).use { server ->
+                assertEquals("<h1>Project woge</h1>", server.text("/projects/woge").body())
+
+                val stream = server.open("/projects/woge/patches").body().readAllBytes()
+                val events = PatchStreamV1.decoder().let { decoder -> decoder.feed(stream).also { decoder.finish() } }
+                val patch = events.filterIsInstance<PatchStreamEvent.PatchFrame>().single().patch
+                assertEquals("summary", patch.target.region.value)
+            }
+        }
+
+    @Test
+    fun `page handler flushes frames and maps request plus response metadata on a real server`() =
+        runBlocking {
+            val releaseSecondFrame = CompletableDeferred<Unit>()
+            val capturedRequest = CompletableDeferred<PageRequest<String>>()
+            val page =
+                PageUseCase<String> { request ->
+                    capturedRequest.complete(request)
+                    streamingHtmlPage(
+                        frames =
+                            flow {
+                                emit(htmlFrame { element("main") { text("Shell for ${request.input}") } })
+                                releaseSecondFrame.await()
+                                emit(htmlFrame { element("footer") { text("Deferred document frame") } })
+                            },
+                        metadata =
+                            ResponseMetadata(
+                                status = ResponseStatus.of(202),
+                                headers = ResponseHeaders.of(httpHeader("x-woge-test", "mapped")),
+                                cookies = listOf(responseCookie("woge-session", "safe")),
+                            ),
+                    )
+                }
+            val handler = WogeWebFluxPageHandler(page, WebFluxPageInput { it.pathVariable("project") })
+
+            TestWebFluxServer(coRouter { GET("/projects/{project}", handler::handle) }).use { server ->
+                val response =
+                    server.open(
+                        "/projects/woge",
+                        mapOf(
+                            "Accept-Language" to "de-DE,de;q=0.8",
+                            "Authorization" to "Bearer not-portable",
+                            "Cookie" to "theme=dark",
+                            "X-Visible" to "yes",
+                        ),
+                    )
+                assertPageMetadata(response)
+
+                val first = response.body().readThrough("</main>".toByteArray())
+                assertEquals("<main>Shell for woge</main>", first.toString(StandardCharsets.UTF_8))
+                assertFalse(releaseSecondFrame.isCompleted)
+
+                assertMappedContext(capturedRequest.await().context)
+
+                releaseSecondFrame.complete(Unit)
+                val rest = response.body().readAllBytes().toString(StandardCharsets.UTF_8)
+                assertEquals("<footer>Deferred document frame</footer>", rest)
+            }
+        }
+
+    @Test
+    fun `redirect controlled failure and pre-stream host error preserve status contracts`() =
+        runBlocking {
+            val input = WebFluxPageInput<Unit> { _ -> }
+            val redirectHandler =
+                WogeWebFluxPageHandler(
+                    PageUseCase<Unit> { redirect(applicationUrl("/target")) },
+                    input,
+                )
+            val failureHandler =
+                WogeWebFluxPageHandler(
+                    PageUseCase<Unit> { request -> failure(FailureCategory.NOT_FOUND, request.context.correlationId) },
+                    input,
+                )
+            val errorHandler =
+                WogeWebFluxPageHandler(
+                    PageUseCase<Unit> { throw ResponseStatusException(HttpStatus.BAD_GATEWAY) },
+                    input,
+                )
+            val routes =
+                coRouter {
+                    GET("/redirect", redirectHandler::handle)
+                    GET("/missing", failureHandler::handle)
+                    GET("/error", errorHandler::handle)
+                }
+
+            TestWebFluxServer(routes).use { server ->
+                val redirect = server.text("/redirect")
+                assertEquals(303, redirect.statusCode())
+                assertEquals("/target", redirect.headers().firstValue("location").orElseThrow())
+                assertEquals("", redirect.body())
+
+                val missing = server.text("/missing")
+                assertEquals(404, missing.statusCode())
+                assertEquals("", missing.body())
+                assertTrue(missing.headers().firstValue("content-type").isEmpty)
+
+                val error = server.text("/error")
+                assertEquals(502, error.statusCode())
+            }
+        }
+
+    @Test
+    fun `deferred handler flushes a fast patch while a slow sibling is still pending`() =
+        runBlocking {
+            val slow = CompletableDeferred<dev.woge.protocol.PatchHtml>()
+            val regions =
+                DeferredRegionsUseCase<String> { request ->
+                    listOf(
+                        region("slow") { slow.await() },
+                        region("fast") { patch("Fast result for ${request.input}") },
+                    )
+                }
+            val handler =
+                WogeWebFluxDeferredHandler(
+                    regions = regions,
+                    input = WebFluxPageInput { it.pathVariable("project") },
+                )
+
+            TestWebFluxServer(coRouter { GET("/projects/{project}/patches", handler::handle) }).use { server ->
+                val response = server.open("/projects/woge/patches")
+                assertEquals(200, response.statusCode())
+                assertTrue(
+                    response
+                        .headers()
+                        .firstValue("content-type")
+                        .orElseThrow()
+                        .startsWith("application/vnd.woge.patch-stream"),
+                )
+                assertEquals("no-store", response.headers().firstValue("cache-control").orElseThrow())
+
+                val first = response.body().readThrough("Fast result for woge".toByteArray())
+                assertFalse(first.toString(StandardCharsets.UTF_8).contains("Slow result"))
+                assertFalse(slow.isCompleted)
+
+                slow.complete(patch("Slow result"))
+                val all = first + response.body().readAllBytes()
+                val decoder = PatchStreamV1.decoder()
+                val events = decoder.feed(all)
+                decoder.finish()
+                assertEquals(
+                    listOf("fast", "slow"),
+                    events.filterIsInstance<PatchStreamEvent.PatchFrame>().map { it.patch.target.region.value },
+                )
+                assertEquals(PatchStreamEvent.Complete(2), events.last())
+            }
+        }
+
+    @Test
+    fun `closing a committed response cancels outstanding deferred work`() =
+        runBlocking {
+            val cancelled = CompletableDeferred<Unit>()
+            val regions =
+                DeferredRegionsUseCase<Unit> {
+                    listOf(
+                        region("waiting") {
+                            try {
+                                awaitCancellation()
+                            } finally {
+                                cancelled.complete(Unit)
+                            }
+                        },
+                        region("ready") { patch("Ready") },
+                    )
+                }
+            val handler = WogeWebFluxDeferredHandler(regions, WebFluxPageInput { _ -> })
+
+            TestWebFluxServer(coRouter { GET("/patches", handler::handle) }).use { server ->
+                val response = server.open("/patches")
+                response.body().readThrough("Ready".toByteArray())
+                response.body().close()
+
+                withTimeout(5.seconds) { cancelled.await() }
+            }
+        }
+}
+
+private fun assertPageMetadata(response: HttpResponse<InputStream>) {
+    assertEquals(202, response.statusCode())
+    assertEquals("mapped", response.headers().firstValue("x-woge-test").orElseThrow())
+    val contentType =
+        response
+            .headers()
+            .firstValue("content-type")
+            .orElseThrow()
+            .lowercase()
+    assertTrue(contentType.startsWith("text/html"))
+    assertTrue(contentType.contains("charset=utf-8"))
+    assertTrue(
+        response
+            .headers()
+            .firstValue("set-cookie")
+            .orElseThrow()
+            .contains("woge-session=safe"),
+    )
+}
+
+private class SharedProjectPage :
+    PageUseCase<String>,
+    DeferredRegionsUseCase<String> {
+    override suspend fun open(request: PageRequest<String>): PageResult =
+        htmlPage { element("h1") { text("Project ${request.input}") } }
+
+    override suspend fun regions(request: PageRequest<String>): Iterable<DeferredRegion> =
+        listOf(region("summary") { patch("Summary for ${request.input}") })
+}
+
+private fun assertMappedContext(context: RequestContext) {
+    assertEquals(RequestMethod.GET, context.method)
+    assertEquals("de-de", context.language.value)
+    assertEquals("yes", context.header("x-visible"))
+    assertNull(context.header("authorization"))
+    assertNull(context.header("cookie"))
+    assertEquals("dark", context.cookie("theme"))
+}
+
+private fun RequestContext.header(name: String): String? = headers.values(HeaderName.of(name)).firstOrNull()?.value
+
+private fun RequestContext.cookie(name: String): String? =
+    cookies
+        .first(
+            dev.woge.host.CookieName
+                .of(name),
+        )?.value
+
+private fun region(
+    id: String,
+    content: suspend () -> dev.woge.protocol.PatchHtml,
+): DeferredRegion =
+    deferredRegion(
+        target = PatchTarget(PageEpoch.of("page-1"), RegionTargetId.of(id)),
+        loading = { element("p") { text("Loading $id") } },
+        onFailure = { patchHtml { element("p") { text("Unavailable") } } },
+        content = content,
+    )
+
+private fun patch(text: String): dev.woge.protocol.PatchHtml = patchHtml { element("p") { text(text) } }
+
+private class TestWebFluxServer(
+    routes: RouterFunction<ServerResponse>,
+) : AutoCloseable {
+    private val server: DisposableServer =
+        HttpServer
+            .create()
+            .host("127.0.0.1")
+            .port(0)
+            .handle(ReactorHttpHandlerAdapter(RouterFunctions.toHttpHandler(routes)))
+            .bindNow()
+    private val client: HttpClient =
+        HttpClient
+            .newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build()
+
+    fun open(
+        path: String,
+        headers: Map<String, String> = emptyMap(),
+    ): HttpResponse<InputStream> {
+        val builder = HttpRequest.newBuilder(uri(path)).GET()
+        headers.forEach(builder::header)
+        return client.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream())
+    }
+
+    fun text(path: String): HttpResponse<String> =
+        client.send(
+            HttpRequest.newBuilder(uri(path)).GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    override fun close() {
+        server.disposeNow()
+    }
+
+    private fun uri(path: String): URI = URI.create("http://127.0.0.1:${server.port()}$path")
+}
+
+private fun InputStream.readThrough(marker: ByteArray): ByteArray {
+    val output = ByteArrayOutputStream()
+    while (!output.toByteArray().endsWith(marker)) {
+        val next = read()
+        check(next >= 0) { "Response ended before marker '${marker.toString(StandardCharsets.UTF_8)}'" }
+        output.write(next)
+        check(output.size() <= MAX_STREAM_PREFIX_BYTES) { "Response marker was not found within the test bound" }
+    }
+    return output.toByteArray()
+}
+
+private fun ByteArray.endsWith(suffix: ByteArray): Boolean =
+    size >= suffix.size && copyOfRange(size - suffix.size, size).contentEquals(suffix)
+
+private const val MAX_STREAM_PREFIX_BYTES: Int = 64 * 1024

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Encode and decode fallback patch streams](guides/patch-stream-codec.md)
 - [Apply a patch stream in the browser](guides/browser-replace-runtime.md)
 - [Render independent page regions](guides/deferred-regions.md)
+- [Run a Woge page with Spring WebFlux](guides/spring-webflux-adapter.md)
 
 ## Performance evidence
 

--- a/docs/adr/0028-functional-spring-webflux-adapter.md
+++ b/docs/adr/0028-functional-spring-webflux-adapter.md
@@ -1,0 +1,111 @@
+# ADR 0028: Adapt Woge through functional Spring WebFlux handlers
+
+- Status: Accepted
+- Date: 2026-09-05
+- Decision owners: Woge maintainers
+- Related issues: [#65](https://github.com/christian-draeger/woge/issues/65), [#66](https://github.com/christian-draeger/woge/issues/66), [#69](https://github.com/christian-draeger/woge/issues/69), [#73](https://github.com/christian-draeger/woge/issues/73), [#122](https://github.com/christian-draeger/woge/issues/122), [#124](https://github.com/christian-draeger/woge/issues/124)
+
+## Context
+
+Spring Boot WebFlux is Woge's first production host. Portable application code already opens a page
+through `PageUseCase` and declares independent `DeferredRegion` values. The adapter must preserve
+that Kotlin API, map finalized metadata before body collection, flush visible work incrementally and
+cancel coroutine children when the reactive subscriber disappears.
+
+Spring supports suspending functional handlers and maps Kotlin `Flow` to reactive publishers. Its
+native response writer can also flush a publisher of publishers as independent groups. Exposing
+`Mono`, `Flux`, `ServerRequest` or `ServerResponse` through the host SPI would nevertheless couple
+the shared application to WebFlux and make MVC and Ktor secondary translations.
+
+[ADR 0027](0027-fetch-deferred-patches-after-html-shell.md) also requires the portable browser path
+to use one normal HTML response followed by one independently authorized Fetch patch response.
+
+## Decision
+
+`woge-spring-webflux` provides functional-route handlers instead of generated or application-owned
+controllers:
+
+- `WogeWebFluxPageHandler` decodes route input, snapshots request context, invokes one
+  `PageUseCase`, and maps its document, redirect or controlled failure to `ServerResponse`.
+- `WogeWebFluxDeferredHandler` decodes the patch request, invokes one host-neutral
+  `DeferredRegionsUseCase`, executes the declarations, and returns the version-1 patch media type.
+- `WebFluxPageInput` is the adapter-local escape hatch for path and query decoding until generated
+  route descriptors own that work.
+- `WebFluxRequestContextFactory` is the explicit integration point for Spring Security, CSRF,
+  tracing and other host facts.
+
+`DeferredRegionsUseCase` lives in `woge-host-spi`, not the Spring adapter. It receives the same typed
+`PageRequest` as the page port, so one application class can implement both contracts without a
+Spring import. It runs again for the Fetch request because authentication and domain authorization
+must be current; the page epoch and region IDs are never capabilities.
+
+The default request-context factory supports only GET, HEAD and OPTIONS. It generates request-local
+trace IDs, copies parsed cookies and ordinary headers, and derives the preferred language range. Raw
+Authorization, Cookie, proxy authorization and common CSRF token headers are not copied into the
+general header bag. The default caller is anonymous. Any authenticated endpoint or unsafe method
+must install a factory that has already translated Spring Security and CSRF outcomes into Woge
+facts.
+
+The page adapter commits status, content type and charset, safe response headers, cookies and redirect
+location from the host SPI before body collection. HTML uses one WebFlux flush group per `HtmlFrame`.
+Each frame is rendered into ordered UTF-8 chunks with the shared HTML writer before its group is
+published. This bounds individual byte-array chunks but temporarily retains the chunks for one
+application frame; hard frame and pending-write budgets remain follow-up work in
+[#122](https://github.com/christian-draeger/woge/issues/122).
+
+The deferred adapter uses one flush group per `EncodedPatchChunk`, including a separate terminal
+group. Reactor types and `asPublisher` bridging are internal to the adapter. Subscriber cancellation
+therefore cancels Flow collection, the deferred executor and all active or queued region children.
+Errors before a `ServerResponse` is returned remain available to normal Spring status handling;
+post-commit errors terminate the response. The complete portable failure mapping remains owned by
+[#124](https://github.com/christian-draeger/woge/issues/124).
+
+The implementation compiles against the current stable Spring Boot 4.1.1 dependency platform and
+Spring Framework 7.0.9. Woge's published compatibility range is not frozen by this implementation
+version and will require consumer testing before beta.
+
+## Alternatives considered
+
+- **Require application controllers:** rejected because every application would repeat response,
+  coroutine and error-lifecycle glue and generated routes could not reuse one adapter handler.
+- **Expose Reactor from the host SPI:** rejected because portable use cases would no longer run
+  unchanged through MVC and Ktor.
+- **Make one generic `WebHandler` own all routing:** rejected because it would duplicate Spring's
+  router and hide familiar HTTP route composition from web developers.
+- **Reuse one request for HTML and fallback patches:** rejected by the one-media-type and stable
+  browser constraints recorded in ADR 0027.
+- **Copy the full raw request into `RequestContext`:** rejected because security tokens and mutable
+  framework state would cross the portable boundary invisibly.
+- **Claim fully bounded frame rendering now:** rejected because the synchronous HTML writer cannot
+  suspend midway through a callback without a larger sink-contract change. Explicit frame buffering
+  is documented and measured before a hard resource promise.
+
+## Consequences
+
+### Positive
+
+- Application page and deferred-region code contains no Spring or Reactor type.
+- WebFlux applications compose Woge with the familiar `coRouter` DSL and no controller class.
+- Real server tests prove page-frame and patch-frame visibility before response completion.
+- Closing the client body cancels outstanding structured coroutine work.
+- Response status, content type, charset, headers, cookies and redirects retain the host-SPI policy.
+- ABI validation detects accidental Reactor or implementation-type leakage.
+
+### Negative
+
+- The host bootstrap still supplies route patterns and small input decoders until code generation.
+- Authenticated applications must provide an explicit Spring Security context factory.
+- One HTML frame is temporarily materialized as bounded chunks before WebFlux publishes that group.
+- Pre- and post-commit failures have only the current provisional mapping until the canonical failure
+  contract is implemented.
+
+## Follow-up
+
+- Select and configure this adapter automatically in the Spring Boot integration in
+  [#69](https://github.com/christian-draeger/woge/issues/69).
+- Turn the tested route into the executable Spring-first guide and no-JavaScript example in
+  [#73](https://github.com/christian-draeger/woge/issues/73).
+- Move the shared lifecycle cases into the cross-host adapter TCK in
+  [#65](https://github.com/christian-draeger/woge/issues/65).
+- Add generated typed route/input binding in [#27](https://github.com/christian-draeger/woge/issues/27).
+- Define hard buffering and pending-write budgets in [#122](https://github.com/christian-draeger/woge/issues/122).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,6 +54,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0025](0025-browser-replace-runtime-and-lifecycle.md) | Accepted | Apply Replace patches through a page-local DOM registry |
 | [0026](0026-structured-deferred-region-execution.md) | Accepted | Execute deferred regions as bounded request children |
 | [0027](0027-fetch-deferred-patches-after-html-shell.md) | Accepted | Fetch deferred patches after the HTML shell |
+| [0028](0028-functional-spring-webflux-adapter.md) | Accepted | Adapt Woge through functional Spring WebFlux handlers |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/guides/spring-webflux-adapter.md
+++ b/docs/guides/spring-webflux-adapter.md
@@ -1,0 +1,74 @@
+# Run a Woge page with Spring WebFlux
+
+Woge keeps the page itself independent from Spring. A small WebFlux bootstrap connects that page to
+normal functional routes; there is no application controller and no Reactor type in page code.
+
+## Write shared application code
+
+The same class can provide the immediate document and the deferred work requested by the browser:
+
+```kotlin
+data class ProjectInput(val project: String)
+
+class ProjectPage :
+    PageUseCase<ProjectInput>,
+    DeferredRegionsUseCase<ProjectInput> {
+
+    override suspend fun open(request: PageRequest<ProjectInput>): PageResult =
+        htmlPage {
+            element("main") {
+                element("h1") { text("Project ${request.input.project}") }
+                regionPlaceholder(summaryRegion(request), elementName = "section")
+            }
+        }
+
+    override suspend fun regions(request: PageRequest<ProjectInput>): Iterable<DeferredRegion> =
+        listOf(summaryRegion(request))
+}
+```
+
+This file imports Woge host, HTML and protocol types only. Repository calls inside a deferred
+region are suspending Kotlin functions; they do not return `Mono` or `Flux`.
+
+The example assumes `summaryRegion` deterministically declares the same page-scoped target in both
+requests. Signed page context and generated descriptors replace manual target reconstruction later.
+
+## Connect functional routes
+
+The WebFlux-only bootstrap owns path decoding and handlers:
+
+```kotlin
+val projectPage = ProjectPage()
+val input = WebFluxPageInput { request ->
+    ProjectInput(request.pathVariable("project"))
+}
+val pageHandler = WogeWebFluxPageHandler(projectPage, input)
+val patchHandler = WogeWebFluxDeferredHandler(projectPage, input)
+
+val routes = coRouter {
+    GET("/projects/{project}", pageHandler::handle)
+    GET("/projects/{project}/woge-patches", patchHandler::handle)
+}
+```
+
+Navigation returns a complete `text/html; charset=UTF-8` response. The fallback browser module then
+Fetches the second route as `application/vnd.woge.patch-stream; version=1`. Each completed region is
+flushed and can become visible while slower work is still running.
+
+The default context mapper intentionally supports safe page methods only and treats the request as
+anonymous. For an authenticated application, provide a `WebFluxRequestContextFactory` that translates
+the current Spring Security principal and verified CSRF decision into Woge's immutable security facts.
+Domain authorization still happens inside `ProjectPage` for both routes.
+
+## What failures mean today
+
+A controlled `PageResult.Failure` maps to its Woge status before the response starts. A Spring
+`ResponseStatusException` thrown by route decoding or application setup also remains a normal
+pre-stream Spring error. Once bytes are committed, an exception ends the response and cancels its
+coroutine work; it cannot change the existing status.
+
+The canonical error/recovery taxonomy and security integration are explicit later contracts. Until
+then, do not translate a failed unsafe request into an automatic retry.
+
+See [ADR 0028](../adr/0028-functional-spring-webflux-adapter.md) for lifecycle and buffering tradeoffs
+and [the deferred-region guide](deferred-regions.md) for region declaration details.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jsoup = "1.23.2"
 kotlin = "2.4.10"
 ktlintGradle = "14.2.0"
 serialization = "1.11.0"
+springBoot = "4.1.1"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
@@ -21,7 +22,12 @@ jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinxCoroutinesReactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
 kotlinxCoroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ktlintGradlePlugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlintGradle" }
+reactorNettyHttp = { module = "io.projectreactor.netty:reactor-netty-http" }
+springBootDependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
+springContext = { module = "org.springframework:spring-context" }
+springWebflux = { module = "org.springframework:spring-webflux" }

--- a/modules/woge-host-spi/api/woge-host-spi.api
+++ b/modules/woge-host-spi/api/woge-host-spi.api
@@ -191,6 +191,10 @@ public final class dev/woge/host/DeferredRegionKt {
 	public static synthetic fun regionPlaceholder$default (Ldev/woge/html/HtmlWriter;Ldev/woge/host/DeferredRegion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
+public abstract interface class dev/woge/host/DeferredRegionsUseCase {
+	public abstract fun regions (Ldev/woge/host/PageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/woge/host/ExternalRedirectLocation : dev/woge/host/RedirectLocation {
 	public final fun getUrl-k-WF5Ao ()Ljava/lang/String;
 	public fun getValue ()Ljava/lang/String;
@@ -437,6 +441,7 @@ public final class dev/woge/host/RequestCookies : java/lang/Iterable, kotlin/jvm
 
 public final class dev/woge/host/RequestCookies$Companion {
 	public final fun getEMPTY ()Ldev/woge/host/RequestCookies;
+	public final fun of (Ljava/lang/Iterable;)Ldev/woge/host/RequestCookies;
 	public final fun of ([Ldev/woge/host/RequestCookie;)Ldev/woge/host/RequestCookies;
 }
 
@@ -450,6 +455,7 @@ public final class dev/woge/host/RequestHeaders : java/lang/Iterable, kotlin/jvm
 
 public final class dev/woge/host/RequestHeaders$Companion {
 	public final fun getEMPTY ()Ldev/woge/host/RequestHeaders;
+	public final fun of (Ljava/lang/Iterable;)Ldev/woge/host/RequestHeaders;
 	public final fun of ([Ldev/woge/host/HttpHeader;)Ldev/woge/host/RequestHeaders;
 }
 

--- a/modules/woge-host-spi/src/main/kotlin/dev/woge/host/DeferredRegionsUseCase.kt
+++ b/modules/woge-host-spi/src/main/kotlin/dev/woge/host/DeferredRegionsUseCase.kt
@@ -1,0 +1,6 @@
+package dev.woge.host
+
+/** Page-load work re-authorized when a browser opens its deferred patch stream. */
+public fun interface DeferredRegionsUseCase<Input : Any> {
+    public suspend fun regions(request: PageRequest<Input>): Iterable<DeferredRegion>
+}

--- a/modules/woge-host-spi/src/main/kotlin/dev/woge/host/HttpValues.kt
+++ b/modules/woge-host-spi/src/main/kotlin/dev/woge/host/HttpValues.kt
@@ -93,6 +93,9 @@ public class RequestHeaders private constructor(
         public val EMPTY: RequestHeaders = RequestHeaders(emptyList())
 
         public fun of(vararg entries: HttpHeader): RequestHeaders = RequestHeaders(entries.asIterable())
+
+        /** Creates a snapshot without requiring an adapter to copy through a vararg array. */
+        public fun of(entries: Iterable<HttpHeader>): RequestHeaders = RequestHeaders(entries)
     }
 }
 
@@ -203,6 +206,9 @@ public class RequestCookies private constructor(
         public val EMPTY: RequestCookies = RequestCookies(emptyList())
 
         public fun of(vararg entries: RequestCookie): RequestCookies = RequestCookies(entries.asIterable())
+
+        /** Creates a snapshot without requiring an adapter to copy through a vararg array. */
+        public fun of(entries: Iterable<RequestCookie>): RequestCookies = RequestCookies(entries)
     }
 }
 

--- a/modules/woge-host-spi/src/test/kotlin/dev/woge/host/HttpValuesTest.kt
+++ b/modules/woge-host-spi/src/test/kotlin/dev/woge/host/HttpValuesTest.kt
@@ -62,4 +62,18 @@ class HttpValuesTest {
             (metadata.cookies as MutableList<ResponseCookie>).clear()
         }
     }
+
+    @Test
+    fun `iterable request values are snapshotted for host adapters`() {
+        val headerSource = mutableListOf(httpHeader("x-mode", "browser"))
+        val cookieSource = mutableListOf(requestCookie("theme", "dark"))
+        val headers = RequestHeaders.of(headerSource)
+        val cookies = RequestCookies.of(cookieSource)
+
+        headerSource.clear()
+        cookieSource.clear()
+
+        assertEquals("browser", headers.values(HeaderName.of("x-mode")).single().value)
+        assertEquals("dark", cookies.first(CookieName.of("theme"))?.value)
+    }
 }


### PR DESCRIPTION
## Summary

- Add functional WebFlux handlers for portable page and deferred-region use cases.
- Map typed request/response metadata while keeping Reactor and runtime internals out of public Woge ports.
- Prove incremental HTML/patch flush and disconnect cancellation through a real Reactor Netty server.
- Add ABI enforcement, ADR 0028, and a Spring WebFlux guide using one shared application object.

## Verification

- `./gradlew check`

Closes #66
