### PR TITLE
Add the shared real-HTTP server-adapter TCK

### DIFF
--- a/adapters/woge-spring-webflux/README.md
+++ b/adapters/woge-spring-webflux/README.md
@@ -5,4 +5,10 @@ functional handlers. Reactor and response-lifecycle details remain inside the ad
 
 Start with [Run a Woge page with Spring WebFlux](../../docs/guides/spring-webflux-adapter.md). The
 [Spring Boot auto-configuration](../../docs/guides/spring-boot-starter.md) can provide the shared
-handler factory. The complete executable reference application is the next M1a slice.
+handler factory. The [executable reference application](../../docs/guides/quickstart-spring-boot.md)
+shows the complete Spring Boot path.
+
+Adapter tests invoke the framework-neutral
+[server-adapter TCK](../../docs/architecture/server-adapter-parity.md) over a real Reactor Netty
+connection. Focused WebFlux tests may cover framework mechanics, but they do not replace that shared
+semantic contract.

--- a/adapters/woge-spring-webflux/build.gradle.kts
+++ b/adapters/woge-spring-webflux/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":woge-server-runtime"))
     implementation(libs.kotlinxCoroutinesReactor)
 
+    testImplementation(project(":woge-adapter-tck"))
     testImplementation(libs.junitJupiter)
     testImplementation(libs.reactorNettyHttp)
     testImplementation(libs.springContext)

--- a/adapters/woge-spring-webflux/src/test/kotlin/dev/woge/spring/webflux/WogeWebFluxAdapterTckTest.kt
+++ b/adapters/woge-spring-webflux/src/test/kotlin/dev/woge/spring/webflux/WogeWebFluxAdapterTckTest.kt
@@ -1,0 +1,70 @@
+package dev.woge.spring.webflux
+
+import dev.woge.tck.AdapterTckApplication
+import dev.woge.tck.AdapterTckCapability
+import dev.woge.tck.AdapterTckDeferredScenario
+import dev.woge.tck.AdapterTckHarnessFactory
+import dev.woge.tck.AdapterTckPageScenario
+import dev.woge.tck.AdapterTckRoutes
+import dev.woge.tck.AdapterTckServer
+import dev.woge.tck.ServerAdapterContract
+import org.junit.jupiter.api.Test
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.coRouter
+import reactor.netty.DisposableServer
+import reactor.netty.http.server.HttpServer
+import java.net.URI
+
+class WogeWebFluxAdapterTckTest {
+    @Test
+    fun `WebFlux passes the shared server adapter contract`() {
+        ServerAdapterContract(WebFluxTckHarnessFactory).verify()
+    }
+}
+
+private object WebFluxTckHarnessFactory : AdapterTckHarnessFactory {
+    override val adapterName: String = "spring-webflux"
+
+    override fun start(application: AdapterTckApplication): AdapterTckServer {
+        val page =
+            WogeWebFluxPageHandler(
+                application.pages,
+                WebFluxPageInput { request ->
+                    AdapterTckPageScenario.fromPath(request.pathVariable("scenario"))
+                },
+            )
+        val deferred =
+            WogeWebFluxDeferredHandler(
+                application.deferredRegions,
+                WebFluxPageInput { request ->
+                    AdapterTckDeferredScenario.fromPath(request.pathVariable("scenario"))
+                },
+            )
+        val routes =
+            coRouter {
+                GET(AdapterTckRoutes.PAGE_PATTERN, page::handle)
+                HEAD(AdapterTckRoutes.PAGE_PATTERN, page::handle)
+                GET(AdapterTckRoutes.DEFERRED_PATTERN, deferred::handle)
+            }
+        return WebFluxTckServer(
+            HttpServer
+                .create()
+                .host("127.0.0.1")
+                .port(0)
+                .handle(ReactorHttpHandlerAdapter(RouterFunctions.toHttpHandler(routes)))
+                .bindNow(),
+        )
+    }
+}
+
+private class WebFluxTckServer(
+    private val server: DisposableServer,
+) : AdapterTckServer {
+    override val origin: URI = URI.create("http://127.0.0.1:${server.port()}")
+    override val capabilities: Set<AdapterTckCapability> = setOf(AdapterTckCapability.CLIENT_ABORT_CANCELLATION)
+
+    override fun close() {
+        server.disposeNow()
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The documentation grows with executable product slices. Pages describing unimple
 ## Canonical architecture guidance
 
 - [M1 module and consumer graph](architecture/module-graph.md)
+- [Server-adapter parity matrix](architecture/server-adapter-parity.md)
 - [Spring MVC and WebFlux support model](architecture/spring-support-model.md)
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)
 - [CSS authoring](architecture/css-authoring.md)

--- a/docs/architecture/module-graph.md
+++ b/docs/architecture/module-graph.md
@@ -65,3 +65,7 @@ The boundary validator fails on missing modules, unknown or cyclic edges, Gradle
 forbidden host references in portable production source and MVC/WebFlux cross-dependencies. Negative
 fixtures prove that those failures remain active. Run both layers directly with
 `./gradlew validateModuleBoundaries testModuleBoundaries` or as part of `./gradlew check`.
+
+The executable contract and current host coverage live in the
+[server-adapter parity matrix](server-adapter-parity.md). Adapter tests depend on the TCK only in
+their test source sets; production adapters remain peers and never depend on one another.

--- a/docs/architecture/server-adapter-parity.md
+++ b/docs/architecture/server-adapter-parity.md
@@ -1,0 +1,51 @@
+# Server-adapter parity matrix
+
+Woge compares observable web outcomes, not framework APIs. The shared
+[`woge-adapter-tck`](../../testing/woge-adapter-tck/README.md) application contains no Spring,
+Reactor, Servlet or Ktor types. Each adapter supplies only a small harness factory that binds the
+same page and deferred-region use cases to a real HTTP server. This executes the boundaries accepted
+in [ADR 0005](../adr/0005-server-host-use-case-ports.md),
+[ADR 0022](../adr/0022-page-host-spi-contract.md) and
+[ADR 0026](../adr/0026-structured-deferred-region-execution.md).
+
+## Canonical journeys
+
+| Contract | Native or no-JavaScript outcome | Enhanced outcome | Recovery outcome | Automated evidence |
+| --- | --- | --- | --- | --- |
+| `page-get-stream` | Standard GET returns UTF-8 HTML, status, safe headers and cookies | The same HTML is the initial enhancement document | A refresh repeats an ordinary GET | Adapter TCK |
+| `page-head` | HEAD exposes GET metadata without body bytes | Asset and route probes use normal HTTP semantics | Clients can probe without rendering | Adapter TCK |
+| `page-redirect` | Browser follows an ordinary policy-checked 303 Location | Enhanced code must preserve the same destination | Full navigation remains valid | Adapter TCK; browser actions follow later |
+| `page-controlled-failure` | Typed failure produces its stable bodyless status | Enhancement must not reinterpret it as success | Native error navigation remains available | Adapter TCK |
+| `page-pre-stream-failure` | Failure before commit becomes a safe 500 without private detail | Enhancement receives an ordinary failed request | Retry is not automatic | Adapter TCK |
+| `deferred-completion-order` | The complete-page route is the useful fallback | Shell is visible before independently completed revisioned patches | The user can navigate to the complete page | Adapter TCK plus reference browser gate |
+| `deferred-client-abort` | Navigation away closes the old response | Abort cancels outstanding request children | New navigation owns new work | Adapter TCK where the harness exposes aborts |
+
+Status, redirect and patch mechanics differ only when the web mode requires it. Equivalent outcomes
+mean the same authorization decision, destination, useful content and failure meaning—not identical
+transport bytes.
+
+Closing the real client response is the deterministic TCK trigger for both a browser disconnect and
+the host's subsequent failed-write/cancellation path. A future host-specific downstream failure
+injection belongs in a focused adapter test when it exposes behavior that cannot be reached by that
+HTTP abort.
+
+## Adapter status
+
+| Adapter | Shared source | Real HTTP | Flush/order | Client abort | Status |
+| --- | --- | --- | --- | --- | --- |
+| Spring Boot WebFlux | Yes | Yes | Yes | Yes | Passing |
+| Spring Boot MVC | Required | Required | Required with Servlet async behavior | Required where deterministic | Planned in [#67](https://github.com/christian-draeger/woge/issues/67) |
+| Ktor | Required | Required | Required | Required | Planned in [#68](https://github.com/christian-draeger/woge/issues/68) |
+
+The WebFlux implementation is the first executable consumer. An adapter is not complete when only
+its own focused tests pass: it must invoke `ServerAdapterContract` from its test suite. The
+multi-host reference slice in [#24](https://github.com/christian-draeger/woge/issues/24) turns all
+three rows into a CI release gate.
+
+## Additive suites
+
+`AdapterTckExtension` runs after the core page/deferred contract against the same live harness.
+Action and CSRF, cache validators, multipart uploads and SSE each add a focused extension only when
+their framework-neutral capability exists. Until then they remain absent rather than receiving
+placeholder production APIs. Failures use stable `[WOGE-TCK]` messages naming the adapter, contract
+and whether the TCK contract, fixture or adapter owns the divergence.

--- a/testing/woge-adapter-tck/README.md
+++ b/testing/woge-adapter-tck/README.md
@@ -1,0 +1,14 @@
+# Woge server-adapter TCK
+
+This test-support module owns the framework-neutral compatibility contract for Woge server adapters.
+An adapter test supplies an `AdapterTckHarnessFactory` that binds the shared `AdapterTckApplication`
+to the canonical paths on an ephemeral real HTTP server. `ServerAdapterContract.verify()` owns the
+requests and assertions; it never imports a Spring, Reactor, Servlet or Ktor type.
+
+The initial contract covers page metadata and request mapping, GET and HEAD, redirects, controlled
+and pre-stream failures, document flush boundaries, deferred completion order and client-abort
+cancellation. Additive `AdapterTckExtension` suites are the hook for actions, CSRF, caching,
+multipart and SSE when those capabilities become executable.
+
+See the [server-adapter parity matrix](../../docs/architecture/server-adapter-parity.md) for contract
+ownership and current adapter coverage.

--- a/testing/woge-adapter-tck/build.gradle.kts
+++ b/testing/woge-adapter-tck/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
     api(project(":woge-protocol"))
     api(project(":woge-host-spi"))
     implementation(project(":woge-server-runtime"))
+    implementation(libs.kotlinxCoroutinesCore)
 }

--- a/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/AdapterTckApplication.kt
+++ b/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/AdapterTckApplication.kt
@@ -1,0 +1,154 @@
+package dev.woge.tck
+
+import dev.woge.host.CookieName
+import dev.woge.host.DeferredRegion
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.FailureCategory
+import dev.woge.host.HeaderName
+import dev.woge.host.PageRequest
+import dev.woge.host.PageResult
+import dev.woge.host.PageUseCase
+import dev.woge.host.RequestContext
+import dev.woge.host.RequestMethod
+import dev.woge.host.ResponseHeaders
+import dev.woge.host.ResponseMetadata
+import dev.woge.host.ResponseStatus
+import dev.woge.host.deferredRegion
+import dev.woge.host.failure
+import dev.woge.host.httpHeader
+import dev.woge.host.redirect
+import dev.woge.host.responseCookie
+import dev.woge.host.streamingHtmlPage
+import dev.woge.html.applicationUrl
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchHtml
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.htmlFrame
+import dev.woge.protocol.patchHtml
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/** Page scenarios understood by the canonical TCK route. */
+public enum class AdapterTckPageScenario(
+    public val pathSegment: String,
+) {
+    DOCUMENT("document"),
+    REDIRECT("redirect"),
+    CONTROLLED_FAILURE("controlled-failure"),
+    PRE_STREAM_FAILURE("pre-stream-failure"),
+    ;
+
+    public companion object {
+        /** Decodes the route segment without involving a host-framework type. */
+        public fun fromPath(pathSegment: String): AdapterTckPageScenario =
+            entries.firstOrNull { it.pathSegment == pathSegment }
+                ?: throw IllegalArgumentException("Unknown adapter TCK page scenario")
+    }
+}
+
+/** Deferred-stream scenarios understood by the canonical TCK route. */
+public enum class AdapterTckDeferredScenario(
+    public val pathSegment: String,
+) {
+    COMPLETION_ORDER("completion-order"),
+    CLIENT_ABORT("client-abort"),
+    ;
+
+    public companion object {
+        /** Decodes the route segment without involving a host-framework type. */
+        public fun fromPath(pathSegment: String): AdapterTckDeferredScenario =
+            entries.firstOrNull { it.pathSegment == pathSegment }
+                ?: throw IllegalArgumentException("Unknown adapter TCK deferred scenario")
+    }
+}
+
+/** Shared portable application fixture compiled once and bound unchanged by every adapter. */
+public class AdapterTckApplication internal constructor() {
+    private val state: AdapterTckFixtureState = AdapterTckFixtureState()
+
+    public val pages: PageUseCase<AdapterTckPageScenario> = PageUseCase(state::openPage)
+    public val deferredRegions: DeferredRegionsUseCase<AdapterTckDeferredScenario> =
+        DeferredRegionsUseCase(state::deferredRegions)
+
+    internal fun fixtureState(): AdapterTckFixtureState = state
+}
+
+internal class AdapterTckFixtureState {
+    val documentTail: CompletableDeferred<Unit> = CompletableDeferred()
+    val slowRegion: CompletableDeferred<PatchHtml> = CompletableDeferred()
+    val cancelledRegion: CompletableDeferred<Unit> = CompletableDeferred()
+    private val observedContexts: ConcurrentLinkedQueue<RequestContext> = ConcurrentLinkedQueue()
+
+    suspend fun openPage(request: PageRequest<AdapterTckPageScenario>): PageResult {
+        observedContexts += request.context
+        return when (request.input) {
+            AdapterTckPageScenario.DOCUMENT -> document()
+            AdapterTckPageScenario.REDIRECT -> redirect(applicationUrl("/woge-tck/redirect-target"))
+            AdapterTckPageScenario.CONTROLLED_FAILURE ->
+                failure(FailureCategory.NOT_FOUND, request.context.correlationId)
+            AdapterTckPageScenario.PRE_STREAM_FAILURE -> error(PRE_STREAM_PRIVATE_DETAIL)
+        }
+    }
+
+    fun context(method: RequestMethod): RequestContext? = observedContexts.firstOrNull { it.method == method }
+
+    fun deferredRegions(request: PageRequest<AdapterTckDeferredScenario>): Iterable<DeferredRegion> =
+        when (request.input) {
+            AdapterTckDeferredScenario.COMPLETION_ORDER ->
+                listOf(
+                    region("slow") { slowRegion.await() },
+                    region("fast") { patch("Fast region") },
+                )
+            AdapterTckDeferredScenario.CLIENT_ABORT ->
+                listOf(
+                    region("waiting") {
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            cancelledRegion.complete(Unit)
+                        }
+                    },
+                    region("ready") { patch("Ready region") },
+                )
+        }
+
+    private fun document(): PageResult.Document =
+        streamingHtmlPage(
+            frames =
+                flow {
+                    emit(htmlFrame { element("main") { text("TCK shell") } })
+                    documentTail.await()
+                    emit(htmlFrame { element("footer") { text("TCK document tail") } })
+                },
+            metadata =
+                ResponseMetadata(
+                    status = ResponseStatus.of(TCK_DOCUMENT_STATUS_CODE),
+                    headers = ResponseHeaders.of(httpHeader(TCK_RESPONSE_HEADER, "mapped")),
+                    cookies = listOf(responseCookie("woge-tck", "safe")),
+                ),
+        )
+
+    private fun region(
+        id: String,
+        content: suspend () -> PatchHtml,
+    ): DeferredRegion =
+        deferredRegion(
+            target = PatchTarget(PageEpoch.of("adapter-tck-page"), RegionTargetId.of(id)),
+            loading = { element("p") { text("Loading $id") } },
+            onFailure = { patch("Unavailable") },
+            content = content,
+        )
+
+    private fun patch(text: String): PatchHtml = patchHtml { element("p") { text(text) } }
+}
+
+internal fun RequestContext.header(name: String): String? = headers.values(HeaderName.of(name)).firstOrNull()?.value
+
+internal fun RequestContext.cookie(name: String): String? = cookies.first(CookieName.of(name))?.value
+
+internal const val TCK_RESPONSE_HEADER: String = "x-woge-tck"
+internal const val PRE_STREAM_PRIVATE_DETAIL: String = "tck-private-pre-stream-detail"
+internal const val TCK_DOCUMENT_STATUS_CODE: Int = 202

--- a/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/AdapterTckHarness.kt
+++ b/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/AdapterTckHarness.kt
@@ -1,0 +1,68 @@
+package dev.woge.tck
+
+import java.net.URI
+
+/** Creates one real HTTP server around the framework-neutral TCK application. */
+public interface AdapterTckHarnessFactory {
+    /** Stable human-readable adapter name included in every contract failure. */
+    public val adapterName: String
+
+    /** Starts the adapter on an ephemeral local port and returns its HTTP boundary. */
+    public fun start(application: AdapterTckApplication): AdapterTckServer
+}
+
+/** A running adapter owned by one contract invocation. */
+public interface AdapterTckServer : AutoCloseable {
+    /** Absolute HTTP origin without an application path. */
+    public val origin: URI
+
+    /** Optional lifecycle behavior that this harness can expose deterministically. */
+    public val capabilities: Set<AdapterTckCapability>
+
+    override fun close()
+}
+
+/** Host lifecycle behavior that needs an explicit real-transport test hook. */
+public enum class AdapterTckCapability {
+    /** Closing a committed response cancels its outstanding structured children. */
+    CLIENT_ABORT_CANCELLATION,
+}
+
+/** Additive capability suite for actions, caching, multipart, SSE and later host contracts. */
+public interface AdapterTckExtension {
+    /** Stable diagnostic name for this extension suite. */
+    public val name: String
+
+    /** Verifies extension-specific routes exposed by the adapter harness. */
+    public suspend fun verify(server: AdapterTckServer)
+}
+
+/** Canonical paths that every server-adapter harness binds. */
+public object AdapterTckRoutes {
+    public const val PAGE_PATTERN: String = "/woge-tck/pages/{scenario}"
+    public const val DEFERRED_PATTERN: String = "/woge-tck/deferred/{scenario}"
+
+    public fun page(scenario: AdapterTckPageScenario): String = "/woge-tck/pages/${scenario.pathSegment}"
+
+    public fun deferred(scenario: AdapterTckDeferredScenario): String = "/woge-tck/deferred/${scenario.pathSegment}"
+}
+
+/** Identifies whether a failure belongs to TCK code, its fixture or the adapter under test. */
+public enum class AdapterTckFailureOwner {
+    CONTRACT,
+    FIXTURE,
+    ADAPTER,
+}
+
+/** One source-located contract failure with stable ownership and contract identifiers. */
+public class AdapterTckViolation internal constructor(
+    public val owner: AdapterTckFailureOwner,
+    public val adapterName: String,
+    public val contract: String,
+    detail: String,
+    cause: Throwable? = null,
+) : AssertionError("[WOGE-TCK][adapter=$adapterName][owner=${owner.name.lowercase()}][contract=$contract] $detail") {
+    init {
+        cause?.let(::initCause)
+    }
+}

--- a/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/ServerAdapterContract.kt
+++ b/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/ServerAdapterContract.kt
@@ -1,0 +1,364 @@
+package dev.woge.tck
+
+import dev.woge.host.RequestMethod
+import dev.woge.host.ResponseStatus
+import dev.woge.protocol.PatchStreamEvent
+import dev.woge.protocol.PatchStreamV1
+import kotlinx.coroutines.withTimeout
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Executes the framework-neutral server-adapter contract over a real HTTP connection. */
+public class ServerAdapterContract(
+    private val factory: AdapterTckHarnessFactory,
+) {
+    /** Runs the core page/deferred suites followed by any additive capability suites. */
+    public fun verify(extensions: Iterable<AdapterTckExtension> = emptyList()) {
+        val application = AdapterTckApplication()
+        val server = start(application)
+        server.use {
+            validateHarness(server)
+            kotlinx.coroutines.runBlocking {
+                val verification = AdapterTckVerification(factory.adapterName, server, application.fixtureState())
+                verification.verifyCore()
+                extensions.forEach { extension ->
+                    contract("extension:${extension.name}") { extension.verify(server) }
+                }
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun start(application: AdapterTckApplication): AdapterTckServer =
+        try {
+            factory.start(application)
+        } catch (cause: Exception) {
+            throw violation(AdapterTckFailureOwner.FIXTURE, "harness-start", "adapter harness did not start", cause)
+        }
+
+    private fun validateHarness(server: AdapterTckServer) {
+        if (factory.adapterName.isBlank()) {
+            throw violation(AdapterTckFailureOwner.FIXTURE, "harness-name", "adapter name must not be blank")
+        }
+        if (!server.origin.isAbsolute || server.origin.scheme !in setOf("http", "https")) {
+            throw violation(AdapterTckFailureOwner.FIXTURE, "harness-origin", "server origin must be absolute HTTP")
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun contract(
+        name: String,
+        block: suspend () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (failure: AdapterTckViolation) {
+            throw failure
+        } catch (cause: Exception) {
+            throw violation(AdapterTckFailureOwner.ADAPTER, name, "adapter request failed", cause)
+        }
+    }
+
+    private fun violation(
+        owner: AdapterTckFailureOwner,
+        contract: String,
+        detail: String,
+        cause: Throwable? = null,
+    ): AdapterTckViolation = AdapterTckViolation(owner, factory.adapterName, contract, detail, cause)
+}
+
+private class AdapterTckVerification(
+    private val adapterName: String,
+    private val server: AdapterTckServer,
+    private val fixture: AdapterTckFixtureState,
+) {
+    private val client: AdapterTckHttpClient = AdapterTckHttpClient(server.origin)
+
+    suspend fun verifyCore() {
+        verifyDocumentGetAndHead()
+        verifyRedirectAndFailures()
+        verifyDeferredCompletionOrder()
+        if (AdapterTckCapability.CLIENT_ABORT_CANCELLATION in server.capabilities) {
+            verifyClientAbortCancellation()
+        }
+    }
+
+    private suspend fun verifyDocumentGetAndHead() {
+        runContract("page-get-stream") {
+            val response =
+                client.open(
+                    RequestMethod.GET,
+                    AdapterTckRoutes.page(AdapterTckPageScenario.DOCUMENT),
+                    mapOf(
+                        "Accept-Language" to "de-DE,de;q=0.8",
+                        "Authorization" to "Bearer tck-secret",
+                        "Cookie" to "tck-theme=dark",
+                        "X-Woge-Tck-Request" to "visible",
+                    ),
+                )
+            response.body().use { body ->
+                expectDocumentMetadata("page-get-stream", response)
+                val shell = body.readThrough("</main>").toString(StandardCharsets.UTF_8)
+                expect(shell == "<main>TCK shell</main>", "page-get-stream", "first flush group was not the shell")
+                expect(!fixture.documentTail.isCompleted, "page-get-stream", "document tail completed before release")
+                fixture.documentTail.complete(Unit)
+                expect(
+                    body.readAllBytes().toString(StandardCharsets.UTF_8) == "<footer>TCK document tail</footer>",
+                    "page-get-stream",
+                    "second flush group was not the document tail",
+                )
+            }
+
+            val context = fixture.context(RequestMethod.GET)
+            expect(context != null, "request-context", "GET request context was not supplied")
+            expect(
+                context?.language?.value == "de-de",
+                "request-context",
+                "accepted language was not normalized",
+            )
+            expect(
+                context?.header("x-woge-tck-request") == "visible",
+                "request-context",
+                "safe header was not copied",
+            )
+            expect(context?.header("authorization") == null, "request-context", "authorization header leaked")
+            expect(context?.header("cookie") == null, "request-context", "raw cookie header leaked")
+            expect(context?.cookie("tck-theme") == "dark", "request-context", "parsed cookie was not supplied")
+        }
+
+        runContract("page-head") {
+            val response = client.bytes(RequestMethod.HEAD, AdapterTckRoutes.page(AdapterTckPageScenario.DOCUMENT))
+            expectDocumentMetadata("page-head", response)
+            expect(response.body().isEmpty(), "page-head", "HEAD response exposed document bytes")
+            expect(fixture.context(RequestMethod.HEAD) != null, "page-head", "HEAD method was not mapped")
+        }
+    }
+
+    private suspend fun verifyRedirectAndFailures() {
+        runContract("page-redirect") {
+            val response = client.text(RequestMethod.GET, AdapterTckRoutes.page(AdapterTckPageScenario.REDIRECT))
+            expect(response.statusCode() == ResponseStatus.SEE_OTHER.code, "page-redirect", "expected HTTP 303")
+            expect(response.header("location") == "/woge-tck/redirect-target", "page-redirect", "location changed")
+            expect(response.body().isEmpty(), "page-redirect", "redirect response was not bodyless")
+        }
+
+        runContract("page-controlled-failure") {
+            val response =
+                client.text(RequestMethod.GET, AdapterTckRoutes.page(AdapterTckPageScenario.CONTROLLED_FAILURE))
+            expect(
+                response.statusCode() == ResponseStatus.NOT_FOUND.code,
+                "page-controlled-failure",
+                "expected HTTP 404",
+            )
+            expect(response.body().isEmpty(), "page-controlled-failure", "controlled failure was not bodyless")
+            expect(response.header("content-type") == null, "page-controlled-failure", "bodyless failure has a type")
+        }
+
+        runContract("page-pre-stream-failure") {
+            val response =
+                client.text(
+                    RequestMethod.GET,
+                    AdapterTckRoutes.page(AdapterTckPageScenario.PRE_STREAM_FAILURE),
+                )
+            expect(
+                response.statusCode() == ResponseStatus.INTERNAL_SERVER_ERROR.code,
+                "page-pre-stream-failure",
+                "expected safe HTTP 500",
+            )
+            expect(
+                !response.body().contains(PRE_STREAM_PRIVATE_DETAIL),
+                "page-pre-stream-failure",
+                "private exception detail reached the client",
+            )
+        }
+    }
+
+    private suspend fun verifyDeferredCompletionOrder() {
+        runContract("deferred-completion-order") {
+            val response =
+                client.open(
+                    RequestMethod.GET,
+                    AdapterTckRoutes.deferred(AdapterTckDeferredScenario.COMPLETION_ORDER),
+                )
+            response.body().use { body ->
+                expect(
+                    response.statusCode() == ResponseStatus.OK.code,
+                    "deferred-completion-order",
+                    "expected HTTP 200",
+                )
+                expect(
+                    response.header("content-type")?.startsWith("application/vnd.woge.patch-stream") == true,
+                    "deferred-completion-order",
+                    "patch media type changed",
+                )
+                expect(
+                    response.header("cache-control") == "no-store",
+                    "deferred-completion-order",
+                    "unsafe cache policy",
+                )
+
+                val prefix = body.readThrough("Fast region")
+                expect(
+                    !prefix.toString(StandardCharsets.UTF_8).contains("Slow region"),
+                    "deferred-completion-order",
+                    "slow declaration blocked fast result",
+                )
+                expect(
+                    !fixture.slowRegion.isCompleted,
+                    "deferred-completion-order",
+                    "slow fixture completed before release",
+                )
+                fixture.slowRegion.complete(patch("Slow region"))
+                val stream = prefix + body.readAllBytes()
+                val events = PatchStreamV1.decoder().let { decoder -> decoder.feed(stream).also { decoder.finish() } }
+                expect(
+                    events.filterIsInstance<PatchStreamEvent.PatchFrame>().map { it.patch.target.region.value } ==
+                        listOf("fast", "slow"),
+                    "deferred-completion-order",
+                    "patches did not preserve completion order",
+                )
+                expect(
+                    events.lastOrNull() == PatchStreamEvent.Complete(EXPECTED_PATCH_COUNT),
+                    "deferred-completion-order",
+                    "stream incomplete",
+                )
+            }
+        }
+    }
+
+    private suspend fun verifyClientAbortCancellation() {
+        runContract("deferred-client-abort") {
+            val response =
+                client.open(
+                    RequestMethod.GET,
+                    AdapterTckRoutes.deferred(AdapterTckDeferredScenario.CLIENT_ABORT),
+                )
+            response.body().use { body -> body.readThrough("Ready region") }
+            withTimeout(CLIENT_ABORT_TIMEOUT) { fixture.cancelledRegion.await() }
+        }
+    }
+
+    private fun expectDocumentMetadata(
+        contract: String,
+        response: HttpResponse<*>,
+    ) {
+        expect(response.statusCode() == TCK_DOCUMENT_STATUS_CODE, contract, "expected HTTP 202")
+        expect(response.header(TCK_RESPONSE_HEADER) == "mapped", contract, "response header changed")
+        val contentType = response.header("content-type")?.lowercase().orEmpty()
+        expect(contentType.startsWith("text/html"), contract, "HTML media type changed")
+        expect(contentType.contains("charset=utf-8"), contract, "UTF-8 charset missing")
+        expect(
+            response.header("set-cookie")?.contains("woge-tck=safe") == true,
+            contract,
+            "response cookie missing",
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun runContract(
+        contract: String,
+        block: suspend () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (failure: AdapterTckViolation) {
+            throw failure
+        } catch (cause: Exception) {
+            throw violation(contract, "adapter request failed", cause)
+        }
+    }
+
+    private fun expect(
+        condition: Boolean,
+        contract: String,
+        detail: String,
+    ) {
+        if (!condition) throw violation(contract, detail)
+    }
+
+    private fun violation(
+        contract: String,
+        detail: String,
+        cause: Throwable? = null,
+    ): AdapterTckViolation = AdapterTckViolation(AdapterTckFailureOwner.ADAPTER, adapterName, contract, detail, cause)
+}
+
+private class AdapterTckHttpClient(
+    origin: URI,
+) {
+    private val base: String = origin.toString().trimEnd('/')
+    private val client: HttpClient =
+        HttpClient
+            .newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+            .build()
+
+    fun open(
+        method: RequestMethod,
+        path: String,
+        headers: Map<String, String> = emptyMap(),
+    ): HttpResponse<InputStream> = send(method, path, headers, HttpResponse.BodyHandlers.ofInputStream())
+
+    fun text(
+        method: RequestMethod,
+        path: String,
+    ): HttpResponse<String> = send(method, path, emptyMap(), HttpResponse.BodyHandlers.ofString())
+
+    fun bytes(
+        method: RequestMethod,
+        path: String,
+    ): HttpResponse<ByteArray> = send(method, path, emptyMap(), HttpResponse.BodyHandlers.ofByteArray())
+
+    private fun <Body> send(
+        method: RequestMethod,
+        path: String,
+        headers: Map<String, String>,
+        handler: HttpResponse.BodyHandler<Body>,
+    ): HttpResponse<Body> {
+        val request =
+            HttpRequest
+                .newBuilder(URI.create(base + path))
+                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+                .method(method.value, HttpRequest.BodyPublishers.noBody())
+                .apply { headers.forEach(::header) }
+                .build()
+        return client.send(request, handler)
+    }
+}
+
+private fun HttpResponse<*>.header(name: String): String? = headers().firstValue(name).orElse(null)
+
+private fun InputStream.readThrough(marker: String): ByteArray {
+    val markerBytes = marker.toByteArray(StandardCharsets.UTF_8)
+    val output = ByteArrayOutputStream()
+    while (!output.endsWith(markerBytes)) {
+        val next = read()
+        check(next >= 0) { "Response ended before the bounded TCK marker" }
+        output.write(next)
+        check(output.size() <= MAX_STREAM_PREFIX_BYTES) { "TCK marker exceeded the bounded response prefix" }
+    }
+    return output.toByteArray()
+}
+
+private fun ByteArrayOutputStream.endsWith(suffix: ByteArray): Boolean {
+    val bytes = toByteArray()
+    return bytes.size >= suffix.size && bytes.copyOfRange(bytes.size - suffix.size, bytes.size).contentEquals(suffix)
+}
+
+private fun patch(text: String): dev.woge.protocol.PatchHtml =
+    dev.woge.protocol.patchHtml { element("p") { text(text) } }
+
+private const val MAX_STREAM_PREFIX_BYTES: Int = 64 * 1024
+private const val EXPECTED_PATCH_COUNT: Int = 2
+private const val CONNECT_TIMEOUT_SECONDS: Long = 5
+private const val REQUEST_TIMEOUT_SECONDS: Long = 10
+private val CLIENT_ABORT_TIMEOUT: kotlin.time.Duration = 5.seconds


### PR DESCRIPTION
## Outcome

- add a framework-neutral server-adapter TCK driven by a small real-HTTP harness factory
- verify GET/HEAD metadata and request mapping, document flush boundaries, redirects, controlled and pre-stream failures, binary patch framing, completion-order streaming and client-abort cancellation
- make Spring WebFlux the first executable TCK consumer over Reactor Netty
- provide additive extension suites for action, CSRF, caching, multipart and SSE capabilities when their portable contracts land
- publish the canonical native/enhanced/recovery parity matrix and stable failure ownership/contract diagnostics

## Verification

- `./gradlew :woge-adapter-tck:check :woge-spring-webflux:check --stacktrace`
- `./gradlew check --stacktrace` (154 tasks)
- documentation, ADR, module-boundary and whitespace validation
- source scan confirms no Spring, Reactor, Servlet or Ktor imports in TCK production sources

## Architecture decision

- Related ADRs: 0005, 0019, 0022 and 0026
- No new ADR is required: this is the executable contract explicitly required by those accepted decisions. It does not change the host-port ownership, module graph, protocol or public runtime API.

## Compatibility

The new API belongs to the non-production `woge-adapter-tck` test-support artifact. Production WebFlux API and wire bytes are unchanged. Spring MVC and Ktor consume the same factory contract in #67 and #68; #24 makes all rows a shared CI gate.

Closes #65
