### PR TITLE
Verify the real browser walking skeleton in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: gradle/actions/setup-gradle@v6
-      - run: ./gradlew check --stacktrace
+      - name: Run clean repository gate without task-output caches
+        run: ./gradlew clean check --no-build-cache --stacktrace
       - name: Upload verification reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -29,3 +30,35 @@ jobs:
           path: |
             **/build/reports/**
             **/build/test-results/**
+
+  reference-browser-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: gradle/actions/setup-gradle@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: client/woge-fallback-client/package-lock.json
+      - name: Install browser-test dependencies
+        working-directory: client/woge-fallback-client
+        run: npm ci
+      - name: Install pinned browser engines
+        working-directory: client/woge-fallback-client
+        run: npx playwright install --with-deps chromium firefox webkit
+      - name: Run the reference application browser gate
+        run: ./gradlew referenceBrowserSmoke --stacktrace
+      - name: Upload reference-browser evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: reference-browser-evidence
+          if-no-files-found: warn
+          path: |
+            client/woge-fallback-client/playwright-report/reference-application/**
+            client/woge-fallback-client/test-results/reference-application/**

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,3 +31,5 @@ jobs:
         run: ./scripts/validate-adrs.sh
       - name: Validate module boundaries
         run: ./scripts/validate-module-boundaries.sh
+      - name: Validate documentation and canonical snippet references
+        run: ./scripts/validate-documentation.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,12 @@ val validateDocumentation = registerValidation(
     "Validates local documentation links and executable snippet references.",
     "scripts/validate-documentation.sh",
 )
+tasks.register<Exec>("referenceBrowserSmoke") {
+    group = "verification"
+    description = "Runs the Spring Boot reference application in the supported Playwright engines."
+    workingDir(layout.projectDirectory.dir("client/woge-fallback-client"))
+    commandLine("npm", "run", "test:reference")
+}
 
 val test = registerAggregate("test", "Runs tests in every production build project.", "test")
 val detekt = registerAggregate("detekt", "Runs Detekt in every production build project.", "detekt")

--- a/client/woge-fallback-client/package.json
+++ b/client/woge-fallback-client/package.json
@@ -21,6 +21,7 @@
     "build": "node scripts/build.mjs",
     "test:unit": "node --test tests/*.test.mjs",
     "test:browser": "playwright test",
+    "test:reference": "playwright test --config=playwright.reference.config.mjs",
     "measure": "node scripts/measure.mjs",
     "check": "npm run build && npm run test:unit && npm run test:browser && npm run measure"
   },

--- a/client/woge-fallback-client/playwright.reference.config.mjs
+++ b/client/woge-fallback-client/playwright.reference.config.mjs
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+
+const browsers = ["chromium", "firefox", "webkit"];
+
+export default defineConfig({
+  testDir: "./reference-browser-tests",
+  fullyParallel: true,
+  forbidOnly: true,
+  retries: 0,
+  workers: process.env.CI ? 3 : undefined,
+  outputDir: "test-results/reference-application",
+  reporter: [
+    ["line"],
+    ["html", { open: "never", outputFolder: "playwright-report/reference-application" }],
+  ],
+  use: {
+    baseURL: "http://127.0.0.1:8080",
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "../../gradlew -p ../.. :woge-reference-spring-webflux:bootRun --console=plain",
+    url: "http://127.0.0.1:8080/projects/woge",
+    reuseExistingServer: false,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+  projects: browsers.flatMap((browserName) => [
+    {
+      name: `${browserName}-enhanced`,
+      testMatch: /enhanced\.spec\.mjs/,
+      use: { browserName },
+    },
+    {
+      name: `${browserName}-no-javascript`,
+      testMatch: /no-javascript\.spec\.mjs/,
+      use: { browserName, javaScriptEnabled: false },
+    },
+  ]),
+});

--- a/client/woge-fallback-client/reference-browser-tests/enhanced.spec.mjs
+++ b/client/woge-fallback-client/reference-browser-tests/enhanced.spec.mjs
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test("renders the useful shell before applying every deferred region", async ({ page }) => {
+  const browserProblems = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") browserProblems.push(message.text());
+  });
+  page.on("pageerror", (problem) => browserProblems.push(problem.message));
+
+  let releasePatchRequest;
+  const patchRequestGate = new Promise((resolve) => {
+    releasePatchRequest = resolve;
+  });
+  await page.route("**/projects/woge/woge-patches", async (route) => {
+    await patchRequestGate;
+    await route.continue();
+  });
+
+  const response = await page.goto("/projects/woge");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/html");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Woge");
+  await expect(page.locator('[data-woge-region][data-woge-revision="0"]')).toHaveCount(3);
+  await expect(page.getByText("Loading from the server…")).toHaveCount(3);
+  await expect(page.locator('link[rel="stylesheet"]')).toHaveAttribute("href", "/assets/application.css");
+  await expect(page.locator('script[type="module"]')).toHaveAttribute("src", "/assets/application.js");
+
+  releasePatchRequest();
+
+  await expect(page.locator('[data-woge-region][data-woge-revision="1"]')).toHaveCount(3);
+  await expect(page.getByRole("table", { name: "Current tasks for Woge" })).toBeVisible();
+  await expect(page.getByText("Spring Boot adapter selected")).toBeVisible();
+  await expect(page.getByText("Loading from the server…")).toHaveCount(0);
+  await expect(page.locator(".is-loading")).toHaveCount(0);
+  expect(browserProblems).toEqual([]);
+});

--- a/client/woge-fallback-client/reference-browser-tests/no-javascript.spec.mjs
+++ b/client/woge-fallback-client/reference-browser-tests/no-javascript.spec.mjs
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test("uses an ordinary full navigation when JavaScript is unavailable", async ({ page }) => {
+  const response = await page.goto("/projects/woge");
+  expect(response.status()).toBe(200);
+  const completePageLink = page.getByRole("link", { name: "Load all project data as one complete page." });
+  await expect(completePageLink).toBeVisible();
+  await expect(page.getByRole("button", { name: "Load the complete page instead" })).toBeVisible();
+  await expect(page.locator('[data-woge-region][data-woge-revision="0"]')).toHaveCount(3);
+  await expect(page.getByText("Loading from the server…")).toHaveCount(3);
+
+  await completePageLink.click();
+
+  await expect(page).toHaveURL(/\/projects\/woge\?view=complete$/);
+  await expect(page.getByRole("table", { name: "Current tasks for Woge" })).toBeVisible();
+  await expect(page.getByText("Spring Boot adapter selected")).toBeVisible();
+  await expect(page.locator("[data-woge-region]")).toHaveCount(0);
+  await expect(page.getByText("Loading from the server…")).toHaveCount(0);
+});

--- a/docs/development/build-and-test.md
+++ b/docs/development/build-and-test.md
@@ -34,6 +34,37 @@ the benchmark fixture but does not execute it. HTML sink results are written bel
 `modules/woge-core/build/results/jmh` and interpreted in the
 [recorded baseline](../performance/html-sinks-baseline.md).
 
+## Reproduce the clean CI gate
+
+Pull requests and pushes to `main` remove previous outputs and disable Gradle's task-output cache:
+
+```shell
+./gradlew clean check --no-build-cache
+```
+
+This keeps dependency and configuration reuse available while proving that generated files and
+compiled fixtures can be rebuilt from the checkout. The gate includes positive example compilation,
+the deterministic negative compiler fixtures, JVM tests, formatting, static analysis, ABI checks,
+module-boundary checks, ADR metadata and documentation/snippet-link validation. It never calls an AI
+model.
+
+The Spring Boot reference application has a separate browser gate. Install its pinned Node and
+Playwright dependencies once, then invoke the same Gradle task as CI:
+
+```shell
+cd client/woge-fallback-client
+npm ci
+npx playwright install chromium firefox webkit
+cd ../..
+./gradlew referenceBrowserSmoke
+```
+
+The task starts the compiled WebFlux example and verifies deferred enhancement plus the normal
+no-JavaScript navigation in Chromium, Firefox and WebKit. Failure traces and screenshots are written
+below `client/woge-fallback-client/test-results/reference-application`; the HTML report is below
+`client/woge-fallback-client/playwright-report/reference-application`. GitHub Actions uploads those
+paths and all JVM test reports even when a gate fails.
+
 Public declarations in `woge-core`, `woge-protocol` and `woge-host-spi` are tracked by Kotlin's
 built-in ABI validator. `checkKotlinAbi` compares current declarations with the committed dump. Run
 the corresponding module's `updateKotlinAbi` task only after reviewing and accepting an intentional

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt
@@ -126,7 +126,7 @@ private fun HtmlWriter.renderFullNavigationFallback(project: ProjectSnapshot) {
 private fun HtmlWriter.renderDeferredProject(project: ProjectSnapshot) {
     deferredRegions(project).forEach { region ->
         regionPlaceholder(region, elementName = "section") {
-            classes("project-region", "is-loading")
+            classes("project-region")
             aria("labelledby", "${region.target.region.value}-heading")
         }
     }

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectRegionMarkup.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectRegionMarkup.kt
@@ -93,7 +93,7 @@ internal fun HtmlWriter.renderRegionLoading(
     title: String,
 ) {
     h2(attributes = { attribute("id", "$region-heading") }) { text(title) }
-    p { text("Loading from the server…") }
+    p(attributes = { classes("is-loading") }) { text("Loading from the server…") }
 }
 
 internal fun HtmlWriter.renderRegionFailure(


### PR DESCRIPTION
## Outcome

- run the root repository gate from clean outputs with Gradle task-output caching disabled
- exercise the compiled Spring Boot WebFlux reference application in Chromium, Firefox and WebKit, both with deferred enhancement and with JavaScript disabled
- preserve Playwright traces/screenshots and JVM reports on CI failures
- expose and document the same browser gate as the root `referenceBrowserSmoke` Gradle task
- remove the loading-only class together with patched loading content instead of leaving muted final regions behind

## Verification

- [x] `./gradlew clean check --no-build-cache --stacktrace` (164 tasks)
- [x] `./gradlew referenceBrowserSmoke --stacktrace` (6 browser journeys)
- [x] `npm run check` (7 decoder tests and 30 browser tests)
- [x] workflow YAML syntax, documentation, ADR and whitespace validation

## Architecture decision

- Related ADRs: 0003, 0007, 0019 and 0025
- No new ADR is required: this change implements their existing deterministic documentation, browser-support, module-boundary and fallback-runtime gates without changing a public API, protocol or support promise. Full MVC/WebFlux/Ktor CI parity remains owned by #24.

## Compatibility

No public Kotlin or wire-protocol surface changes. The reference application's transient loading class now belongs to the replaced loading child, so final content no longer retains loading-only styling.

Closes #15
