### PR TITLE
Add executable Spring Boot web-first quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Woge is an HTML-first Kotlin framework for typed, server-driven and progressively enhanced web applications.
 
-The M0 architecture and product-validation baseline is complete. Implementation begins with the M1 walking skeleton; Woge is not ready for application use yet.
+The M0 architecture and product-validation baseline is complete. The first M1 Spring Boot WebFlux
+vertical slice is executable from the repository; Woge is not ready for production application use yet.
+
+Run the maintained example with `./gradlew :woge-reference-spring-webflux:bootRun`, then open
+`http://localhost:8080/projects/woge`. The [web-first quickstart](docs/guides/quickstart-spring-boot.md)
+explains the page, its full-navigation fallback and the small amount of Kotlin it uses.
 
 ## Direction
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ The documentation grows with executable product slices. Pages describing unimple
 
 ## Start here
 
+- [Spring Boot WebFlux quickstart](guides/quickstart-spring-boot.md)
+- [Kotlin for this web task](guides/kotlin-for-web-developers.md)
 - [Project direction](../README.md)
 - [MVP boundary and definition of done](mvp-boundary.md)
 - [Reference application](product/reference-application.md)
@@ -28,6 +30,8 @@ The documentation grows with executable product slices. Pages describing unimple
 
 ## Implemented API guides
 
+- [Build the first Woge page with Spring Boot](guides/quickstart-spring-boot.md)
+- [Kotlin for the first web task](guides/kotlin-for-web-developers.md)
 - [Render safe HTML values](guides/safe-html-values.md)
 - [Style pages and load assets](guides/css-and-assets.md)
 - [Buffer or stream HTML](guides/stream-html.md)
@@ -67,4 +71,5 @@ The spikes below justify accepted decisions. Their code is evidence, not a produ
 4. **API reference:** list exact types, defaults and compatibility constraints.
 5. **Internals:** explain protocols, generated code and adapter implementation.
 
-Only the architecture and quality foundations exist today. The quick start begins with the walking skeleton.
+The Spring Boot WebFlux quickstart is the first executable vertical slice. MVC and Ktor parity, typed
+interactions and the broader component system remain later milestones.

--- a/docs/adr/0031-root-build-spring-boot-quickstart-consumer.md
+++ b/docs/adr/0031-root-build-spring-boot-quickstart-consumer.md
@@ -1,0 +1,85 @@
+# ADR 0031: Keep the canonical Spring Boot quickstart as a separated root-build consumer
+
+- Status: Accepted
+- Date: 2026-09-05
+- Decision owners: Woge maintainers
+- Related issues: [#73](https://github.com/christian-draeger/woge/issues/73), [#24](https://github.com/christian-draeger/woge/issues/24), [#27](https://github.com/christian-draeger/woge/issues/27), [#74](https://github.com/christian-draeger/woge/issues/74)
+
+## Context
+
+The first guide must prove that the published module boundaries form a usable Spring Boot application,
+not merely show fragments copied from unit tests. It should start with one standard Gradle command,
+exercise immediate HTML plus deferred regions, remain understandable without JavaScript and create the
+seam where Spring MVC and Ktor can be added without rewriting application code.
+
+The first complete document also exposed two gaps in the low-level writer: standards mode required a
+raw HTML escape hatch for the doctype, and familiar elements still required string tag names despite
+ADR 0012 choosing common tag wrappers as the documented path.
+
+## Decision
+
+The maintained reference application joins the root Gradle build as two consumer projects:
+
+- `woge-reference-shared` owns the project data, semantic HTML, `PageUseCase` and deferred regions and
+  has no Spring, Reactor, Servlet or Ktor dependency;
+- `woge-reference-spring-webflux` owns Spring Boot startup, functional routes, static assets and a
+  real-server integration test.
+
+The documented command is `./gradlew :woge-reference-spring-webflux:bootRun`. Root `check` compiles and
+tests both projects. Documentation excerpts point to those canonical sources rather than creating an
+uncompiled sample tree.
+
+The enhanced URL returns a useful HTML shell with three region placeholders. A small ordinary ES
+module fetches the versioned deferred stream and delegates decoding/application to the maintained
+fallback client. The development build copies that client's unbundled canonical source into the
+example resources without requiring Node.js. This is a repository-example convenience, not the final
+browser-package distribution contract.
+
+The same page exposes a normal GET form to `?view=complete`. That full-navigation response renders all
+region content on the server and does not load the patch module. Unknown projects and view modes keep
+ordinary 404 and 400 behavior.
+
+`HtmlWriter.doctype()` writes only the standard `<!doctype html>` declaration. Common document,
+sectioning, text, list, table and form tags receive thin typed wrapper functions over the existing
+writer. Their names and nesting follow HTML; `element(...)` and `voidElement(...)` remain available for
+new, uncommon and custom elements. The wrappers do not add a DOM, widget model or property catalog.
+
+## Alternatives considered
+
+- **Keep snippets only in documentation:** rejected because source can drift and does not prove the
+  dependency graph or Boot startup.
+- **Put portable page and Spring routes in one module:** rejected because framework leakage would be
+  possible before MVC/Ktor parity work begins.
+- **Make JavaScript mandatory for final content:** rejected because the native navigation must remain
+  useful and testable.
+- **Render all data before the initial response:** retained as the explicit full-navigation path but
+  rejected as the only path because it cannot prove completion-order deferred rendering.
+- **Commit a second bundled fallback-client copy:** rejected because generated browser code would have
+  two sources of truth.
+- **Require string names for every HTML tag:** retained as the forward-compatible escape hatch but
+  rejected as the primary guide because common tags should be discoverable and typo-resistant.
+
+## Consequences
+
+### Positive
+
+- The guide, application, adapter wiring and tests describe one executable system.
+- The host-neutral boundary is enforced by Gradle projects rather than prose alone.
+- Web developers can inspect familiar HTML, CSS, JavaScript, URLs, forms and status codes.
+- Common tags gain Kotlin completion while custom and future platform elements remain open.
+- MVC and Ktor can add launchers around the same shared page in #24.
+
+### Negative
+
+- The repository has two additional verification projects and a slower real-server test.
+- The development-only source copy does not define npm/Maven/browser package publication.
+- The initial wrapper set must later be generated or mechanically checked against standards data.
+- The full-navigation query mode is an explicit example policy, not a universal Woge convention.
+
+## Follow-up
+
+- Add Spring MVC and Ktor launchers plus cross-host browser coverage in [#24](https://github.com/christian-draeger/woge/issues/24).
+- Replace manual route/epoch reconstruction with generated descriptors in [#27](https://github.com/christian-draeger/woge/issues/27).
+- Expand compile-verified examples and diagnostics in [#74](https://github.com/christian-draeger/woge/issues/74).
+- Generate the complete standards-derived tag surface in [#131](https://github.com/christian-draeger/woge/issues/131).
+- Publish a normal browser-client consumption path in [#132](https://github.com/christian-draeger/woge/issues/132).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0028](0028-functional-spring-webflux-adapter.md) | Accepted | Adapt Woge through functional Spring WebFlux handlers |
 | [0029](0029-neutral-spring-boot-starter-and-explicit-adapter-selection.md) | Accepted | Keep the Spring Boot starter neutral and adapter selection explicit |
 | [0030](0030-materialize-css-and-head-asset-boundaries.md) | Accepted | Materialize CSS and head asset boundaries without a styling runtime |
+| [0031](0031-root-build-spring-boot-quickstart-consumer.md) | Accepted | Keep the canonical Spring Boot quickstart as a separated root-build consumer |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,6 +1,8 @@
 # Guides
 
-Task-oriented, web-first guides live here. The first executable Spring Boot guide is delivered with the M1 walking skeleton.
+Task-oriented, web-first guides live here. Start with the executable
+[Spring Boot WebFlux quickstart](quickstart-spring-boot.md), then use its focused
+[Kotlin bridge](kotlin-for-web-developers.md) when unfamiliar syntax appears.
 
 Canonical Kotlin examples belong in the root [`examples`](../../examples/README.md) build. Guides link to those sources instead of maintaining a second uncompiled copy.
 

--- a/docs/guides/kotlin-for-web-developers.md
+++ b/docs/guides/kotlin-for-web-developers.md
@@ -1,0 +1,108 @@
+# Kotlin for this web task
+
+You do not need a Kotlin course before reading the Woge quickstart. This page translates the small
+amount of syntax in the project page into concepts you already know from HTML, JavaScript and server
+routes.
+
+## Read declarations from left to right
+
+This request value comes from the compiled
+[`ProjectPage.kt`](../../examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt):
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt -->
+
+```kotlin
+public data class ProjectPageInput(
+    public val project: String,
+    public val view: ProjectPageView = ProjectPageView.SHELL,
+)
+```
+
+- `data class` is a typed value with named fields.
+- `val` makes a read-only field. Use `var` only when a value must be reassigned.
+- The type follows the name: `project: String`.
+- `= ProjectPageView.SHELL` is a default argument.
+- The trailing comma keeps multiline edits tidy; it does not create another value.
+
+Callers can name arguments, which makes route decoding readable: `ProjectPageInput(project = slug,
+view = ProjectPageView.COMPLETE)`.
+
+## Treat HTML blocks as nested callbacks
+
+Woge tag functions take a Kotlin lambda: a block of code passed to a function. Inside the block, the
+current `HtmlWriter` is implicit, so nested markup stays close to nested HTML.
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt -->
+
+```kotlin
+header(attributes = { classes("site-header") }) {
+    nav(attributes = { aria("label", "Primary") }) {
+        a(attributes = { url("href", applicationUrl("/projects/${project.slug}")) }) {
+            text("Projects")
+        }
+    }
+}
+```
+
+The named `attributes = { ... }` block describes the start tag. The final block describes child
+content. `${project.slug}` is string interpolation, like inserting a value into a JavaScript template
+literal. `applicationUrl(...)` validates the completed relative URL; interpolation itself does not
+percent-encode a path or query component.
+
+The tag wrappers give completion for common elements. `element("project-card") { ... }` remains the
+escape hatch for a custom or newly standardized element. `text(value)` is explicit because it escapes
+markup characters; raw HTML needs a separate unsafe opt-in.
+
+## Let `suspend` mark code that can wait
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt -->
+
+```kotlin
+override suspend fun open(request: PageRequest<ProjectPageInput>): PageResult {
+    val project = findProject(request.input.project)
+        ?: return failure(FailureCategory.NOT_FOUND, request.context.correlationId)
+    return htmlPage { renderProjectDocument(project, request.input.view) }
+}
+```
+
+- `fun` declares a function.
+- `suspend fun` can wait for asynchronous work without claiming one thread while it waits.
+- `override` says the function fulfills an interface contract.
+- `PageRequest<ProjectPageInput>` means a page request carrying that input type.
+- `?: return` means “if the value on the left is absent, return the value on the right”. Kotlin writes
+  an optional value as `ProjectSnapshot?`.
+
+The fixed `PageResult` outcomes let the compiler distinguish an HTML document, redirect and safe
+failure. An unknown project becomes a typed `NOT_FOUND` result that WebFlux maps to status 404.
+
+## Interfaces form the application port
+
+The colon after `ProjectPage` lists interfaces it implements:
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt -->
+
+```kotlin
+public class ProjectPage :
+    PageUseCase<ProjectPageInput>,
+    DeferredRegionsUseCase<ProjectPageInput>
+```
+
+`PageUseCase` opens the immediate page. `DeferredRegionsUseCase` declares later region work. Neither
+contains a Spring request, Reactor type or Ktor call. Spring code translates HTTP at the outside edge,
+which is why another host adapter can call the same class.
+
+## Use the compiler as the first feedback loop
+
+The important boundaries are types rather than naming conventions:
+
+- text and raw HTML are different values;
+- application and external URLs are different values;
+- complete stylesheets and declaration lists are different values;
+- a `PageUseCase<ProjectPageInput>` cannot accidentally receive another page's input type.
+
+Run `./gradlew check` after an edit. It compiles the canonical example, starts its real-server test,
+checks the public ABI, formats Kotlin, runs static analysis and validates documentation links. The
+same deterministic gate is intended for human-written and AI-generated Woge applications.
+
+Return to the [Spring Boot quickstart](quickstart-spring-boot.md) or read
+[Render safe HTML values](safe-html-values.md) for the context-specific output rules.

--- a/docs/guides/quickstart-spring-boot.md
+++ b/docs/guides/quickstart-spring-boot.md
@@ -1,0 +1,150 @@
+# Build the first Woge page with Spring Boot
+
+This quickstart runs a real Spring Boot WebFlux application. The browser receives useful HTML first,
+then three independent project regions. Normal CSS styles the page and a small ES module applies the
+updates. A complete page remains available through an ordinary GET form when JavaScript is disabled.
+
+Woge is pre-release. This repository currently uses Woge `0.1.0-SNAPSHOT`, Spring Boot `4.1.1` and a
+JDK 21 toolchain while producing Java 17-compatible JVM bytecode.
+
+## Run one command
+
+From the repository root, run:
+
+```shell
+./gradlew :woge-reference-spring-webflux:bootRun
+```
+
+Open `http://localhost:8080/projects/woge`. Stop the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
+
+The command needs no Node.js installation. Gradle includes the maintained, unbundled Woge browser
+module in this development example. A normal published application will consume a versioned browser
+package through its own asset pipeline once that distribution contract ships.
+
+## Read the page as normal web traffic
+
+The browser-visible flow uses ordinary requests and responses:
+
+1. `GET /projects/woge` returns status 200 and a standards-mode HTML document immediately.
+2. The head loads `/assets/application.css` and `/assets/application.js` through normal `link` and
+   `script type="module"` elements.
+3. The HTML already contains navigation, the project heading, three semantic loading sections and a
+   GET form for the complete page.
+4. The ES module fetches `GET /projects/woge/woge-patches` and passes its byte stream to Woge's small
+   browser adapter.
+5. Summary, activity and task markup replace their matching section contents as server work finishes.
+
+Open the browser Network panel to inspect all of this. Region IDs are opaque registry keys rather than
+CSS selectors. Woge leaves each outer `section`, its classes and its accessibility attributes in place
+while replacing the children.
+
+The real-server test in
+[`WogeQuickstartApplicationTest.kt`](../../examples/reference-application/spring-webflux/src/test/kotlin/dev/woge/example/WogeQuickstartApplicationTest.kt)
+starts the same application on a random port and verifies the HTML, status codes, decoded patch frames,
+full navigation and static assets in `./gradlew check`.
+
+## Write familiar HTML
+
+The canonical page uses tag functions named after HTML elements. This excerpt is compiled from the
+shared example; the [complete document source](../../examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt)
+contains its imports and surrounding functions.
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt -->
+
+```kotlin
+internal fun HtmlWriter.renderProjectDocument(
+    project: ProjectSnapshot,
+    view: ProjectPageView,
+) {
+    doctype()
+    html(attributes = { attribute("lang", "en") }) {
+        renderHead(project, view)
+        renderBody(project, view)
+    }
+}
+
+private fun HtmlWriter.renderHead(
+    project: ProjectSnapshot,
+    view: ProjectPageView,
+) {
+    head {
+        meta { attribute("charset", "utf-8") }
+        metadata("viewport", "width=device-width, initial-scale=1")
+        metadata("description", "A web-native Woge project page")
+        metadata("woge-page-epoch", projectEpoch(project).value)
+        title { text("${project.name} project · Woge quickstart") }
+        stylesheet(applicationUrl("/assets/application.css"))
+        if (view == ProjectPageView.SHELL) {
+            moduleScript(applicationUrl("/assets/application.js"))
+        }
+    }
+}
+```
+
+`text(...)` escapes data. `url("href", applicationUrl(...))` keeps URL handling explicit. Attributes,
+classes, `data-*`, `aria-*`, custom elements and unknown future tags still use the generic writer where
+needed. There is no virtual DOM or mobile-style widget vocabulary.
+
+## Keep application code outside Spring
+
+[`ProjectPage.kt`](../../examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt)
+depends on Woge's host-neutral interfaces, not Spring, Reactor or a server request. It returns the first
+HTML document and declares the independently completing regions.
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt -->
+
+```kotlin
+public class ProjectPage :
+    PageUseCase<ProjectPageInput>,
+    DeferredRegionsUseCase<ProjectPageInput> {
+    override suspend fun open(request: PageRequest<ProjectPageInput>): PageResult {
+        val project = findProject(request.input.project)
+            ?: return failure(FailureCategory.NOT_FOUND, request.context.correlationId)
+        return htmlPage { renderProjectDocument(project, request.input.view) }
+    }
+
+    override suspend fun regions(request: PageRequest<ProjectPageInput>): Iterable<DeferredRegion> {
+        val project = findProject(request.input.project) ?: return emptyList()
+        return deferredRegions(project)
+    }
+}
+```
+
+This is the application-side port in a ports-and-adapters architecture. The same class is the input to
+future Spring MVC and Ktor launchers in issue #24.
+
+Spring-specific code stays in
+[`ProjectRoutes.kt`](../../examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/ProjectRoutes.kt).
+It keeps paths, path variables, query parameters and HTTP methods visible:
+
+<!-- snippet: examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/ProjectRoutes.kt -->
+
+```kotlin
+return coRouter {
+    GET("/projects/{project}", page::handle)
+    GET("/projects/{project}/woge-patches", patches::handle)
+}
+```
+
+The neutral Woge starter selects and configures the WebFlux adapter. It does not make Spring a core
+dependency and does not bundle MVC and WebFlux together.
+
+## See progressive enhancement fail safely
+
+Disable JavaScript and reload `/projects/woge`. The server HTML still exposes the project identity,
+navigation, headings, loading state and a normal form. Submit **Load the complete page instead**. The
+browser navigates to `GET /projects/woge?view=complete`, and the server returns all three sections in
+one HTML response without the patch module.
+
+An unknown project returns 404. An unknown `view` query value returns 400. The patch endpoint returns
+its versioned media type with `Cache-Control: no-store`. These remain ordinary HTTP outcomes; Woge
+does not hide them behind a client state machine.
+
+The example's [`application.js`](../../examples/reference-application/spring-webflux/src/main/resources/static/assets/application.js)
+uses standard `fetch`, `ReadableStream` and ES modules. Its
+[`application.css`](../../examples/reference-application/spring-webflux/src/main/resources/static/assets/application.css)
+uses cascade layers, nesting, logical properties and a container query. Replace either with your normal
+frontend toolchain; Woge does not require a CSS or JavaScript replacement.
+
+Next, read [Kotlin for this web task](kotlin-for-web-developers.md). It explains only the syntax used
+above. The [Spring Boot integration guide](spring-boot-starter.md) covers adapter selection and limits.

--- a/docs/guides/safe-html-values.md
+++ b/docs/guides/safe-html-values.md
@@ -3,9 +3,8 @@
 Woge renders ordinary text and attributes as data, even when their contents look like markup. Use a
 different API only when the browser will parse the value in a different context, such as a URL.
 
-The API on this page is available from `woge-core`. The common `div`, `a` and `input` wrappers planned
-for M1 are not implemented yet, so this guide shows the lower-level `element` and `voidElement`
-fallbacks.
+The API on this page is available from `woge-core`. Common tags use familiar wrappers such as `article`,
+`a` and `input`; `element` and `voidElement` remain available for custom, uncommon and new tags.
 
 ## Render text and attributes
 
@@ -15,8 +14,7 @@ The compiled example renders a project card with familiar HTML attributes:
 
 ```kotlin
 val html = renderHtml {
-    element(
-        "article",
+    article(
         attributes = {
             classes("project-card", "grid gap-3", "md:grid-cols-[1fr_auto]")
             data("project-id", "woge-7")
@@ -25,8 +23,8 @@ val html = renderHtml {
             styles(declarations("--accent: oklch(62% 0.2 250);"))
         },
     ) {
-        element("h2") { text("Woge <preview>") }
-        element("a", attributes = { url("href", applicationUrl("/projects/woge-7")) }) {
+        h2 { text("Woge <preview>") }
+        a(attributes = { url("href", applicationUrl("/projects/woge-7")) }) {
             text("Open & inspect")
         }
     }
@@ -45,7 +43,7 @@ the start tag. Named arguments make those two lambdas unambiguous for readers wh
 HTML Boolean attributes use presence, not the strings `"true"` and `"false"`:
 
 ```kotlin
-voidElement("input", attributes = { boolean("disabled", formIsLocked) })
+input { boolean("disabled", formIsLocked) }
 ```
 
 When `formIsLocked` is false, Woge omits `disabled`. Enumerated attributes such as

--- a/docs/guides/spring-boot-starter.md
+++ b/docs/guides/spring-boot-starter.md
@@ -3,6 +3,8 @@
 The Woge starter configures shared policy and selects one server adapter. You still write normal
 Spring routes, choose normal HTTP methods and use the browser as a browser.
 
+For a complete runnable page first, use the [Spring Boot WebFlux quickstart](quickstart-spring-boot.md).
+
 ## Add one web stack
 
 For the implemented WebFlux path, an application uses these three dependencies:

--- a/docs/reviews/first-web-developer-quickstart.md
+++ b/docs/reviews/first-web-developer-quickstart.md
@@ -1,0 +1,24 @@
+# First web-developer quickstart terminology review
+
+- Date: 2026-09-05
+- Scope: Spring Boot WebFlux quickstart from a fresh repository checkout
+- Perspective: structured maintainer proxy review using the documented target reader—comfortable with
+  HTML, CSS, JavaScript and HTTP, but new to Kotlin
+- Evidence: canonical example compilation, real-server integration test and no-JavaScript walkthrough
+
+This is the first terminology pass, not a substitute for an independent usability study before beta.
+Each confusing point below has either been fixed in #73 or assigned to a concrete follow-up.
+
+| Observation | Resolution |
+| --- | --- |
+| `element("h1")` looked like a string-template API and hid tag completion | Added thin common-tag wrappers such as `h1 {}`, `form {}` and `table {}`; standards-derived expansion is tracked by [#131](https://github.com/christian-draeger/woge/issues/131) |
+| `suspend`, receiver lambdas, named arguments and `?: return` interrupted the web task | Added the task-scoped [Kotlin bridge](../guides/kotlin-for-web-developers.md) and avoided a general language detour |
+| `PageUseCase` and `DeferredRegionsUseCase` sounded framework-internal | The guide defines them once as the host-neutral application port and shows Spring routes separately |
+| Page epoch, region ID and patch URL reconstruction is visible but repetitive | Keep it explicit in the first slice; generated host-neutral descriptors remain owned by [#27](https://github.com/christian-draeger/woge/issues/27) |
+| Copying browser source into example resources is not a normal consumer installation story | The guide labels it development-only; versioned browser-package consumption is tracked by [#132](https://github.com/christian-draeger/woge/issues/132) |
+| A loading shell could be mistaken for the no-JavaScript end state | Added a visible GET form and `noscript` link to the complete server-rendered response, plus an explicit disable-JavaScript walkthrough |
+
+The first independent reviewer should run only the public quickstart and record time-to-page, terms
+looked up, compiler errors, browser observations and whether the fallback was discoverable. Repeated
+problems feed [#74](https://github.com/christian-draeger/woge/issues/74) and the consumer AI-DX run in
+[#93](https://github.com/christian-draeger/woge/issues/93).

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,5 @@ Maintained documentation examples live below this directory and join the root ve
 they are executable. They use supported public APIs and compile in `./gradlew check`.
 
 Do not copy spike packages into examples. The first maintained consumer is the
-[multi-host reference application](reference-application/README.md).
+[reference application](reference-application/README.md), whose Spring Boot WebFlux launcher and
+host-neutral page are part of the root build.

--- a/examples/reference-application/README.md
+++ b/examples/reference-application/README.md
@@ -1,9 +1,21 @@
 # Reference application
 
-This directory is the maintained multi-host consumer of Woge's public modules. Its project-operations
-domain and journeys are defined in [ADR 0004](../../docs/adr/0004-project-operations-reference-application.md).
+This directory is the maintained consumer of Woge's public modules. Its project-operations domain and
+journeys are defined in [ADR 0004](../../docs/adr/0004-project-operations-reference-application.md).
 
-The application will share framework-neutral page and domain code while keeping Spring MVC, Spring
-WebFlux and Ktor launchers at the outer edge. It is a build consumer and executable documentation, not
-a production Woge artifact. Issue [#24](https://github.com/christian-draeger/woge/issues/24) owns the
-complete walking-skeleton slice.
+Run its first host with:
+
+```shell
+./gradlew :woge-reference-spring-webflux:bootRun
+```
+
+Then open `http://localhost:8080/projects/woge`.
+
+[`shared`](shared) contains the host-neutral `ProjectPage`, semantic HTML and region work.
+[`spring-webflux`](spring-webflux) contains only Spring Boot startup, functional routes, static assets
+and the real-server integration test. The example consumes root projects and is verified by
+`./gradlew check`; it is executable documentation, not a published Woge artifact.
+
+The [quickstart](../../docs/guides/quickstart-spring-boot.md) explains the observable web behavior.
+Issue [#24](https://github.com/christian-draeger/woge/issues/24) adds MVC and Ktor launchers around the
+same `shared` code.

--- a/examples/reference-application/shared/build.gradle.kts
+++ b/examples/reference-application/shared/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Host-neutral project page used by the executable Woge reference application."
+
+dependencies {
+    api(project(":woge-host-spi"))
+
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectData.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectData.kt
@@ -1,0 +1,36 @@
+package dev.woge.example.project
+
+internal data class ProjectSnapshot(
+    val slug: String,
+    val name: String,
+    val tasks: List<ProjectTask>,
+    val activity: List<ProjectActivity>,
+)
+
+internal data class ProjectTask(
+    val title: String,
+    val owner: String,
+    val status: String,
+)
+
+internal data class ProjectActivity(
+    val description: String,
+    val date: String,
+)
+
+internal val REFERENCE_PROJECT: ProjectSnapshot =
+    ProjectSnapshot(
+        slug = "woge",
+        name = "Woge",
+        tasks =
+            listOf(
+                ProjectTask("Publish the first web-first guide", "Ada", "In progress"),
+                ProjectTask("Verify the deferred browser path", "Lin", "Open"),
+                ProjectTask("Record the architecture decision", "Sam", "Complete"),
+            ),
+        activity =
+            listOf(
+                ProjectActivity("Standards-native CSS contract implemented", "2026-09-05"),
+                ProjectActivity("Spring Boot adapter selected", "2026-09-05"),
+            ),
+    )

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt
@@ -1,0 +1,133 @@
+package dev.woge.example.project
+
+import dev.woge.host.regionPlaceholder
+import dev.woge.html.HtmlWriter
+import dev.woge.html.a
+import dev.woge.html.applicationUrl
+import dev.woge.html.body
+import dev.woge.html.button
+import dev.woge.html.footer
+import dev.woge.html.form
+import dev.woge.html.h1
+import dev.woge.html.head
+import dev.woge.html.header
+import dev.woge.html.html
+import dev.woge.html.main
+import dev.woge.html.meta
+import dev.woge.html.metadata
+import dev.woge.html.moduleScript
+import dev.woge.html.nav
+import dev.woge.html.noscript
+import dev.woge.html.p
+import dev.woge.html.stylesheet
+import dev.woge.html.title
+
+internal fun HtmlWriter.renderProjectDocument(
+    project: ProjectSnapshot,
+    view: ProjectPageView,
+) {
+    doctype()
+    html(attributes = { attribute("lang", "en") }) {
+        renderHead(project, view)
+        renderBody(project, view)
+    }
+}
+
+private fun HtmlWriter.renderHead(
+    project: ProjectSnapshot,
+    view: ProjectPageView,
+) {
+    head {
+        meta { attribute("charset", "utf-8") }
+        metadata("viewport", "width=device-width, initial-scale=1")
+        metadata("description", "A web-native Woge project page")
+        metadata("woge-page-epoch", projectEpoch(project).value)
+        title { text("${project.name} project · Woge quickstart") }
+        stylesheet(applicationUrl("/assets/application.css"))
+        if (view == ProjectPageView.SHELL) {
+            moduleScript(applicationUrl("/assets/application.js"))
+        }
+    }
+}
+
+private fun HtmlWriter.renderBody(
+    project: ProjectSnapshot,
+    view: ProjectPageView,
+) {
+    body(
+        attributes = {
+            classes("project-page")
+            if (view == ProjectPageView.SHELL) {
+                data("woge-patch-url", "/projects/${project.slug}/woge-patches")
+            }
+        },
+    ) {
+        a(attributes = {
+            classes("skip-link")
+            url("href", applicationUrl("#main-content"))
+        }) {
+            text("Skip to project content")
+        }
+        header(attributes = { classes("site-header") }) {
+            nav(attributes = { aria("label", "Primary") }) {
+                a(attributes = { url("href", applicationUrl("/projects/${project.slug}")) }) {
+                    text("Projects")
+                }
+            }
+        }
+        main(attributes = {
+            attribute("id", "main-content")
+            classes("page-shell")
+        }) {
+            p(attributes = { classes("eyebrow") }) { text("Spring Boot WebFlux quickstart") }
+            h1 { text(project.name) }
+            p(attributes = { classes("lede") }) {
+                text("The server sent this useful HTML shell first. Independent regions can follow in any order.")
+            }
+            if (view == ProjectPageView.COMPLETE) {
+                renderCompleteProject(project)
+            } else {
+                renderFullNavigationFallback(project)
+                renderDeferredProject(project)
+            }
+        }
+        footer(attributes = { classes("site-footer") }) {
+            text("Normal HTML, CSS, URLs and HTTP remain the application contract.")
+        }
+    }
+}
+
+private fun HtmlWriter.renderFullNavigationFallback(project: ProjectSnapshot) {
+    val completeUrl = applicationUrl("/projects/${project.slug}?view=complete")
+    noscript {
+        p(attributes = { classes("notice") }) {
+            text("JavaScript is off. ")
+            a(attributes = { url("href", completeUrl) }) {
+                text("Load all project data as one complete page.")
+            }
+        }
+    }
+    form(attributes = {
+        url("action", applicationUrl("/projects/${project.slug}"))
+        attribute("method", "get")
+    }) {
+        button(
+            attributes = {
+                attribute("type", "submit")
+                attribute("name", "view")
+                attribute("value", "complete")
+            },
+        ) {
+            text("Load the complete page instead")
+        }
+    }
+}
+
+private fun HtmlWriter.renderDeferredProject(project: ProjectSnapshot) {
+    deferredRegions(project).forEach { region ->
+        regionPlaceholder(region, elementName = "section") {
+            classes("project-region", "is-loading")
+            aria("labelledby", "${region.target.region.value}-heading")
+        }
+    }
+}

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt
@@ -1,0 +1,96 @@
+package dev.woge.example.project
+
+import dev.woge.host.DeferredRegion
+import dev.woge.host.DeferredRegionFailure
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.FailureCategory
+import dev.woge.host.PageRequest
+import dev.woge.host.PageResult
+import dev.woge.host.PageUseCase
+import dev.woge.host.deferredRegion
+import dev.woge.host.failure
+import dev.woge.host.htmlPage
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.patchHtml
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+
+/** Selects the immediate enhanced shell or a complete full-navigation response. */
+public enum class ProjectPageView {
+    SHELL,
+    COMPLETE,
+}
+
+/** Route input decoded by a host adapter before portable page code runs. */
+public data class ProjectPageInput(
+    public val project: String,
+    public val view: ProjectPageView = ProjectPageView.SHELL,
+)
+
+/** Host-neutral project page used unchanged by Spring WebFlux and future MVC/Ktor launchers. */
+public class ProjectPage :
+    PageUseCase<ProjectPageInput>,
+    DeferredRegionsUseCase<ProjectPageInput> {
+    override suspend fun open(request: PageRequest<ProjectPageInput>): PageResult {
+        val project =
+            findProject(request.input.project)
+                ?: return failure(FailureCategory.NOT_FOUND, request.context.correlationId)
+        return htmlPage { renderProjectDocument(project, request.input.view) }
+    }
+
+    override suspend fun regions(request: PageRequest<ProjectPageInput>): Iterable<DeferredRegion> {
+        val project = findProject(request.input.project) ?: return emptyList()
+        return deferredRegions(project)
+    }
+}
+
+private fun findProject(slug: String): ProjectSnapshot? = REFERENCE_PROJECT.takeIf { it.slug == slug }
+
+internal fun deferredRegions(project: ProjectSnapshot): List<DeferredRegion> =
+    listOf(
+        projectRegion(project, "summary", "Project summary", SUMMARY_DELAY_MILLIS) { renderSummary(project) },
+        projectRegion(project, "tasks", "Tasks", TASKS_DELAY_MILLIS) { renderTasks(project) },
+        projectRegion(project, "activity", "Recent activity", ACTIVITY_DELAY_MILLIS) { renderActivity(project) },
+    )
+
+private fun projectRegion(
+    project: ProjectSnapshot,
+    region: String,
+    title: String,
+    delayMillis: Long,
+    content: dev.woge.html.HtmlWriter.() -> Unit,
+): DeferredRegion =
+    deferredRegion(
+        target = projectTarget(project, region),
+        loading = { renderRegionLoading(region, title) },
+        onFailure = { failure ->
+            patchHtml { renderRegionFailure(project, region, title, failure) }
+        },
+        content = {
+            delay(delayMillis.milliseconds)
+            patchHtml(content)
+        },
+    )
+
+private fun projectTarget(
+    project: ProjectSnapshot,
+    region: String,
+): PatchTarget =
+    PatchTarget(
+        pageEpoch = projectEpoch(project),
+        region = RegionTargetId.of(region),
+    )
+
+internal fun projectEpoch(project: ProjectSnapshot): PageEpoch = PageEpoch.of("quickstart-${project.slug}")
+
+internal fun failureLabel(failure: DeferredRegionFailure): String =
+    when (failure) {
+        DeferredRegionFailure.TIMED_OUT -> "took too long"
+        DeferredRegionFailure.FAILED -> "could not be loaded"
+    }
+
+private const val SUMMARY_DELAY_MILLIS: Long = 120
+private const val TASKS_DELAY_MILLIS: Long = 360
+private const val ACTIVITY_DELAY_MILLIS: Long = 220

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectRegionMarkup.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectRegionMarkup.kt
@@ -1,0 +1,124 @@
+package dev.woge.example.project
+
+import dev.woge.host.DeferredRegionFailure
+import dev.woge.html.HtmlWriter
+import dev.woge.html.a
+import dev.woge.html.applicationUrl
+import dev.woge.html.caption
+import dev.woge.html.dd
+import dev.woge.html.div
+import dev.woge.html.dl
+import dev.woge.html.dt
+import dev.woge.html.h2
+import dev.woge.html.li
+import dev.woge.html.ol
+import dev.woge.html.p
+import dev.woge.html.section
+import dev.woge.html.table
+import dev.woge.html.tbody
+import dev.woge.html.td
+import dev.woge.html.th
+import dev.woge.html.thead
+import dev.woge.html.time
+import dev.woge.html.tr
+
+internal fun HtmlWriter.renderCompleteProject(project: ProjectSnapshot) {
+    section(attributes = {
+        classes("project-region")
+        aria("labelledby", "summary-heading")
+    }) {
+        renderSummary(project)
+    }
+    section(attributes = {
+        classes("project-region")
+        aria("labelledby", "tasks-heading")
+    }) {
+        renderTasks(project)
+    }
+    section(attributes = {
+        classes("project-region")
+        aria("labelledby", "activity-heading")
+    }) {
+        renderActivity(project)
+    }
+}
+
+internal fun HtmlWriter.renderSummary(project: ProjectSnapshot) {
+    h2(attributes = { attribute("id", "summary-heading") }) { text("Project summary") }
+    dl(attributes = { classes("summary-grid") }) {
+        metric("Open tasks", project.tasks.count { it.status != "Complete" })
+        metric("Completed tasks", project.tasks.count { it.status == "Complete" })
+        metric("Recent events", project.activity.size)
+    }
+}
+
+internal fun HtmlWriter.renderTasks(project: ProjectSnapshot) {
+    h2(attributes = { attribute("id", "tasks-heading") }) { text("Tasks") }
+    table {
+        caption { text("Current tasks for ${project.name}") }
+        thead {
+            tr {
+                tableHeading("Task")
+                tableHeading("Owner")
+                tableHeading("Status")
+            }
+        }
+        tbody {
+            project.tasks.forEach { task ->
+                tr {
+                    th(attributes = { attribute("scope", "row") }) { text(task.title) }
+                    td { text(task.owner) }
+                    td { text(task.status) }
+                }
+            }
+        }
+    }
+}
+
+internal fun HtmlWriter.renderActivity(project: ProjectSnapshot) {
+    h2(attributes = { attribute("id", "activity-heading") }) { text("Recent activity") }
+    ol(attributes = { classes("activity-list") }) {
+        project.activity.forEach { event ->
+            li {
+                text(event.description)
+                text(" · ")
+                time(attributes = { attribute("datetime", event.date) }) { text(event.date) }
+            }
+        }
+    }
+}
+
+internal fun HtmlWriter.renderRegionLoading(
+    region: String,
+    title: String,
+) {
+    h2(attributes = { attribute("id", "$region-heading") }) { text(title) }
+    p { text("Loading from the server…") }
+}
+
+internal fun HtmlWriter.renderRegionFailure(
+    project: ProjectSnapshot,
+    region: String,
+    title: String,
+    failure: DeferredRegionFailure,
+) {
+    h2(attributes = { attribute("id", "$region-heading") }) { text(title) }
+    p { text("This region ${failureLabel(failure)}. ") }
+    a(attributes = { url("href", applicationUrl("/projects/${project.slug}?view=complete")) }) {
+        text("Load the complete page")
+    }
+}
+
+private fun HtmlWriter.metric(
+    label: String,
+    value: Int,
+) {
+    div {
+        dt { text(label) }
+        dd { text(value.toString()) }
+    }
+}
+
+private fun HtmlWriter.tableHeading(label: String) {
+    th(attributes = { attribute("scope", "col") }) { text(label) }
+}

--- a/examples/reference-application/spring-webflux/build.gradle.kts
+++ b/examples/reference-application/spring-webflux/build.gradle.kts
@@ -1,0 +1,25 @@
+import org.gradle.language.jvm.tasks.ProcessResources
+
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+    alias(libs.plugins.springBoot)
+}
+
+description = "Executable Spring Boot WebFlux quickstart for Woge."
+
+dependencies {
+    implementation(project(":woge-reference-shared"))
+    implementation(project(":woge-spring-boot-starter"))
+    implementation(project(":woge-spring-webflux"))
+    implementation(libs.springBootStarterWebflux)
+
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.named<ProcessResources>("processResources") {
+    from(rootProject.layout.projectDirectory.dir("client/woge-fallback-client/src")) {
+        include("*.js")
+        into("static/assets/woge")
+    }
+}

--- a/examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/ProjectRoutes.kt
+++ b/examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/ProjectRoutes.kt
@@ -1,0 +1,51 @@
+package dev.woge.example
+
+import dev.woge.example.project.ProjectPage
+import dev.woge.example.project.ProjectPageInput
+import dev.woge.example.project.ProjectPageView
+import dev.woge.spring.webflux.WebFluxPageInput
+import dev.woge.spring.webflux.WogeWebFluxHandlers
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.server.ResponseStatusException
+
+/** Connects normal HTTP routes to the framework-neutral project page. */
+@Configuration(proxyBeanMethods = false)
+public class ProjectRoutes {
+    /** Keeps application paths and query-string behavior visible at the host boundary. */
+    @Bean
+    public fun projectHttpRoutes(
+        projectPage: ProjectPage,
+        handlers: WogeWebFluxHandlers,
+    ): RouterFunction<ServerResponse> {
+        val pageInput =
+            WebFluxPageInput<ProjectPageInput> { request ->
+                ProjectPageInput(
+                    project = request.pathVariable("project"),
+                    view = parseView(request.queryParam("view").orElse("")),
+                )
+            }
+        val patchInput =
+            WebFluxPageInput<ProjectPageInput> { request ->
+                ProjectPageInput(request.pathVariable("project"))
+            }
+        val page = handlers.page(projectPage, pageInput)
+        val patches = handlers.deferred(projectPage, patchInput)
+
+        return coRouter {
+            GET("/projects/{project}", page::handle)
+            GET("/projects/{project}/woge-patches", patches::handle)
+        }
+    }
+}
+
+private fun parseView(value: String): ProjectPageView =
+    when (value) {
+        "" -> ProjectPageView.SHELL
+        "complete" -> ProjectPageView.COMPLETE
+        else -> throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown project view")
+    }

--- a/examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/WogeQuickstartApplication.kt
+++ b/examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/WogeQuickstartApplication.kt
@@ -1,0 +1,20 @@
+package dev.woge.example
+
+import dev.woge.example.project.ProjectPage
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+
+/** Starts the maintained Woge quickstart on Spring Boot WebFlux. */
+@SpringBootApplication(proxyBeanMethods = false)
+public class WogeQuickstartApplication {
+    /** Portable application entry point discovered by Woge's Spring Boot integration. */
+    @Bean
+    public fun projectPage(): ProjectPage = ProjectPage()
+}
+
+/** Runs the quickstart with Spring Boot's normal application lifecycle. */
+@Suppress("SpreadOperator")
+public fun main(args: Array<String>) {
+    runApplication<WogeQuickstartApplication>(*args)
+}

--- a/examples/reference-application/spring-webflux/src/main/resources/application.properties
+++ b/examples/reference-application/spring-webflux/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.application.name=woge-quickstart
+spring.main.web-application-type=reactive
+woge.adapter=webflux

--- a/examples/reference-application/spring-webflux/src/main/resources/static/assets/application.css
+++ b/examples/reference-application/spring-webflux/src/main/resources/static/assets/application.css
@@ -1,0 +1,122 @@
+@layer reset, page, components;
+
+@layer reset {
+  *, *::before, *::after { box-sizing: border-box; }
+
+  html { color-scheme: light dark; }
+
+  body { margin: 0; }
+
+  button, input, select, textarea { font: inherit; }
+}
+
+@layer page {
+  :root {
+    --surface: light-dark(#f8fafc, #111827);
+    --panel: light-dark(#ffffff, #1f2937);
+    --text: light-dark(#172033, #f8fafc);
+    --muted: light-dark(#526178, #cbd5e1);
+    --accent: light-dark(#3451d1, #8ea2ff);
+    --line: light-dark(#d8e0eb, #435069);
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    background: var(--surface);
+    color: var(--text);
+  }
+
+  .project-page {
+    min-block-size: 100dvb;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+  }
+
+  .site-header,
+  .site-footer,
+  .page-shell {
+    inline-size: min(72rem, calc(100% - 2rem));
+    margin-inline: auto;
+  }
+
+  .site-header,
+  .site-footer { padding-block: 1.25rem; }
+
+  .page-shell { padding-block: clamp(2rem, 6vw, 5rem); }
+
+  a { color: var(--accent); }
+
+  :focus-visible { outline: 0.2rem solid var(--accent); outline-offset: 0.2rem; }
+
+  .skip-link {
+    position: fixed;
+    inset-block-start: 0.5rem;
+    inset-inline-start: 0.5rem;
+    translate: 0 -200%;
+    background: var(--panel);
+    padding: 0.75rem;
+    z-index: 10;
+
+    &:focus { translate: 0; }
+  }
+
+  .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+
+  h1 { font-size: clamp(2.5rem, 8vw, 5rem); line-height: 0.95; margin-block: 0.35rem 1rem; }
+
+  .lede { max-inline-size: 62ch; color: var(--muted); font-size: 1.125rem; }
+}
+
+@layer components {
+  form { margin-block: 1.5rem; }
+
+  button {
+    border: 1px solid var(--accent);
+    border-radius: 0.5rem;
+    padding: 0.65rem 0.9rem;
+    background: var(--accent);
+    color: #fff;
+    cursor: pointer;
+  }
+
+  .notice,
+  .project-region {
+    border: 1px solid var(--line);
+    border-radius: 0.85rem;
+    background: var(--panel);
+    padding: clamp(1rem, 3vw, 1.5rem);
+  }
+
+  .project-region {
+    container-type: inline-size;
+    margin-block: 1rem;
+
+    & > h2 { margin-block-start: 0; }
+  }
+
+  .is-loading { color: var(--muted); }
+
+  .summary-grid {
+    display: grid;
+    gap: 1rem;
+
+    & > div { display: grid; gap: 0.25rem; }
+
+    dt { color: var(--muted); }
+
+    dd { margin: 0; font-size: 1.75rem; font-weight: 700; }
+  }
+
+  @container (width >= 32rem) {
+    .summary-grid { grid-template-columns: repeat(3, 1fr); }
+  }
+
+  table { inline-size: 100%; border-collapse: collapse; }
+
+  caption { text-align: start; color: var(--muted); margin-block-end: 0.75rem; }
+
+  th, td { text-align: start; border-block-end: 1px solid var(--line); padding: 0.75rem 0.5rem; }
+
+  .activity-list { padding-inline-start: 1.25rem; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .project-region { transition: border-color 160ms ease; }
+}

--- a/examples/reference-application/spring-webflux/src/main/resources/static/assets/application.js
+++ b/examples/reference-application/spring-webflux/src/main/resources/static/assets/application.js
@@ -1,0 +1,21 @@
+import { createWogePatchRuntime } from "./woge/index.js";
+
+const page = document.querySelector("[data-woge-patch-url]");
+
+if (page) {
+  void loadDeferredRegions(page.dataset.wogePatchUrl);
+}
+
+async function loadDeferredRegions(url) {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/vnd.woge.patch-stream; version=1" },
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`Deferred request failed with HTTP ${response.status}`);
+    }
+    await createWogePatchRuntime(document).applyPatchStream(response.body);
+  } catch (problem) {
+    console.error("Woge enhancement stopped; the full-page form remains available.", problem);
+  }
+}

--- a/examples/reference-application/spring-webflux/src/test/kotlin/dev/woge/example/WogeQuickstartApplicationTest.kt
+++ b/examples/reference-application/spring-webflux/src/test/kotlin/dev/woge/example/WogeQuickstartApplicationTest.kt
@@ -1,0 +1,102 @@
+package dev.woge.example
+
+import dev.woge.protocol.PatchStreamEvent
+import dev.woge.protocol.PatchStreamV1
+import dev.woge.protocol.ReplacePatch
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.web.server.context.ConfigurableWebServerApplicationContext
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class WogeQuickstartApplicationTest {
+    @Test
+    fun `fresh application serves shell deferred regions full navigation and ordinary assets`() {
+        SpringApplication(WogeQuickstartApplication::class.java)
+            .apply {
+                setDefaultProperties(
+                    mapOf(
+                        "server.port" to "0",
+                        "spring.main.banner-mode" to "off",
+                        "logging.level.root" to "WARN",
+                    ),
+                )
+            }.run()
+            .use { context -> verifyApplication(context as ConfigurableWebServerApplicationContext) }
+    }
+
+    private fun verifyApplication(context: ConfigurableWebServerApplicationContext) {
+        val origin = "http://127.0.0.1:${requireNotNull(context.webServer).port}"
+        val shell = get(origin, "/projects/woge")
+
+        assertEquals(200, shell.statusCode())
+        assertTrue(shell.header("content-type").startsWith("text/html"))
+        assertTrue(shell.body().startsWith("<!doctype html><html lang=\"en\">"))
+        assertTrue(shell.body().contains("data-woge-region=\"summary\""))
+        assertTrue(shell.body().contains("action=\"/projects/woge\" method=\"get\""))
+        assertTrue(shell.body().contains("src=\"/assets/application.js\""))
+        assertFalse(shell.body().contains("Publish the first web-first guide"))
+
+        val patches = getBytes(origin, "/projects/woge/woge-patches")
+        assertEquals(200, patches.statusCode())
+        assertTrue(patches.header("content-type").startsWith("application/vnd.woge.patch-stream"))
+        assertTrue(patches.header("content-type").contains("version=1"))
+        val events = decode(patches.body())
+        val frames = events.filterIsInstance<PatchStreamEvent.PatchFrame>()
+        assertEquals(setOf("summary", "tasks", "activity"), frames.map { it.patch.target.region.value }.toSet())
+        assertEquals(PatchStreamEvent.Complete(3), events.last())
+        assertTrue(frames.any { (it.patch as ReplacePatch).html.value.contains("Publish the first web-first guide") })
+
+        val complete = get(origin, "/projects/woge?view=complete")
+        assertEquals(200, complete.statusCode())
+        assertTrue(complete.body().contains("Publish the first web-first guide"))
+        assertFalse(complete.body().contains("data-woge-region"))
+        assertFalse(complete.body().contains("src=\"/assets/application.js\""))
+
+        assertEquals(404, get(origin, "/projects/missing").statusCode())
+        assertEquals(400, get(origin, "/projects/woge?view=unknown").statusCode())
+
+        val css = get(origin, "/assets/application.css")
+        assertTrue(css.body().contains("@container (width >= 32rem)"))
+        val javascript = get(origin, "/assets/application.js")
+        assertTrue(javascript.body().contains("createWogePatchRuntime"))
+        val runtime = get(origin, "/assets/woge/index.js")
+        assertTrue(runtime.body().contains("export function createWogePatchRuntime"))
+    }
+
+    private fun decode(bytes: ByteArray): List<PatchStreamEvent> {
+        val decoder = PatchStreamV1.decoder()
+        val events = decoder.feed(bytes)
+        decoder.finish()
+        return events
+    }
+
+    private fun get(
+        origin: String,
+        path: String,
+    ): HttpResponse<String> =
+        CLIENT.send(
+            HttpRequest.newBuilder(URI.create(origin + path)).GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun getBytes(
+        origin: String,
+        path: String,
+    ): HttpResponse<ByteArray> =
+        CLIENT.send(
+            HttpRequest.newBuilder(URI.create(origin + path)).GET().build(),
+            HttpResponse.BodyHandlers.ofByteArray(),
+        )
+
+    private fun <T> HttpResponse<T>.header(name: String): String = headers().firstValue(name).orElseThrow()
+
+    private companion object {
+        private val CLIENT: HttpClient = HttpClient.newHttpClient()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmhGradle" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
+springBoot = { id = "org.springframework.boot", version.ref = "springBoot" }
 
 [libraries]
 assertjCore = { module = "org.assertj:assertj-core" }
@@ -36,6 +37,7 @@ springBoot = { module = "org.springframework.boot:spring-boot" }
 springBootAutoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
 springBootConfigurationProcessor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "springBoot" }
 springBootDependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
+springBootStarterWebflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
 springBootTest = { module = "org.springframework.boot:spring-boot-test" }
 springContext = { module = "org.springframework:spring-context" }
 springWebmvc = { module = "org.springframework:spring-webmvc" }

--- a/modules/woge-core/api/woge-core.api
+++ b/modules/woge-core/api/woge-core.api
@@ -89,6 +89,21 @@ public final class dev/woge/html/CspNonce {
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
+public final class dev/woge/html/DocumentTagsKt {
+	public static final fun body (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun body$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun head (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun head$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun html (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun html$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun meta (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun meta$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun noscript (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun noscript$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun title (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun title$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
 public final class dev/woge/html/ExternalUrl : dev/woge/html/HtmlUrl {
 	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/woge/html/ExternalUrl;
 	public fun equals (Ljava/lang/Object;)Z
@@ -100,6 +115,23 @@ public final class dev/woge/html/ExternalUrl : dev/woge/html/HtmlUrl {
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/html/FormTagsKt {
+	public static final fun button (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun button$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun form (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun form$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun input (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun input$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun label (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun label$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun option (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun option$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun select (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun select$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun textarea (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun textarea$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class dev/woge/html/HeadAssetsKt {
@@ -142,6 +174,7 @@ public final class dev/woge/html/HtmlValuesKt {
 }
 
 public final class dev/woge/html/HtmlWriter {
+	public final fun doctype ()V
 	public final fun element (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun element$default (Ldev/woge/html/HtmlWriter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun raw-WmHVnZ8 (Ljava/lang/String;)V
@@ -154,6 +187,40 @@ public final class dev/woge/html/HtmlWriterKt {
 	public static final fun renderHtml (Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public static final fun srcdoc-mHIzVm8 (Ldev/woge/html/Attributes;Ljava/lang/String;)V
 	public static final fun writeHtml (Ldev/woge/html/HtmlSink;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class dev/woge/html/ListTagsKt {
+	public static final fun dd (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun dd$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun dl (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun dl$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun dt (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun dt$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun li (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun li$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun ol (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun ol$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun ul (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun ul$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class dev/woge/html/SectionTagsKt {
+	public static final fun article (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun article$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun aside (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun aside$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun div (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun div$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun footer (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun footer$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun header (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun header$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun main (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun main$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun nav (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun nav$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun section (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun section$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class dev/woge/html/StreamingHtmlSink : dev/woge/html/HtmlSink {
@@ -174,6 +241,44 @@ public final class dev/woge/html/SubresourceIntegrity {
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/woge/html/TableTagsKt {
+	public static final fun caption (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun caption$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun table (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun table$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun tbody (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun tbody$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun td (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun td$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun th (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun th$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun thead (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun thead$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun tr (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun tr$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class dev/woge/html/TextTagsKt {
+	public static final fun a (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun a$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun em (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun em$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun h1 (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun h1$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun h2 (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun h2$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun h3 (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun h3$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun p (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun p$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun span (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun span$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun strong (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun strong$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun time (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun time$default (Ldev/woge/html/HtmlWriter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class dev/woge/html/UnsafeHtml {

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/DocumentTags.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/DocumentTags.kt
@@ -1,0 +1,34 @@
+package dev.woge.html
+
+/** Writes an `html` element. */
+public fun HtmlWriter.html(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("html", attributes, content)
+
+/** Writes a `head` element. */
+public fun HtmlWriter.head(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("head", attributes, content)
+
+/** Writes a `body` element. */
+public fun HtmlWriter.body(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("body", attributes, content)
+
+/** Writes a `title` element. */
+public fun HtmlWriter.title(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("title", attributes, content)
+
+/** Writes a void `meta` element. */
+public fun HtmlWriter.meta(attributes: Attributes.() -> Unit = {}): Unit = voidElement("meta", attributes)
+
+/** Writes a `noscript` element whose content is useful without JavaScript. */
+public fun HtmlWriter.noscript(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("noscript", attributes, content)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/FormTags.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/FormTags.kt
@@ -1,0 +1,40 @@
+package dev.woge.html
+
+/** Writes a `form` element. Use [Attributes.url] for its `action`. */
+public fun HtmlWriter.form(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("form", attributes, content)
+
+/** Writes a `button` element. */
+public fun HtmlWriter.button(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("button", attributes, content)
+
+/** Writes a void `input` element. */
+public fun HtmlWriter.input(attributes: Attributes.() -> Unit = {}): Unit = voidElement("input", attributes)
+
+/** Writes a `label` element. */
+public fun HtmlWriter.label(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("label", attributes, content)
+
+/** Writes a `select` element. */
+public fun HtmlWriter.select(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("select", attributes, content)
+
+/** Writes an `option` element. */
+public fun HtmlWriter.option(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("option", attributes, content)
+
+/** Writes a `textarea` element. */
+public fun HtmlWriter.textarea(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("textarea", attributes, content)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlWriter.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlWriter.kt
@@ -9,6 +9,11 @@ import dev.woge.html.internal.escapeHtmlText
 public class HtmlWriter internal constructor(
     private val sink: HtmlSink,
 ) {
+    /** Writes the standard declaration that selects standards mode for an HTML document. */
+    public fun doctype() {
+        sink.write("<!doctype html>")
+    }
+
     /** Writes [value] as HTML text. Markup characters are escaped rather than interpreted. */
     public fun text(value: String) {
         sink.write(escapeHtmlText(value))

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/ListTags.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/ListTags.kt
@@ -1,0 +1,37 @@
+package dev.woge.html
+
+/** Writes a `ul` element. */
+public fun HtmlWriter.ul(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("ul", attributes, content)
+
+/** Writes an `ol` element. */
+public fun HtmlWriter.ol(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("ol", attributes, content)
+
+/** Writes an `li` element. */
+public fun HtmlWriter.li(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("li", attributes, content)
+
+/** Writes a `dl` element. */
+public fun HtmlWriter.dl(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("dl", attributes, content)
+
+/** Writes a `dt` element. */
+public fun HtmlWriter.dt(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("dt", attributes, content)
+
+/** Writes a `dd` element. */
+public fun HtmlWriter.dd(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("dd", attributes, content)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/SectionTags.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/SectionTags.kt
@@ -1,0 +1,49 @@
+package dev.woge.html
+
+/** Writes a `header` element. */
+public fun HtmlWriter.header(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("header", attributes, content)
+
+/** Writes a `nav` element. */
+public fun HtmlWriter.nav(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("nav", attributes, content)
+
+/** Writes a `main` element. */
+public fun HtmlWriter.main(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("main", attributes, content)
+
+/** Writes a `footer` element. */
+public fun HtmlWriter.footer(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("footer", attributes, content)
+
+/** Writes a `section` element. */
+public fun HtmlWriter.section(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("section", attributes, content)
+
+/** Writes an `article` element. */
+public fun HtmlWriter.article(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("article", attributes, content)
+
+/** Writes an `aside` element. */
+public fun HtmlWriter.aside(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("aside", attributes, content)
+
+/** Writes a `div` element. */
+public fun HtmlWriter.div(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("div", attributes, content)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/TableTags.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/TableTags.kt
@@ -1,0 +1,43 @@
+package dev.woge.html
+
+/** Writes a `table` element. */
+public fun HtmlWriter.table(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("table", attributes, content)
+
+/** Writes a `caption` element. */
+public fun HtmlWriter.caption(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("caption", attributes, content)
+
+/** Writes a `thead` element. */
+public fun HtmlWriter.thead(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("thead", attributes, content)
+
+/** Writes a `tbody` element. */
+public fun HtmlWriter.tbody(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("tbody", attributes, content)
+
+/** Writes a `tr` element. */
+public fun HtmlWriter.tr(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("tr", attributes, content)
+
+/** Writes a `th` element. */
+public fun HtmlWriter.th(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("th", attributes, content)
+
+/** Writes a `td` element. */
+public fun HtmlWriter.td(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("td", attributes, content)

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/TextTags.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/TextTags.kt
@@ -1,0 +1,55 @@
+package dev.woge.html
+
+/** Writes an `h1` element. */
+public fun HtmlWriter.h1(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("h1", attributes, content)
+
+/** Writes an `h2` element. */
+public fun HtmlWriter.h2(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("h2", attributes, content)
+
+/** Writes an `h3` element. */
+public fun HtmlWriter.h3(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("h3", attributes, content)
+
+/** Writes a `p` element. */
+public fun HtmlWriter.p(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("p", attributes, content)
+
+/** Writes an `a` element. Use [Attributes.url] for its `href`. */
+public fun HtmlWriter.a(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("a", attributes, content)
+
+/** Writes a `span` element. */
+public fun HtmlWriter.span(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("span", attributes, content)
+
+/** Writes a `strong` element. */
+public fun HtmlWriter.strong(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("strong", attributes, content)
+
+/** Writes an `em` element. */
+public fun HtmlWriter.em(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("em", attributes, content)
+
+/** Writes a `time` element. */
+public fun HtmlWriter.time(
+    attributes: Attributes.() -> Unit = {},
+    content: HtmlWriter.() -> Unit = {},
+): Unit = element("time", attributes, content)

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlWriterTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/HtmlWriterTest.kt
@@ -8,6 +8,46 @@ import org.junit.jupiter.api.Test
 
 class HtmlWriterTest {
     @Test
+    fun `doctype writes the standard HTML declaration without an unsafe escape hatch`() {
+        assertEquals(
+            "<!doctype html><html></html>",
+            renderHtml {
+                doctype()
+                element("html")
+            },
+        )
+    }
+
+    @Test
+    fun `common tag wrappers retain familiar HTML names and generic future fallback`() {
+        val html =
+            renderHtml {
+                main(attributes = { attribute("id", "content") }) {
+                    article {
+                        h1 { text("Typed structure") }
+                        form(
+                            attributes = {
+                                url("action", applicationUrl("/search"))
+                                attribute("method", "get")
+                            },
+                        ) {
+                            input { attribute("name", "query") }
+                            button { text("Search") }
+                        }
+                    }
+                    element("future-card") { text("Still open to the platform") }
+                }
+            }
+
+        assertEquals(
+            "<main id=\"content\"><article><h1>Typed structure</h1>" +
+                "<form action=\"/search\" method=\"get\"><input name=\"query\"><button>Search</button></form>" +
+                "</article><future-card>Still open to the platform</future-card></main>",
+            html,
+        )
+    }
+
+    @Test
     fun `text and quoted attributes use separate escaping contexts`() {
         val html =
             renderHtml {

--- a/modules/woge-core/src/test/kotlin/dev/woge/html/SafeHtmlValuesGuideTest.kt
+++ b/modules/woge-core/src/test/kotlin/dev/woge/html/SafeHtmlValuesGuideTest.kt
@@ -9,8 +9,7 @@ class SafeHtmlValuesGuideTest {
     fun `project card example remains executable`() {
         val html =
             renderHtml {
-                element(
-                    "article",
+                article(
                     attributes = {
                         classes("project-card", "grid gap-3", "md:grid-cols-[1fr_auto]")
                         data("project-id", "woge-7")
@@ -19,8 +18,8 @@ class SafeHtmlValuesGuideTest {
                         styles(declarations("--accent: oklch(62% 0.2 250);"))
                     },
                 ) {
-                    element("h2") { text("Woge <preview>") }
-                    element("a", attributes = { url("href", applicationUrl("/projects/woge-7")) }) {
+                    h2 { text("Woge <preview>") }
+                    a(attributes = { url("href", applicationUrl("/projects/woge-7")) }) {
                         text("Open & inspect")
                     }
                 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,3 +29,9 @@ file("config/architecture/module-boundaries.tsv")
         include(":$moduleName")
         project(":$moduleName").projectDir = file(columns[3])
     }
+
+include(":woge-reference-shared")
+project(":woge-reference-shared").projectDir = file("examples/reference-application/shared")
+
+include(":woge-reference-spring-webflux")
+project(":woge-reference-spring-webflux").projectDir = file("examples/reference-application/spring-webflux")


### PR DESCRIPTION
## Summary

- add an executable Spring Boot WebFlux reference application with an immediate HTML shell and independently deferred Woge regions
- keep page rendering and deferred use cases host-neutral while the Spring adapter only translates HTTP requests and responses
- add a web-developer-first quickstart, Kotlin bridge, ADR, and terminology review with concrete follow-up issues
- add a small type-safe common-tag layer while retaining the generic standards escape hatch

## Verification

- `./gradlew check`
- `./scripts/validate-adrs.sh`
- `./scripts/validate-documentation.sh`
- `git diff --check`
- `./gradlew :woge-reference-spring-webflux:bootRun`
- browser smoke test: shell, three deferred regions, no console errors, and full-page form fallback

Closes #73
