### PR TITLE
Add Spring Boot auto-configuration foundation

### DIFF
--- a/adapters/woge-spring-webflux/README.md
+++ b/adapters/woge-spring-webflux/README.md
@@ -4,4 +4,5 @@ This module maps framework-neutral Woge page and deferred-region use cases to Sp
 functional handlers. Reactor and response-lifecycle details remain inside the adapter.
 
 Start with [Run a Woge page with Spring WebFlux](../../docs/guides/spring-webflux-adapter.md). The
-Spring Boot starter and complete executable reference application are the next M1a slices.
+[Spring Boot auto-configuration](../../docs/guides/spring-boot-starter.md) can provide the shared
+handler factory. The complete executable reference application is the next M1a slice.

--- a/adapters/woge-spring-webflux/api/woge-spring-webflux.api
+++ b/adapters/woge-spring-webflux/api/woge-spring-webflux.api
@@ -17,6 +17,13 @@ public final class dev/woge/spring/webflux/WogeWebFluxDeferredHandler {
 	public final fun handle (Lorg/springframework/web/reactive/function/server/ServerRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class dev/woge/spring/webflux/WogeWebFluxHandlers {
+	public synthetic fun <init> (Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun deferred (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;)Ldev/woge/spring/webflux/WogeWebFluxDeferredHandler;
+	public final fun page (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;)Ldev/woge/spring/webflux/WogeWebFluxPageHandler;
+}
+
 public final class dev/woge/spring/webflux/WogeWebFluxPageHandler {
 	public fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;)V
 	public synthetic fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxHandlers.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxHandlers.kt
@@ -1,0 +1,37 @@
+package dev.woge.spring.webflux
+
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageUseCase
+import dev.woge.runtime.DeferredRegionPolicy
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Creates route-local Woge handlers with one shared WebFlux runtime policy. */
+public class WogeWebFluxHandlers(
+    private val contexts: WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory,
+    private val maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
+    private val regionTimeout: Duration = 30.seconds,
+) {
+    init {
+        DeferredRegionPolicy(maxConcurrency, regionTimeout)
+    }
+
+    /** Creates a handler for one typed page and its route-local input decoder. */
+    public fun <Input : Any> page(
+        useCase: PageUseCase<Input>,
+        input: WebFluxPageInput<Input>,
+    ): WogeWebFluxPageHandler<Input> = WogeWebFluxPageHandler(useCase, input, contexts)
+
+    /** Creates a handler for one typed deferred-region stream and its route-local input decoder. */
+    public fun <Input : Any> deferred(
+        useCase: DeferredRegionsUseCase<Input>,
+        input: WebFluxPageInput<Input>,
+    ): WogeWebFluxDeferredHandler<Input> =
+        WogeWebFluxDeferredHandler(
+            regions = useCase,
+            input = input,
+            contexts = contexts,
+            maxConcurrency = maxConcurrency,
+            regionTimeout = regionTimeout,
+        )
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Apply a patch stream in the browser](guides/browser-replace-runtime.md)
 - [Render independent page regions](guides/deferred-regions.md)
 - [Run a Woge page with Spring WebFlux](guides/spring-webflux-adapter.md)
+- [Configure Woge with Spring Boot](guides/spring-boot-starter.md)
 
 ## Performance evidence
 

--- a/docs/adr/0029-neutral-spring-boot-starter-and-explicit-adapter-selection.md
+++ b/docs/adr/0029-neutral-spring-boot-starter-and-explicit-adapter-selection.md
@@ -1,0 +1,88 @@
+# ADR 0029: Keep the Spring Boot starter neutral and adapter selection explicit
+
+- Status: Accepted
+- Date: 2026-09-05
+- Decision owners: Woge maintainers
+- Related issues: [#69](https://github.com/christian-draeger/woge/issues/69), [#66](https://github.com/christian-draeger/woge/issues/66), [#67](https://github.com/christian-draeger/woge/issues/67), [#73](https://github.com/christian-draeger/woge/issues/73)
+
+## Context
+
+Woge needs an idiomatic Spring Boot entry point without making Spring the portable application
+abstraction. Spring MVC and WebFlux are separate first-class adapters with different execution and
+response lifecycles. A shared starter cannot transitively include both without making Boot's
+classpath inference ambiguous and charging every application for an unused web stack.
+
+Spring Boot also expects external auto-configuration to be registered explicitly, guarded by
+classpath, web-application and missing-bean conditions, and tested against representative application
+contexts. Woge needs those conventions while preserving familiar application-owned functional routes.
+
+## Decision
+
+`woge-spring-boot-starter` is a transport-neutral dependency entry point. It includes
+`woge-spring-boot-autoconfigure` but neither Spring WebFlux, Spring MVC nor either Woge transport
+adapter. A consumer adds exactly one Spring web starter and its matching Woge adapter. The reference
+application and future project generator provide that complete dependency pair.
+
+`woge-spring-boot-autoconfigure` is registered through Boot's
+`AutoConfiguration.imports` mechanism. It uses the `woge` property namespace and initially exposes
+only three proven settings: adapter selection, per-request deferred concurrency and per-region
+timeout. The configuration processor publishes descriptions and types for IDE completion.
+
+`woge.adapter=auto` accepts exactly one supported Spring web stack and matching Woge adapter. If MVC
+and WebFlux are both present, startup fails with an instruction to select `webflux` or `mvc`. An
+explicit selection must still match the actual Boot web application context. Missing and unsupported
+adapter artifacts also fail at startup with the required artifact name.
+
+Auto-configuration supplies a safe default `WebFluxRequestContextFactory` and one
+`WogeWebFluxHandlers` factory. Both back off when an application supplies a bean. The factory carries
+the shared deferred execution policy into route-local typed page and patch handlers. It does not hide
+routes, path decoding or HTTP methods.
+
+Spring bean discovery records `PageUseCase` and `DeferredRegionsUseCase` entry points for diagnostics
+and future generated route descriptors. HTML components are not Spring-scanned: they remain ordinary
+typed Kotlin functions and values composed by application code. This avoids a second component model
+and keeps their behavior visible to the compiler and coding tools.
+
+Startup logs and an injectable `WogeRuntimeInfo` report the selected adapter, patch protocol version,
+Woge artifact version and discovered use-case counts. Context-runner tests cover activation,
+application overrides, property binding, non-web back-off, missing artifacts and ambiguous classpaths.
+
+## Alternatives considered
+
+- **Bundle MVC and WebFlux in one starter:** rejected because selection becomes classpath-order
+  dependent and both stacks become transitive runtime cost.
+- **Make the shared starter WebFlux-opinionated:** rejected because its generic name would make future
+  MVC support look secondary and changing that dependency later would be surprising.
+- **Silently follow Boot's preferred stack when both are present:** rejected because adding an
+  unrelated dependency could change Woge's transport semantics.
+- **Auto-scan HTML components:** rejected because components do not need runtime identity or a Spring
+  lifecycle; page and deferred use cases are the actual host entry points.
+- **Generate routes in auto-configuration:** deferred until typed route descriptors define paths,
+  methods and input decoding without string reflection.
+
+## Consequences
+
+### Positive
+
+- Applications choose one transport deliberately and never receive both web stacks from Woge.
+- Spring defaults are convenient but all security/context and handler policies remain replaceable.
+- Routes still read like ordinary WebFlux or MVC code and can use the full host framework.
+- Startup failures identify dependency or application-type mismatches before serving traffic.
+- Configuration metadata helps IntelliJ users and coding models discover the small supported surface.
+
+### Negative
+
+- Until an opinionated generated project exists, setup requires the neutral starter plus one Woge
+  adapter and one Spring web starter.
+- MVC selection remains an actionable unsupported setup until [#67](https://github.com/christian-draeger/woge/issues/67)
+  implements and marks that adapter.
+- Bean-name discovery does not yet provide typed route metadata.
+
+## Follow-up
+
+- Implement the equivalent MVC handler factory and conditional configuration in
+  [#67](https://github.com/christian-draeger/woge/issues/67).
+- Replace hand-written path wiring with generated typed route descriptors in
+  [#27](https://github.com/christian-draeger/woge/issues/27).
+- Put the complete Spring WebFlux dependency set in the executable quick-start and scaffold in
+  [#73](https://github.com/christian-draeger/woge/issues/73).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,6 +55,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0026](0026-structured-deferred-region-execution.md) | Accepted | Execute deferred regions as bounded request children |
 | [0027](0027-fetch-deferred-patches-after-html-shell.md) | Accepted | Fetch deferred patches after the HTML shell |
 | [0028](0028-functional-spring-webflux-adapter.md) | Accepted | Adapt Woge through functional Spring WebFlux handlers |
+| [0029](0029-neutral-spring-boot-starter-and-explicit-adapter-selection.md) | Accepted | Keep the Spring Boot starter neutral and adapter selection explicit |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/guides/spring-boot-starter.md
+++ b/docs/guides/spring-boot-starter.md
@@ -1,0 +1,97 @@
+# Configure Woge with Spring Boot
+
+The Woge starter configures shared policy and selects one server adapter. You still write normal
+Spring routes, choose normal HTTP methods and use the browser as a browser.
+
+## Add one web stack
+
+For the implemented WebFlux path, an application uses these three dependencies:
+
+```kotlin
+dependencies {
+    implementation("dev.woge:woge-spring-boot-starter:<version>")
+    implementation("dev.woge:woge-spring-webflux:<version>")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+}
+```
+
+The general Woge starter deliberately includes neither MVC nor WebFlux. This makes it safe to replace
+the transport adapter without pulling two server stacks into the application. The MVC equivalent is
+planned but not implemented yet.
+
+## Connect a page to familiar routes
+
+Declare your `PageUseCase` as a Spring bean. Boot discovers it for diagnostics and provides a
+`WogeWebFluxHandlers` factory with the configured request-context and deferred-work policy:
+
+```kotlin
+@Configuration(proxyBeanMethods = false)
+class ProjectRoutes {
+    @Bean
+    fun routes(
+        projectPage: ProjectPage,
+        handlers: WogeWebFluxHandlers,
+    ): RouterFunction<ServerResponse> {
+        val input = WebFluxPageInput { request ->
+            ProjectInput(request.pathVariable("project"))
+        }
+        val page = handlers.page(projectPage, input)
+        val patches = handlers.deferred(projectPage, input)
+
+        return coRouter {
+            GET("/projects/{project}", page::handle)
+            GET("/projects/{project}/woge-patches", patches::handle)
+        }
+    }
+}
+```
+
+The paths and decoder stay visible because they are application behavior. Generated typed route
+descriptors can remove this small amount of repetition later without changing the page port.
+
+HTML components are normal Kotlin functions or values called by the page. They do not need an
+annotation or Spring component scan.
+
+## Tune only measured limits
+
+Defaults work without configuration. When measurements show a need, Spring's normal duration syntax
+and IDE metadata are available:
+
+```yaml
+woge:
+  deferred:
+    max-concurrency: 6
+    region-timeout: 2s
+```
+
+These limits apply per deferred patch-stream request. Invalid non-positive values fail while the
+application context starts.
+
+## Make security context explicit
+
+The default `WebFluxRequestContextFactory` permits safe page methods and creates an anonymous Woge
+request snapshot. A Spring Security application should expose its own bean that translates the
+authenticated principal, capabilities and verified request facts into Woge-owned values. The default
+backs off automatically.
+
+## Resolve mixed Spring stacks
+
+With one stack, `woge.adapter=auto` needs no property. If both Spring MVC and WebFlux are on the
+classpath, Woge refuses to guess. Select the intended adapter and make Boot create the same web
+application type:
+
+```yaml
+woge:
+  adapter: webflux
+spring:
+  main:
+    web-application-type: reactive
+```
+
+At startup, `WogeRuntimeInfo` and one log line report the selected adapter, patch protocol and runtime
+versions, and the number of page/deferred use-case beans. A missing adapter error names the dependency
+that must be added.
+
+See [the WebFlux adapter guide](spring-webflux-adapter.md) for response and cancellation behavior and
+[ADR 0029](../adr/0029-neutral-spring-boot-starter-and-explicit-adapter-selection.md) for the dependency
+and ambiguity tradeoffs.

--- a/docs/guides/spring-webflux-adapter.md
+++ b/docs/guides/spring-webflux-adapter.md
@@ -51,6 +51,11 @@ val routes = coRouter {
 }
 ```
 
+In a Spring Boot application, inject `WogeWebFluxHandlers` and call `page(...)` and `deferred(...)`
+instead of constructing both handlers separately. The shared factory applies the configured context
+and execution policy while the routes stay ordinary WebFlux code. See the
+[Spring Boot guide](spring-boot-starter.md).
+
 Navigation returns a complete `text/html; charset=UTF-8` response. The fallback browser module then
 Fetches the second route as `application/vnd.woge.patch-stream; version=1`. Each completed region is
 flushed and can become visible while slower work is still running.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,9 @@ kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
 
 [libraries]
+assertjCore = { module = "org.assertj:assertj-core" }
 detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+jakartaServletApi = { module = "jakarta.servlet:jakarta.servlet-api" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
@@ -28,6 +30,11 @@ kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serializati
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ktlintGradlePlugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlintGradle" }
 reactorNettyHttp = { module = "io.projectreactor.netty:reactor-netty-http" }
+springBoot = { module = "org.springframework.boot:spring-boot" }
+springBootAutoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
+springBootConfigurationProcessor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "springBoot" }
 springBootDependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
+springBootTest = { module = "org.springframework.boot:spring-boot-test" }
 springContext = { module = "org.springframework:spring-context" }
+springWebmvc = { module = "org.springframework:spring-webmvc" }
 springWebflux = { module = "org.springframework:spring-webflux" }

--- a/integrations/woge-spring-boot-autoconfigure/README.md
+++ b/integrations/woge-spring-boot-autoconfigure/README.md
@@ -1,0 +1,7 @@
+# Woge Spring Boot auto-configuration
+
+Conditional adapter selection, configuration metadata, use-case discovery and startup diagnostics for
+Spring Boot applications. Adapter dependencies remain optional so this artifact never chooses a web
+stack transitively.
+
+Start with [Configure Woge with Spring Boot](../../docs/guides/spring-boot-starter.md).

--- a/integrations/woge-spring-boot-autoconfigure/api/woge-spring-boot-autoconfigure.api
+++ b/integrations/woge-spring-boot-autoconfigure/api/woge-spring-boot-autoconfigure.api
@@ -1,0 +1,50 @@
+public final class dev/woge/spring/boot/autoconfigure/WogeApplicationCatalog {
+	public final fun getDeferredRegionUseCases ()Ljava/util/List;
+	public final fun getPageUseCases ()Ljava/util/List;
+}
+
+public final class dev/woge/spring/boot/autoconfigure/WogeAutoConfiguration {
+	public fun <init> ()V
+	public final fun wogeApplicationCatalog (Lorg/springframework/beans/factory/ListableBeanFactory;)Ldev/woge/spring/boot/autoconfigure/WogeApplicationCatalog;
+	public final fun wogeRuntimeInfo (Ldev/woge/spring/boot/autoconfigure/WogeProperties;Ldev/woge/spring/boot/autoconfigure/WogeApplicationCatalog;Lorg/springframework/core/io/ResourceLoader;Lorg/springframework/context/ApplicationContext;)Ldev/woge/spring/boot/autoconfigure/WogeRuntimeInfo;
+}
+
+public final class dev/woge/spring/boot/autoconfigure/WogeProperties {
+	public static final field Companion Ldev/woge/spring/boot/autoconfigure/WogeProperties$Companion;
+	public static final field DEFAULT_MAX_CONCURRENCY I
+	public fun <init> ()V
+	public final fun getAdapter ()Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+	public final fun getDeferred ()Ldev/woge/spring/boot/autoconfigure/WogeProperties$Deferred;
+	public final fun setAdapter (Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;)V
+	public final fun setDeferred (Ldev/woge/spring/boot/autoconfigure/WogeProperties$Deferred;)V
+}
+
+public final class dev/woge/spring/boot/autoconfigure/WogeProperties$Companion {
+	public final fun getDEFAULT_REGION_TIMEOUT ()Ljava/time/Duration;
+}
+
+public final class dev/woge/spring/boot/autoconfigure/WogeProperties$Deferred {
+	public fun <init> ()V
+	public final fun getMaxConcurrency ()I
+	public final fun getRegionTimeout ()Ljava/time/Duration;
+	public final fun setMaxConcurrency (I)V
+	public final fun setRegionTimeout (Ljava/time/Duration;)V
+}
+
+public final class dev/woge/spring/boot/autoconfigure/WogeRuntimeInfo {
+	public final fun getAdapter ()Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+	public final fun getDeferredRegionUseCases ()I
+	public final fun getPageUseCases ()I
+	public final fun getProtocolVersion ()I
+	public final fun getRuntimeVersion ()Ljava/lang/String;
+}
+
+public final class dev/woge/spring/boot/autoconfigure/WogeSpringAdapter : java/lang/Enum {
+	public static final field AUTO Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+	public static final field MVC Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+	public static final field WEBFLUX Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+	public static fun values ()[Ldev/woge/spring/boot/autoconfigure/WogeSpringAdapter;
+}
+

--- a/integrations/woge-spring-boot-autoconfigure/build.gradle.kts
+++ b/integrations/woge-spring-boot-autoconfigure/build.gradle.kts
@@ -1,11 +1,42 @@
+import org.gradle.api.tasks.bundling.Jar
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     id("dev.woge.kotlin-jvm-library")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 description = "Conditional Spring Boot wiring and diagnostics for the Woge server adapters."
 
+kotlin {
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation()
+}
+
 dependencies {
+    api(platform(libs.springBootDependencies))
     api(project(":woge-host-spi"))
+    api(libs.springBootAutoconfigure)
+
     compileOnly(project(":woge-spring-mvc"))
     compileOnly(project(":woge-spring-webflux"))
+
+    kapt(libs.springBootConfigurationProcessor)
+
+    testImplementation(project(":woge-spring-webflux"))
+    testImplementation(libs.assertjCore)
+    testImplementation(libs.jakartaServletApi)
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.springBoot)
+    testImplementation(libs.springBootTest)
+    testImplementation(libs.springWebmvc)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("checkKotlinAbi"))
+}
+
+tasks.named<Jar>("jar") {
+    manifest.attributes["Implementation-Version"] = project.version
 }

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeAdapterSelector.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeAdapterSelector.kt
@@ -1,0 +1,93 @@
+package dev.woge.spring.boot.autoconfigure
+
+import org.springframework.util.ClassUtils
+
+internal object WogeAdapterSelector {
+    private const val WEBFLUX_FRAMEWORK = "org.springframework.web.reactive.DispatcherHandler"
+    private const val MVC_FRAMEWORK = "org.springframework.web.servlet.DispatcherServlet"
+    private const val WOGE_WEBFLUX_ADAPTER = "dev.woge.spring.webflux.WogeWebFluxHandlers"
+    private const val WOGE_MVC_ADAPTER = "dev.woge.spring.mvc.WogeSpringMvcHandlers"
+
+    fun select(
+        requested: WogeSpringAdapter,
+        classLoader: ClassLoader,
+    ): WogeSpringAdapter {
+        val webFluxFramework = ClassUtils.isPresent(WEBFLUX_FRAMEWORK, classLoader)
+        val mvcFramework = ClassUtils.isPresent(MVC_FRAMEWORK, classLoader)
+        val webFluxAdapter = ClassUtils.isPresent(WOGE_WEBFLUX_ADAPTER, classLoader)
+        val mvcAdapter = ClassUtils.isPresent(WOGE_MVC_ADAPTER, classLoader)
+
+        return when (requested) {
+            WogeSpringAdapter.AUTO ->
+                selectAutomatically(
+                    webFluxFramework = webFluxFramework,
+                    mvcFramework = mvcFramework,
+                    webFluxAdapter = webFluxAdapter,
+                    mvcAdapter = mvcAdapter,
+                )
+
+            WogeSpringAdapter.WEBFLUX -> {
+                requireAvailable(
+                    selected = WogeSpringAdapter.WEBFLUX,
+                    frameworkAvailable = webFluxFramework,
+                    adapterAvailable = webFluxAdapter,
+                )
+                WogeSpringAdapter.WEBFLUX
+            }
+
+            WogeSpringAdapter.MVC -> {
+                requireAvailable(
+                    selected = WogeSpringAdapter.MVC,
+                    frameworkAvailable = mvcFramework,
+                    adapterAvailable = mvcAdapter,
+                )
+                WogeSpringAdapter.MVC
+            }
+        }
+    }
+
+    private fun selectAutomatically(
+        webFluxFramework: Boolean,
+        mvcFramework: Boolean,
+        webFluxAdapter: Boolean,
+        mvcAdapter: Boolean,
+    ): WogeSpringAdapter {
+        check(!(webFluxFramework && mvcFramework)) {
+            "Woge found both Spring MVC and WebFlux. Set 'woge.adapter=webflux' or " +
+                "'woge.adapter=mvc' and include only the matching Woge adapter dependency."
+        }
+
+        return when {
+            webFluxFramework -> {
+                requireAvailable(WogeSpringAdapter.WEBFLUX, webFluxFramework, webFluxAdapter)
+                WogeSpringAdapter.WEBFLUX
+            }
+
+            mvcFramework -> {
+                requireAvailable(WogeSpringAdapter.MVC, mvcFramework, mvcAdapter)
+                WogeSpringAdapter.MVC
+            }
+
+            else ->
+                error(
+                    "Woge requires a Spring web application. Add Spring Boot WebFlux plus " +
+                        "'woge-spring-webflux', or Spring MVC plus 'woge-spring-mvc'.",
+                )
+        }
+    }
+
+    private fun requireAvailable(
+        selected: WogeSpringAdapter,
+        frameworkAvailable: Boolean,
+        adapterAvailable: Boolean,
+    ) {
+        val displayName = if (selected == WogeSpringAdapter.WEBFLUX) "WebFlux" else "MVC"
+        val artifact = if (selected == WogeSpringAdapter.WEBFLUX) "woge-spring-webflux" else "woge-spring-mvc"
+        check(frameworkAvailable) {
+            "Woge adapter '$displayName' was selected but the Spring $displayName web stack is missing."
+        }
+        check(adapterAvailable) {
+            "Woge adapter '$displayName' was selected but '$artifact' is missing from the runtime classpath."
+        }
+    }
+}

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeApplicationCatalog.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeApplicationCatalog.kt
@@ -1,0 +1,13 @@
+package dev.woge.spring.boot.autoconfigure
+
+/** Names of portable Woge application entry points discovered as Spring beans. */
+public class WogeApplicationCatalog internal constructor(
+    pageUseCases: Iterable<String>,
+    deferredRegionUseCases: Iterable<String>,
+) {
+    /** Stable, sorted Spring bean names implementing a typed Woge page use case. */
+    public val pageUseCases: List<String> = pageUseCases.distinct().sorted()
+
+    /** Stable, sorted Spring bean names implementing a typed deferred-regions use case. */
+    public val deferredRegionUseCases: List<String> = deferredRegionUseCases.distinct().sorted()
+}

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfiguration.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfiguration.kt
@@ -1,0 +1,75 @@
+package dev.woge.spring.boot.autoconfigure
+
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageUseCase
+import dev.woge.protocol.PatchProtocolVersion
+import org.apache.commons.logging.LogFactory
+import org.springframework.beans.factory.ListableBeanFactory
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.context.reactive.ConfigurableReactiveWebApplicationContext
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.core.io.ResourceLoader
+
+/** Shared Spring Boot discovery, deterministic adapter selection and startup diagnostics. */
+@AutoConfiguration
+@ConditionalOnWebApplication
+@EnableConfigurationProperties(WogeProperties::class)
+@Import(WogeWebFluxAutoConfiguration::class)
+public class WogeAutoConfiguration {
+    /** Discovers only Woge host entry points; HTML components remain ordinary Kotlin values/functions. */
+    @Bean
+    @ConditionalOnMissingBean
+    public fun wogeApplicationCatalog(beanFactory: ListableBeanFactory): WogeApplicationCatalog =
+        WogeApplicationCatalog(
+            pageUseCases = beanFactory.getBeanNamesForType(PageUseCase::class.java, true, false).asIterable(),
+            deferredRegionUseCases =
+                beanFactory.getBeanNamesForType(DeferredRegionsUseCase::class.java, true, false).asIterable(),
+        )
+
+    /** Selects one adapter, exposes versions and emits one concise startup diagnostic. */
+    @Bean
+    @ConditionalOnMissingBean
+    public fun wogeRuntimeInfo(
+        properties: WogeProperties,
+        catalog: WogeApplicationCatalog,
+        resourceLoader: ResourceLoader,
+        applicationContext: ApplicationContext,
+    ): WogeRuntimeInfo {
+        val classLoader = resourceLoader.classLoader ?: WogeAutoConfiguration::class.java.classLoader
+        val selectedAdapter = WogeAdapterSelector.select(properties.adapter, classLoader)
+        val contextAdapter =
+            if (applicationContext is ConfigurableReactiveWebApplicationContext) {
+                WogeSpringAdapter.WEBFLUX
+            } else {
+                WogeSpringAdapter.MVC
+            }
+        check(selectedAdapter == contextAdapter) {
+            "Woge selected '$selectedAdapter', but Spring Boot created a '$contextAdapter' web application. " +
+                "Set 'woge.adapter=${contextAdapter.name.lowercase()}' or configure " +
+                "'spring.main.web-application-type' to match."
+        }
+        val runtimeInfo =
+            WogeRuntimeInfo(
+                adapter = selectedAdapter,
+                protocolVersion = PatchProtocolVersion.CURRENT.value,
+                runtimeVersion = WogeAutoConfiguration::class.java.`package`?.implementationVersion ?: "development",
+                pageUseCases = catalog.pageUseCases.size,
+                deferredRegionUseCases = catalog.deferredRegionUseCases.size,
+            )
+        logger.info(
+            "Woge initialized: adapter=${runtimeInfo.adapter}, " +
+                "protocol=${runtimeInfo.protocolVersion}, runtime=${runtimeInfo.runtimeVersion}, " +
+                "pages=${runtimeInfo.pageUseCases}, deferred=${runtimeInfo.deferredRegionUseCases}",
+        )
+        return runtimeInfo
+    }
+
+    private companion object {
+        private val logger = LogFactory.getLog(WogeAutoConfiguration::class.java)
+    }
+}

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeProperties.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeProperties.kt
@@ -1,0 +1,31 @@
+package dev.woge.spring.boot.autoconfigure
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/** Small set of proven Spring Boot settings for the M1 deferred-page path. */
+@ConfigurationProperties("woge")
+public class WogeProperties {
+    /** Adapter selection. AUTO requires exactly one supported Spring web stack. */
+    public var adapter: WogeSpringAdapter = WogeSpringAdapter.AUTO
+
+    /** Execution limits for one deferred patch-stream request. */
+    public var deferred: Deferred = Deferred()
+
+    /** Bounded execution policy applied by the WebFlux deferred handler factory. */
+    public class Deferred {
+        /** Maximum number of deferred regions executed concurrently per request. */
+        public var maxConcurrency: Int = DEFAULT_MAX_CONCURRENCY
+
+        /** Maximum execution time allowed for one deferred region. */
+        public var regionTimeout: Duration = DEFAULT_REGION_TIMEOUT
+    }
+
+    public companion object {
+        /** Default concurrency used by the shared server runtime. */
+        public const val DEFAULT_MAX_CONCURRENCY: Int = 8
+
+        /** Conservative first default; applications should tune this from observed latency. */
+        public val DEFAULT_REGION_TIMEOUT: Duration = Duration.ofSeconds(30)
+    }
+}

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeRuntimeInfo.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeRuntimeInfo.kt
@@ -1,0 +1,15 @@
+package dev.woge.spring.boot.autoconfigure
+
+/** Inspectable result of Woge's deterministic Spring Boot startup selection. */
+public class WogeRuntimeInfo internal constructor(
+    /** Active Spring transport adapter. */
+    public val adapter: WogeSpringAdapter,
+    /** Active Woge patch protocol version. */
+    public val protocolVersion: Int,
+    /** Woge artifact version, or `development` when running from classes directories. */
+    public val runtimeVersion: String,
+    /** Number of typed page use-case beans discovered at startup. */
+    public val pageUseCases: Int,
+    /** Number of deferred-region use-case beans discovered at startup. */
+    public val deferredRegionUseCases: Int,
+)

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeSpringAdapter.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeSpringAdapter.kt
@@ -1,0 +1,13 @@
+package dev.woge.spring.boot.autoconfigure
+
+/** Spring transport selected for the current application. */
+public enum class WogeSpringAdapter {
+    /** Infer one unambiguous adapter from the application classpath. */
+    AUTO,
+
+    /** Use the non-blocking Spring WebFlux adapter. */
+    WEBFLUX,
+
+    /** Use the Servlet-based Spring MVC adapter. */
+    MVC,
+}

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeWebFluxAutoConfiguration.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeWebFluxAutoConfiguration.kt
@@ -1,0 +1,40 @@
+package dev.woge.spring.boot.autoconfigure
+
+import dev.woge.spring.webflux.DefaultWebFluxRequestContextFactory
+import dev.woge.spring.webflux.WebFluxRequestContextFactory
+import dev.woge.spring.webflux.WogeWebFluxHandlers
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import kotlin.time.toKotlinDuration
+
+/** WebFlux-specific bean definitions isolated from the optional adapter classpath. */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+@ConditionalOnClass(name = ["dev.woge.spring.webflux.WogeWebFluxHandlers"])
+internal class WogeWebFluxAutoConfiguration {
+    /** Safe-method anonymous default; security-aware applications should provide their own bean. */
+    @Bean
+    @ConditionalOnMissingBean
+    public fun wogeWebFluxRequestContextFactory(): WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory
+
+    /** Shared policy factory used from familiar functional WebFlux routes. */
+    @Bean
+    @ConditionalOnMissingBean
+    public fun wogeWebFluxHandlers(
+        properties: WogeProperties,
+        contexts: WebFluxRequestContextFactory,
+        runtimeInfo: WogeRuntimeInfo,
+    ): WogeWebFluxHandlers {
+        check(runtimeInfo.adapter == WogeSpringAdapter.WEBFLUX) {
+            "Reactive Woge configuration requires 'woge.adapter=webflux'."
+        }
+        return WogeWebFluxHandlers(
+            contexts = contexts,
+            maxConcurrency = properties.deferred.maxConcurrency,
+            regionTimeout = properties.deferred.regionTimeout.toKotlinDuration(),
+        )
+    }
+}

--- a/integrations/woge-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.woge.spring.boot.autoconfigure.WogeAutoConfiguration

--- a/integrations/woge-spring-boot-autoconfigure/src/test/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfigurationTest.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/test/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfigurationTest.kt
@@ -1,0 +1,202 @@
+package dev.woge.spring.boot.autoconfigure
+
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageUseCase
+import dev.woge.spring.webflux.WebFluxRequestContextFactory
+import dev.woge.spring.webflux.WogeWebFluxHandlers
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+class WogeAutoConfigurationTest {
+    @Test
+    fun `activates WebFlux and discovers portable use cases`() {
+        webFluxRunner()
+            .withUserConfiguration(UseCaseConfiguration::class.java)
+            .run { context ->
+                assertNull(context.startupFailure)
+                assertNotNull(context.getBean(WogeWebFluxHandlers::class.java))
+
+                val catalog = context.getBean(WogeApplicationCatalog::class.java)
+                assertEquals(listOf("homePage"), catalog.pageUseCases)
+                assertEquals(listOf("homeRegions"), catalog.deferredRegionUseCases)
+
+                val info = context.getBean(WogeRuntimeInfo::class.java)
+                assertEquals(WogeSpringAdapter.WEBFLUX, info.adapter)
+                assertEquals(1, info.protocolVersion)
+                assertEquals(1, info.pageUseCases)
+                assertEquals(1, info.deferredRegionUseCases)
+            }
+    }
+
+    @Test
+    fun `backs off for an application request context factory`() {
+        webFluxRunner()
+            .withUserConfiguration(CustomContextConfiguration::class.java)
+            .run { context ->
+                assertNull(context.startupFailure)
+                assertSame(
+                    CustomContextConfiguration.contexts,
+                    context.getBean(WebFluxRequestContextFactory::class.java),
+                )
+            }
+    }
+
+    @Test
+    fun `backs off for an application handler factory`() {
+        webFluxRunner()
+            .withUserConfiguration(CustomHandlersConfiguration::class.java)
+            .run { context ->
+                assertNull(context.startupFailure)
+                assertSame(
+                    CustomHandlersConfiguration.handlers,
+                    context.getBean(WogeWebFluxHandlers::class.java),
+                )
+                assertEquals(1, context.getBeansOfType(WogeWebFluxHandlers::class.java).size)
+            }
+    }
+
+    @Test
+    fun `binds the bounded deferred policy`() {
+        webFluxRunner()
+            .withPropertyValues(
+                "woge.deferred.max-concurrency=3",
+                "woge.deferred.region-timeout=750ms",
+            ).run { context ->
+                assertNull(context.startupFailure)
+                val properties = context.getBean(WogeProperties::class.java)
+                assertEquals(3, properties.deferred.maxConcurrency)
+                assertEquals(Duration.ofMillis(750), properties.deferred.regionTimeout)
+            }
+    }
+
+    @Test
+    fun `fails with an actionable error when both Spring web stacks are present`() {
+        ReactiveWebApplicationContextRunner()
+            .withConfiguration(autoConfiguration)
+            .run { context ->
+                val failure = context.startupFailure
+                assertNotNull(failure)
+                assertTrue(failure.messages().contains("both Spring MVC and WebFlux"))
+                assertTrue(failure.messages().contains("woge.adapter=webflux"))
+            }
+    }
+
+    @Test
+    fun `explicit WebFlux selection resolves a dual-stack classpath`() {
+        ReactiveWebApplicationContextRunner()
+            .withConfiguration(autoConfiguration)
+            .withPropertyValues("woge.adapter=webflux")
+            .run { context ->
+                assertNull(context.startupFailure)
+                assertEquals(
+                    WogeSpringAdapter.WEBFLUX,
+                    context.getBean(WogeRuntimeInfo::class.java).adapter,
+                )
+            }
+    }
+
+    @Test
+    fun `fails when explicit adapter and Boot application type disagree`() {
+        WebApplicationContextRunner()
+            .withConfiguration(autoConfiguration)
+            .withPropertyValues("woge.adapter=webflux")
+            .run { context ->
+                val failure = context.startupFailure
+                assertNotNull(failure)
+                assertTrue(failure.messages().contains("Spring Boot created a 'MVC' web application"))
+                assertTrue(failure.messages().contains("spring.main.web-application-type"))
+            }
+    }
+
+    @Test
+    fun `fails when the selected Woge adapter artifact is missing`() {
+        ReactiveWebApplicationContextRunner()
+            .withConfiguration(autoConfiguration)
+            .withClassLoader(
+                FilteredClassLoader(
+                    "org.springframework.web.servlet",
+                    "dev.woge.spring.webflux",
+                ),
+            ).run { context ->
+                val failure = context.startupFailure
+                assertNotNull(failure)
+                assertTrue(failure.messages().contains("woge-spring-webflux"))
+                assertTrue(failure.messages().contains("runtime classpath"))
+            }
+    }
+
+    @Test
+    fun `backs off outside a web application`() {
+        ApplicationContextRunner()
+            .withConfiguration(autoConfiguration)
+            .run { context ->
+                assertNull(context.startupFailure)
+                assertTrue(context.getBeansOfType(WogeRuntimeInfo::class.java).isEmpty())
+            }
+    }
+
+    @Test
+    fun `publishes IDE configuration metadata`() {
+        val metadata =
+            requireNotNull(javaClass.classLoader.getResource("META-INF/spring-configuration-metadata.json"))
+                .readText()
+        assertTrue(metadata.contains("woge.adapter"))
+        assertTrue(metadata.contains("woge.deferred.max-concurrency"))
+        assertTrue(metadata.contains("woge.deferred.region-timeout"))
+    }
+
+    private fun webFluxRunner(): ReactiveWebApplicationContextRunner =
+        ReactiveWebApplicationContextRunner()
+            .withConfiguration(autoConfiguration)
+            .withClassLoader(FilteredClassLoader("org.springframework.web.servlet"))
+
+    private fun Throwable?.messages(): String =
+        generateSequence(this) {
+            it.cause
+        }.joinToString("\n") { it.message.orEmpty() }
+
+    private companion object {
+        private val autoConfiguration = AutoConfigurations.of(WogeAutoConfiguration::class.java)
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    internal class UseCaseConfiguration {
+        @Bean
+        fun homePage(): PageUseCase<Unit> = PageUseCase { error("not executed during discovery") }
+
+        @Bean
+        fun homeRegions(): DeferredRegionsUseCase<Unit> = DeferredRegionsUseCase { emptyList() }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    internal class CustomContextConfiguration {
+        @Bean
+        fun customWebFluxRequestContextFactory(): WebFluxRequestContextFactory = contexts
+
+        companion object {
+            val contexts = WebFluxRequestContextFactory { error("not executed during startup") }
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    internal class CustomHandlersConfiguration {
+        @Bean
+        fun customWogeWebFluxHandlers(): WogeWebFluxHandlers = handlers
+
+        companion object {
+            val handlers = WogeWebFluxHandlers()
+        }
+    }
+}

--- a/integrations/woge-spring-boot-starter/README.md
+++ b/integrations/woge-spring-boot-starter/README.md
@@ -1,0 +1,6 @@
+# Woge Spring Boot starter
+
+Neutral Spring Boot dependency entry point for Woge. Add exactly one Woge transport adapter and its
+matching Spring web starter alongside this artifact.
+
+Start with [Configure Woge with Spring Boot](../../docs/guides/spring-boot-starter.md).

--- a/integrations/woge-spring-boot-starter/build.gradle.kts
+++ b/integrations/woge-spring-boot-starter/build.gradle.kts
@@ -5,5 +5,40 @@ plugins {
 description = "Spring Boot dependency entry point for Woge applications."
 
 dependencies {
+    api(platform(libs.springBootDependencies))
     api(project(":woge-spring-boot-autoconfigure"))
+}
+
+val verifyNoBundledWebStacks =
+    tasks.register("verifyNoBundledWebStacks") {
+        group = "verification"
+        description = "Verifies that the neutral Woge starter does not transitively bundle a web stack."
+
+        val runtimeClasspath = configurations.named("runtimeClasspath")
+        inputs.files(runtimeClasspath)
+
+        doLast {
+            val bundledModules =
+                inputs.files.files
+                    .map { it.name.removeSuffix(".jar") }
+                    .toSet()
+            val forbidden =
+                setOf(
+                    "spring-webmvc",
+                    "spring-webflux",
+                    "woge-spring-mvc",
+                    "woge-spring-webflux",
+                )
+            val bundledWebStacks =
+                forbidden.filter { forbiddenName ->
+                    bundledModules.any { it.startsWith(forbiddenName) }
+                }
+            check(bundledWebStacks.isEmpty()) {
+                "The neutral Woge starter bundled a web stack: ${bundledWebStacks.sorted()}"
+            }
+        }
+    }
+
+tasks.named("check") {
+    dependsOn(verifyNoBundledWebStacks)
 }


### PR DESCRIPTION
Closes #69

## Outcome

- adds Boot 4.1 auto-configuration registration, typed properties and generated IDE metadata
- deterministically selects WebFlux/MVC and fails with actionable diagnostics for ambiguous, missing or application-type-mismatched setups
- discovers portable page/deferred use-case beans without inventing Spring component scanning for HTML components
- provides overridable request-context and shared WebFlux handler-factory beans
- keeps the generic starter transport-neutral and verifies that it bundles no Spring/Woge web stack
- reports adapter, protocol/runtime versions and discovered use-case counts at startup
- records the dependency and selection policy in ADR 0029 and adds a web-developer-oriented Boot guide

## Verification

- `./gradlew check`
- built JAR contains `AutoConfiguration.imports`, `spring-configuration-metadata.json` and `Implementation-Version`
