### PR TITLE
Implement the Ktor walking-skeleton adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ and MVC vertical slices are executable from the repository; Woge is not ready fo
 Run the maintained example with `./gradlew :woge-reference-spring-webflux:bootRun`, then open
 `http://localhost:8080/projects/woge`. The [web-first quickstart](docs/guides/quickstart-spring-boot.md)
 explains the page, its full-navigation fallback and the small amount of Kotlin it uses.
-The same portable page runs on MVC with `./gradlew :woge-reference-spring-mvc:bootRun`.
+The same portable page runs on MVC with `./gradlew :woge-reference-spring-mvc:bootRun` and on Ktor
+with `./gradlew :woge-reference-ktor:run`.
 
 ## Direction
 

--- a/adapters/woge-ktor/README.md
+++ b/adapters/woge-ktor/README.md
@@ -1,0 +1,9 @@
+# Woge Ktor adapter
+
+`woge-ktor` connects framework-neutral Woge page use cases to ordinary Ktor routes. Applications
+keep path and query decoding in `routing { ... }`; the adapter owns HTTP metadata, HTML streaming,
+patch framing and request cancellation.
+
+Start with the [Ktor adapter guide](../../docs/guides/ktor-adapter.md) and the executable
+[`woge-reference-ktor`](../../examples/reference-application/ktor) application. Spring Boot remains
+Woge's primary getting-started host; this module is the maintained portability proof.

--- a/adapters/woge-ktor/api/woge-ktor.api
+++ b/adapters/woge-ktor/api/woge-ktor.api
@@ -1,0 +1,28 @@
+public final class dev/woge/ktor/DefaultKtorRequestContextFactory : dev/woge/ktor/KtorRequestContextFactory {
+	public static final field INSTANCE Ldev/woge/ktor/DefaultKtorRequestContextFactory;
+	public fun create (Lio/ktor/server/application/ApplicationCall;)Ldev/woge/host/RequestContext;
+}
+
+public abstract interface class dev/woge/ktor/KtorPageInput {
+	public abstract fun decode (Lio/ktor/server/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/woge/ktor/KtorRequestContextFactory {
+	public abstract fun create (Lio/ktor/server/application/ApplicationCall;)Ldev/woge/host/RequestContext;
+}
+
+public final class dev/woge/ktor/WogeKtorDeferredHandler {
+	public final fun handle (Lio/ktor/server/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/woge/ktor/WogeKtorHandlers {
+	public synthetic fun <init> (Ldev/woge/ktor/KtorRequestContextFactory;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/ktor/KtorRequestContextFactory;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun deferred (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/ktor/KtorPageInput;)Ldev/woge/ktor/WogeKtorDeferredHandler;
+	public final fun page (Ldev/woge/host/PageUseCase;Ldev/woge/ktor/KtorPageInput;)Ldev/woge/ktor/WogeKtorPageHandler;
+}
+
+public final class dev/woge/ktor/WogeKtorPageHandler {
+	public final fun handle (Lio/ktor/server/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/adapters/woge-ktor/build.gradle.kts
+++ b/adapters/woge-ktor/build.gradle.kts
@@ -1,12 +1,30 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     id("dev.woge.kotlin-jvm-library")
 }
 
 description = "Ktor transport adapter for Woge."
 
+kotlin {
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation()
+}
+
 dependencies {
     api(project(":woge-core"))
     api(project(":woge-protocol"))
     api(project(":woge-host-spi"))
+    api(libs.ktorServerCore)
+
     implementation(project(":woge-server-runtime"))
+
+    testImplementation(project(":woge-adapter-tck"))
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.ktorServerNetty)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("checkKotlinAbi"))
 }

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorPageInput.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorPageInput.kt
@@ -1,0 +1,8 @@
+package dev.woge.ktor
+
+import io.ktor.server.application.ApplicationCall
+
+/** Decodes route-specific page input at the Ktor adapter boundary. */
+public fun interface KtorPageInput<Input : Any> {
+    public suspend fun decode(call: ApplicationCall): Input
+}

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorRequestContextFactory.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorRequestContextFactory.kt
@@ -1,0 +1,97 @@
+package dev.woge.ktor
+
+import dev.woge.host.CorrelationId
+import dev.woge.host.HttpHeader
+import dev.woge.host.LanguageTag
+import dev.woge.host.RequestContext
+import dev.woge.host.RequestCookies
+import dev.woge.host.RequestHeaders
+import dev.woge.host.RequestId
+import dev.woge.host.RequestMethod
+import dev.woge.host.RequestTrace
+import dev.woge.host.httpHeader
+import dev.woge.host.requestCookie
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.httpMethod
+import java.util.Locale
+import java.util.UUID
+
+/** Maps adapter-owned Ktor request state to an immutable Woge request snapshot. */
+public fun interface KtorRequestContextFactory {
+    public fun create(call: ApplicationCall): RequestContext
+}
+
+/**
+ * Safe default context mapping for GET, HEAD and OPTIONS page endpoints.
+ *
+ * It creates request-local trace IDs, copies non-sensitive headers and parsed cookies, and marks the
+ * caller anonymous. Applications using authentication or unsafe methods must install a factory that
+ * translates their Ktor authentication and CSRF decisions explicitly.
+ */
+public object DefaultKtorRequestContextFactory : KtorRequestContextFactory {
+    override fun create(call: ApplicationCall): RequestContext {
+        val method = RequestMethod.of(call.request.httpMethod.value)
+        require(method in SAFE_METHODS) {
+            "The default Ktor context supports safe page methods only; install an explicit security context factory"
+        }
+        val traceValue = UUID.randomUUID().toString()
+        val headers =
+            buildList<HttpHeader> {
+                call.request.headers.forEach { name, values ->
+                    if (name.lowercase(Locale.ROOT) !in SENSITIVE_REQUEST_HEADERS) {
+                        values.forEach { value -> add(httpHeader(name, value)) }
+                    }
+                }
+            }
+        val cookies =
+            call.request.cookies.rawCookies
+                .keys
+                .mapNotNull { name -> call.request.cookies[name]?.let { value -> requestCookie(name, value) } }
+        val language = preferredLanguage(call.request.headers[HttpHeaders.AcceptLanguage])
+
+        return RequestContext(
+            method = method,
+            trace = RequestTrace(RequestId.of(traceValue), CorrelationId.of(traceValue)),
+            language =
+                if (language.isEmpty() || language == "*") {
+                    LanguageTag.UNDETERMINED
+                } else {
+                    LanguageTag.of(language)
+                },
+            headers = RequestHeaders.of(headers),
+            cookies = RequestCookies.of(cookies),
+        )
+    }
+}
+
+private fun preferredLanguage(header: String?): String =
+    header
+        .orEmpty()
+        .split(',')
+        .asSequence()
+        .map { candidate ->
+            val parts = candidate.trim().split(';')
+            val quality =
+                parts
+                    .drop(1)
+                    .firstOrNull { it.trim().startsWith("q=", ignoreCase = true) }
+                    ?.substringAfter('=')
+                    ?.toDoubleOrNull()
+                    ?: 1.0
+            parts.first().trim() to quality
+        }.filter { (tag, quality) -> tag.isNotEmpty() && quality > 0.0 }
+        .maxByOrNull { (_, quality) -> quality }
+        ?.first
+        ?.lowercase(Locale.ROOT)
+        .orEmpty()
+
+private val SAFE_METHODS: Set<RequestMethod> = setOf(RequestMethod.GET, RequestMethod.HEAD, RequestMethod.OPTIONS)
+private val SENSITIVE_REQUEST_HEADERS: Set<String> =
+    setOf(
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+        "x-csrf-token",
+        "x-xsrf-token",
+    )

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorResponses.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorResponses.kt
@@ -1,0 +1,130 @@
+package dev.woge.ktor
+
+import dev.woge.host.PageResult
+import dev.woge.host.ResponseCookie
+import dev.woge.host.ResponseMetadata
+import dev.woge.host.SameSite
+import dev.woge.html.DEFAULT_HTML_CHUNK_CHARS
+import dev.woge.html.HtmlSink
+import dev.woge.html.StreamingHtmlSink
+import dev.woge.protocol.HtmlFrame
+import dev.woge.protocol.PatchStreamV1
+import dev.woge.runtime.EncodedPatchChunk
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.log
+import io.ktor.server.request.httpMethod
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import java.nio.charset.StandardCharsets
+
+internal suspend fun ApplicationCall.respondWogePage(result: PageResult) {
+    when (result) {
+        is PageResult.Document -> respondDocument(result)
+        is PageResult.Redirect -> {
+            applyMetadata(result.metadata)
+            response.headers.append(HttpHeaders.Location, result.location.value)
+            respond(BodylessContent)
+        }
+
+        is PageResult.Failure -> {
+            applyMetadata(result.metadata)
+            respond(BodylessContent)
+        }
+    }
+}
+
+internal suspend fun ApplicationCall.respondWogePatches(chunks: Flow<EncodedPatchChunk>) {
+    response.headers.append(HttpHeaders.CacheControl, "no-store")
+    respondBytesWriter(contentType = ContentType.parse(PatchStreamV1.MEDIA_TYPE)) {
+        chunks.writeAndFlushKtorChunks { bytes ->
+            writeFully(bytes)
+            flush()
+        }
+    }
+}
+
+internal suspend fun Flow<EncodedPatchChunk>.writeAndFlushKtorChunks(writeAndFlush: suspend (ByteArray) -> Unit) {
+    collect { chunk -> writeAndFlush(chunk.bytes) }
+}
+
+internal suspend fun ApplicationCall.respondWogePreStreamFailure(failure: Throwable) {
+    application.log.error("Woge request failed before response streaming", failure)
+    response.status(HttpStatusCode.InternalServerError)
+    respond(BodylessContent)
+}
+
+private suspend fun ApplicationCall.respondDocument(document: PageResult.Document) {
+    applyMetadata(document.metadata)
+    if (request.httpMethod == HttpMethod.Head) {
+        response.headers.append(HttpHeaders.ContentType, requireNotNull(document.metadata.contentType).value)
+        respond(BodylessContent)
+        return
+    }
+
+    respondBytesWriter(
+        contentType = ContentType.parse(requireNotNull(document.metadata.contentType).value),
+        status = HttpStatusCode.fromValue(document.metadata.status.code),
+    ) {
+        document.frames.collect { frame ->
+            frame.renderChunks().forEach { bytes -> writeFully(bytes) }
+            flush()
+        }
+    }
+}
+
+private fun ApplicationCall.applyMetadata(metadata: ResponseMetadata) {
+    response.status(HttpStatusCode.fromValue(metadata.status.code))
+    metadata.headers.forEach { header -> response.headers.append(header.name.value, header.value.value) }
+    metadata.cookies.forEach { cookie -> response.headers.append(HttpHeaders.SetCookie, cookie.render()) }
+}
+
+private fun ResponseCookie.render(): String =
+    buildString {
+        append(name.value)
+        append('=')
+        append(value.value)
+        append("; Path=")
+        append(path.value)
+        maxAgeSeconds?.let { maxAge ->
+            append("; Max-Age=")
+            append(maxAge)
+        }
+        if (secure) append("; Secure")
+        if (httpOnly) append("; HttpOnly")
+        append("; SameSite=")
+        append(sameSite.httpValue)
+    }
+
+private val SameSite.httpValue: String
+    get() = name.lowercase().replaceFirstChar(Char::uppercase)
+
+private object BodylessContent : OutgoingContent.NoContent()
+
+private suspend fun HtmlFrame.renderChunks(): List<ByteArray> {
+    val context = currentCoroutineContext()
+    val chunks = mutableListOf<ByteArray>()
+    val sink =
+        StreamingHtmlSink(
+            downstream =
+                HtmlSink { value ->
+                    context.ensureActive()
+                    chunks += value.toByteArray(StandardCharsets.UTF_8)
+                },
+            maxChunkChars = DEFAULT_HTML_CHUNK_CHARS,
+        )
+    context.ensureActive()
+    writeTo(sink)
+    context.ensureActive()
+    sink.flush()
+    return chunks
+}

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorDeferredHandler.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorDeferredHandler.kt
@@ -1,0 +1,44 @@
+package dev.woge.ktor
+
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageRequest
+import dev.woge.protocol.PatchId
+import dev.woge.runtime.DeferredRegionExecutor
+import dev.woge.runtime.DeferredRegionPolicy
+import dev.woge.runtime.encodeDeferredPatchStream
+import io.ktor.server.application.ApplicationCall
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration
+
+/** Executes page-scoped deferred work and streams patches through a Ktor route. */
+public class WogeKtorDeferredHandler<Input : Any> internal constructor(
+    private val regions: DeferredRegionsUseCase<Input>,
+    private val input: KtorPageInput<Input>,
+    private val contexts: KtorRequestContextFactory,
+    maxConcurrency: Int,
+    regionTimeout: Duration,
+) {
+    private val executor = DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency, regionTimeout))
+
+    /** Re-authorizes the request before returning an incrementally flushed patch response. */
+    @Suppress("TooGenericExceptionCaught")
+    public suspend fun handle(call: ApplicationCall) {
+        val pageRequest = PageRequest(input.decode(call), contexts.create(call))
+        val declaredRegions =
+            try {
+                regions.regions(pageRequest).toList()
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Throwable) {
+                call.respondWogePreStreamFailure(failure)
+                return
+            }
+        var patchNumber = 0
+        val chunks =
+            executor.execute(declaredRegions).encodeDeferredPatchStream {
+                patchNumber += 1
+                PatchId.of("deferred-$patchNumber")
+            }
+        call.respondWogePatches(chunks)
+    }
+}

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorHandlers.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorHandlers.kt
@@ -1,0 +1,37 @@
+package dev.woge.ktor
+
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageUseCase
+import dev.woge.runtime.DeferredRegionPolicy
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Creates route-local Woge handlers with one shared Ktor runtime policy. */
+public class WogeKtorHandlers(
+    private val contexts: KtorRequestContextFactory = DefaultKtorRequestContextFactory,
+    private val maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
+    private val regionTimeout: Duration = 30.seconds,
+) {
+    init {
+        DeferredRegionPolicy(maxConcurrency, regionTimeout)
+    }
+
+    /** Creates a handler for one typed page and its route-local input decoder. */
+    public fun <Input : Any> page(
+        useCase: PageUseCase<Input>,
+        input: KtorPageInput<Input>,
+    ): WogeKtorPageHandler<Input> = WogeKtorPageHandler(useCase, input, contexts)
+
+    /** Creates a handler for one typed deferred-region stream and its route-local input decoder. */
+    public fun <Input : Any> deferred(
+        useCase: DeferredRegionsUseCase<Input>,
+        input: KtorPageInput<Input>,
+    ): WogeKtorDeferredHandler<Input> =
+        WogeKtorDeferredHandler(
+            regions = useCase,
+            input = input,
+            contexts = contexts,
+            maxConcurrency = maxConcurrency,
+            regionTimeout = regionTimeout,
+        )
+}

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorPageHandler.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorPageHandler.kt
@@ -1,0 +1,29 @@
+package dev.woge.ktor
+
+import dev.woge.host.PageRequest
+import dev.woge.host.PageUseCase
+import io.ktor.server.application.ApplicationCall
+import kotlinx.coroutines.CancellationException
+
+/** Executes one portable [PageUseCase] from a Ktor route. */
+public class WogeKtorPageHandler<Input : Any> internal constructor(
+    private val page: PageUseCase<Input>,
+    private val input: KtorPageInput<Input>,
+    private val contexts: KtorRequestContextFactory,
+) {
+    /** Decodes, executes and maps the page without an application-owned transport controller. */
+    @Suppress("TooGenericExceptionCaught")
+    public suspend fun handle(call: ApplicationCall) {
+        val pageRequest = PageRequest(input.decode(call), contexts.create(call))
+        val result =
+            try {
+                page.open(pageRequest)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Throwable) {
+                call.respondWogePreStreamFailure(failure)
+                return
+            }
+        call.respondWogePage(result)
+    }
+}

--- a/adapters/woge-ktor/src/test/kotlin/dev/woge/ktor/KtorResponseLifecycleTest.kt
+++ b/adapters/woge-ktor/src/test/kotlin/dev/woge/ktor/KtorResponseLifecycleTest.kt
@@ -1,0 +1,63 @@
+package dev.woge.ktor
+
+import dev.woge.host.DeferredRegionFailure
+import dev.woge.host.deferredRegion
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchId
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.patchHtml
+import dev.woge.runtime.DeferredRegionExecutor
+import dev.woge.runtime.encodeDeferredPatchStream
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import kotlin.time.Duration.Companion.seconds
+
+class KtorResponseLifecycleTest {
+    @Test
+    fun `downstream write failure cancels structured region children`() {
+        val waitingStarted = CompletableDeferred<Unit>()
+        val waitingCancelled = CompletableDeferred<Unit>()
+        val regions =
+            listOf(
+                region("waiting") {
+                    try {
+                        waitingStarted.complete(Unit)
+                        awaitCancellation()
+                    } finally {
+                        waitingCancelled.complete(Unit)
+                    }
+                },
+                region("ready") { patchHtml { text("Ready") } },
+            )
+        val chunks =
+            DeferredRegionExecutor()
+                .execute(regions)
+                .encodeDeferredPatchStream { PatchId.of("lifecycle-${it.region.target.region.value}") }
+
+        assertThrows(IOException::class.java) {
+            runBlocking {
+                chunks.writeAndFlushKtorChunks {
+                    waitingStarted.await()
+                    throw IOException("simulated downstream failure")
+                }
+            }
+        }
+        runBlocking { withTimeout(5.seconds) { waitingCancelled.await() } }
+    }
+}
+
+private fun region(
+    id: String,
+    content: suspend () -> dev.woge.protocol.PatchHtml,
+) = deferredRegion(
+    target = PatchTarget(PageEpoch.of("ktor-lifecycle"), RegionTargetId.of(id)),
+    loading = { text("Loading") },
+    onFailure = { _: DeferredRegionFailure -> patchHtml { text("Unavailable") } },
+    content = content,
+)

--- a/adapters/woge-ktor/src/test/kotlin/dev/woge/ktor/WogeKtorAdapterTckTest.kt
+++ b/adapters/woge-ktor/src/test/kotlin/dev/woge/ktor/WogeKtorAdapterTckTest.kt
@@ -1,0 +1,76 @@
+package dev.woge.ktor
+
+import dev.woge.tck.AdapterTckApplication
+import dev.woge.tck.AdapterTckCapability
+import dev.woge.tck.AdapterTckDeferredScenario
+import dev.woge.tck.AdapterTckHarnessFactory
+import dev.woge.tck.AdapterTckPageScenario
+import dev.woge.tck.AdapterTckRoutes
+import dev.woge.tck.AdapterTckServer
+import dev.woge.tck.ServerAdapterContract
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.routing.get
+import io.ktor.server.routing.head
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class WogeKtorAdapterTckTest {
+    @Test
+    fun `Ktor passes the shared server adapter contract`() {
+        ServerAdapterContract(KtorTckHarnessFactory).verify()
+    }
+}
+
+private object KtorTckHarnessFactory : AdapterTckHarnessFactory {
+    override val adapterName: String = "ktor"
+
+    override fun start(application: AdapterTckApplication): AdapterTckServer {
+        val page =
+            WogeKtorHandlers().page(
+                application.pages,
+                KtorPageInput { call ->
+                    AdapterTckPageScenario.fromPath(requireNotNull(call.parameters["scenario"]))
+                },
+            )
+        val deferred =
+            WogeKtorHandlers().deferred(
+                application.deferredRegions,
+                KtorPageInput { call ->
+                    AdapterTckDeferredScenario.fromPath(requireNotNull(call.parameters["scenario"]))
+                },
+            )
+        val server =
+            embeddedServer(Netty, host = "127.0.0.1", port = 0) {
+                routing {
+                    get(AdapterTckRoutes.PAGE_PATTERN) { page.handle(call) }
+                    head(AdapterTckRoutes.PAGE_PATTERN) { page.handle(call) }
+                    get(AdapterTckRoutes.DEFERRED_PATTERN) { deferred.handle(call) }
+                }
+            }.start(wait = false)
+        return KtorTckServer(server)
+    }
+}
+
+private class KtorTckServer(
+    private val server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>,
+) : AdapterTckServer {
+    private val port: Int =
+        runBlocking {
+            server.engine
+                .resolvedConnectors()
+                .single()
+                .port
+        }
+    override val origin: URI =
+        URI.create("http://127.0.0.1:$port")
+    override val capabilities: Set<AdapterTckCapability> = emptySet()
+
+    override fun close() {
+        server.stop(1_000, 1_000)
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Render independent page regions](guides/deferred-regions.md)
 - [Run a Woge page with Spring WebFlux](guides/spring-webflux-adapter.md)
 - [Run a Woge page with Spring MVC](guides/spring-mvc-adapter.md)
+- [Run a Woge page with Ktor](guides/ktor-adapter.md)
 - [Configure Woge with Spring Boot](guides/spring-boot-starter.md)
 
 ## Performance evidence
@@ -73,5 +74,6 @@ The spikes below justify accepted decisions. Their code is evidence, not a produ
 4. **API reference:** list exact types, defaults and compatibility constraints.
 5. **Internals:** explain protocols, generated code and adapter implementation.
 
-The Spring Boot WebFlux and MVC launchers are executable vertical slices over one shared application.
-Ktor parity, typed interactions and the broader component system remain later milestones.
+The Spring Boot WebFlux, Spring MVC and Ktor launchers are executable vertical slices over one shared
+application. Cross-host browser journeys, typed interactions and the broader component system remain
+later milestones.

--- a/docs/adr/0033-suspending-ktor-adapter.md
+++ b/docs/adr/0033-suspending-ktor-adapter.md
@@ -1,0 +1,95 @@
+# ADR 0033: Bind Woge to idiomatic suspending Ktor routes
+
+- Status: Accepted
+- Date: 2026-09-06
+- Decision owners: Woge maintainers
+- Related issues: [#68](https://github.com/christian-draeger/woge/issues/68), [#24](https://github.com/christian-draeger/woge/issues/24), [#122](https://github.com/christian-draeger/woge/issues/122), [#124](https://github.com/christian-draeger/woge/issues/124)
+
+## Context
+
+Ktor must prove that Woge's host SPI and portable page code do not depend on Spring, Reactor or the
+Servlet API. The integration should still look like normal Ktor to a Ktor developer: paths, query
+parameters, authentication plugins and application startup belong to the host application.
+
+Woge HTML writers are intentionally synchronous while Ktor response channels suspend. Ktor's Netty
+engine can stream and flush a response incrementally, but it does not notify a handler reliably when
+an idle peer disappears. Like Servlet, it observes that condition no later than a subsequent failed
+write. The adapter must describe that limitation honestly instead of passing a fixture through a
+transport-specific workaround.
+
+Spring Boot is Woge's primary onboarding and enterprise integration. Ktor is a first-class maintained
+adapter and portability proof, not a replacement product direction. RPC, including `kotlinx.rpc`, is
+outside this HTTP and HTML adapter boundary.
+
+## Decision
+
+`woge-ktor` exposes `WogeKtorHandlers`, a route-local `KtorPageInput` decoder and a replaceable
+`KtorRequestContextFactory`. Applications call the resulting suspending handlers from ordinary
+`get` and `head` routes. `ApplicationCall` remains confined to adapter/bootstrap code; portable
+`PageUseCase` and `DeferredRegionsUseCase` implementations receive only Woge host types.
+
+The default request-context factory admits GET, HEAD and OPTIONS, creates request-local trace IDs,
+copies parsed cookies and accepted language, and omits raw authentication, cookie and CSRF headers.
+Authenticated or unsafe routes require an application factory that translates verified Ktor plugin
+state into immutable Woge security facts.
+
+Page metadata is applied before collection. Ktor's `respondBytesWriter` owns one suspending response
+producer. Each HTML frame renders through Woge's shared 8 KiB chunking sink, its chunks are written,
+and the channel is flushed before the next frame is collected. Patch chunks are written and flushed
+one at a time. This preserves Woge flush semantics and Ktor backpressure. One HTML frame is currently
+retained while crossing the synchronous-writer/suspending-channel boundary; hard frame budgets remain
+the responsibility of [#122](https://github.com/christian-draeger/woge/issues/122).
+
+Status, content type, headers, cookies and redirects derive from the same `ResponseMetadata` as the
+Spring adapters. HEAD returns identical document metadata without collecting body frames. A use-case
+failure before streaming is logged server-side and becomes a bodyless 500 so private exception text
+cannot reach the client. Controlled failures remain typed and bodyless.
+
+The response producer collects the deferred-region flow in the Ktor request coroutine. Coroutine
+cancellation and downstream write failures propagate unchanged and cancel its structured children.
+The Netty harness does not advertise the adapter TCK's passive client-abort capability: closing an
+idle response is not itself a deterministic server signal until another write occurs. Later
+long-lived protocols need heartbeat policy if they require a bounded disconnect-detection delay.
+
+The adapter uses Ktor 3.5.2 and its Netty engine in tests and the example. The shared adapter TCK runs
+over a real ephemeral HTTP listener. A separate executable Ktor launcher reuses the exact project
+page, markup and assets used by Spring MVC and WebFlux.
+
+## Alternatives considered
+
+- **Hide routing behind a generated Ktor application plugin:** rejected because normal routes and
+  host-owned authentication should remain visible. Generated typed route helpers can be additive.
+- **Expose Ktor types to page code:** rejected because it would invalidate host portability and make
+  the shared TCK application impossible.
+- **Buffer an entire document before responding:** rejected because delayed frames would block the
+  shell and erase the streaming contract.
+- **Run a blocking bridge around `ByteWriteChannel`:** rejected because it would bypass Ktor's
+  suspending backpressure and complicate cancellation.
+- **Advertise immediate passive client-abort cancellation:** rejected because Netty cannot prove it
+  while an idle response performs no I/O.
+- **Use RPC as the page transport:** rejected because links, forms, HTML, HTTP status and progressive
+  enhancement are the first-class interface. RPC may only be reconsidered for a separate capability.
+
+## Consequences
+
+### Positive
+
+- The same application and HTML source now run on Spring WebFlux, Spring MVC and Ktor.
+- Ktor developers keep familiar routing, plugins, request decoding and server lifecycle.
+- A suspending response producer preserves backpressure and structured cancellation.
+- The real-server TCK proves metadata, safe failures, HTML flushes and patch completion order.
+- The public adapter API is small, compiler-visible and ABI-checked.
+
+### Negative
+
+- One HTML frame is retained as bounded chunks before a suspending channel write.
+- Passive disconnect cancellation can lag until the next write.
+- Applications still write small route-input decoders until typed route generation exists.
+- Spring Boot and Ktor require separate bootstrap code even though their page code is shared.
+
+## Follow-up
+
+- Run shared browser journeys across all three hosts in [#24](https://github.com/christian-draeger/woge/issues/24).
+- Define hard pending-write and frame budgets in [#122](https://github.com/christian-draeger/woge/issues/122).
+- Complete canonical pre/post-commit diagnostics in [#124](https://github.com/christian-draeger/woge/issues/124).
+- Add heartbeat policy only with a protocol that genuinely needs long-lived idle responses.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0030](0030-materialize-css-and-head-asset-boundaries.md) | Accepted | Materialize CSS and head asset boundaries without a styling runtime |
 | [0031](0031-root-build-spring-boot-quickstart-consumer.md) | Accepted | Keep the canonical Spring Boot quickstart as a separated root-build consumer |
 | [0032](0032-async-servlet-spring-mvc-adapter.md) | Accepted | Stream Spring MVC responses through adapter-owned Servlet async handlers |
+| [0033](0033-suspending-ktor-adapter.md) | Accepted | Bind Woge to idiomatic suspending Ktor routes |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/architecture/server-adapter-parity.md
+++ b/docs/architecture/server-adapter-parity.md
@@ -35,12 +35,12 @@ HTTP abort.
 | --- | --- | --- | --- | --- | --- |
 | Spring Boot WebFlux | Yes | Yes | Yes | Yes | Passing |
 | Spring Boot MVC | Yes | Yes | Yes | Failed-write/timeout | Passing |
-| Ktor | Required | Required | Required | Required | Planned in [#68](https://github.com/christian-draeger/woge/issues/68) |
+| Ktor | Yes | Yes | Yes | Failed-write/coroutine cancellation | Passing |
 
-WebFlux and MVC are executable consumers of the same fixture. MVC intentionally omits the passive
-client-abort capability because Servlet exposes a disconnect only when a later write fails; its
-adapter tests and [guide](../guides/spring-mvc-adapter.md) cover that boundary explicitly. An adapter
-is not complete when only its own focused tests pass: it must invoke `ServerAdapterContract` from its test suite. The
+WebFlux, MVC and Ktor are executable consumers of the same fixture. MVC and Ktor intentionally omit
+the passive client-abort capability because their tested engines expose an idle disconnect only when
+a later write fails; their adapter guides cover that boundary explicitly. An adapter is not complete
+when only its own focused tests pass: it must invoke `ServerAdapterContract` from its test suite. The
 multi-host reference slice in [#24](https://github.com/christian-draeger/woge/issues/24) turns all
 three rows into a CI release gate.
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,7 +16,7 @@ plain/CSS-Module/Tailwind class composition, head assets and explicit CSP/SRI bo
 The [HTML sink guide](stream-html.md) explains when to buffer or stream the same component functions.
 
 The [server host SPI guide](server-host-spi.md) introduces typed page use cases, immutable request
-facts, streamed HTML frames, redirects and safe failures before the Spring and Ktor adapters land.
+facts, streamed HTML frames, redirects and safe failures shared by the Spring and Ktor adapters.
 
 The [Patch IR guide](patch-ir.md) explains the first transport-neutral replace operation and its
 page, target, interaction and revision checks in browser terms.
@@ -29,3 +29,6 @@ page-local regions, streamed application, delegated lifecycle events and safe fa
 
 The [deferred-region guide](deferred-regions.md) shows ordinary loading HTML, independently completing
 server work, bounded concurrency and request-owned cancellation.
+
+The [Ktor adapter guide](ktor-adapter.md) connects the same portable page to ordinary suspending Ktor
+routes while keeping Spring Boot as the primary getting-started path.

--- a/docs/guides/ktor-adapter.md
+++ b/docs/guides/ktor-adapter.md
@@ -1,0 +1,97 @@
+# Run a Woge page with Ktor
+
+Woge keeps your page independent from Ktor. A small Ktor bootstrap connects it to normal routes. If
+you already know HTTP and Ktor routing, those concepts remain the application model.
+
+Spring Boot is the primary Woge quickstart. Use this adapter when Ktor is your host or when you want
+to verify that application code stays independent from either server framework.
+
+## Keep page code portable
+
+Define the page against Woge's typed host boundary:
+
+```kotlin
+data class ProjectInput(val project: String)
+
+class ProjectPage : PageUseCase<ProjectInput> {
+    override suspend fun open(request: PageRequest<ProjectInput>): PageResult =
+        htmlPage {
+            element("main") {
+                element("h1") { text("Project ${request.input.project}") }
+            }
+        }
+}
+```
+
+This class has no `ApplicationCall`, server engine or Ktor plugin import. The compiler therefore
+keeps accidental host coupling visible.
+
+## Connect ordinary Ktor routes
+
+Create handlers once while installing your application module:
+
+```kotlin
+fun Application.projectModule() {
+    val projectPage = ProjectPage()
+    val handlers = WogeKtorHandlers()
+    val input = KtorPageInput<ProjectInput> { call ->
+        ProjectInput(requireNotNull(call.parameters["project"]))
+    }
+    val page = handlers.page(projectPage, input)
+
+    routing {
+        get("/projects/{project}") { page.handle(call) }
+        head("/projects/{project}") { page.handle(call) }
+        staticResources("/assets", "static/assets")
+    }
+}
+```
+
+The route still owns its URL and input decoding. The handler maps the portable result to status,
+headers, cookies and `text/html; charset=UTF-8`. Each Woge HTML frame is flushed before the next one
+is requested.
+
+If the page also implements `DeferredRegionsUseCase<ProjectInput>`, add the patch route:
+
+```kotlin
+val patches = handlers.deferred(projectPage, input)
+
+routing {
+    get("/projects/{project}/woge-patches") { patches.handle(call) }
+}
+```
+
+The browser receives the same versioned patch stream as it does from either Spring adapter. No RPC
+layer or Ktor serialization format sits between the browser and the web-native page contract.
+
+## Add authentication explicitly
+
+The default mapper supports safe GET, HEAD and OPTIONS requests. It copies ordinary headers, parsed
+cookies and the preferred language, but deliberately excludes raw credentials and CSRF headers.
+
+For an authenticated application, supply a `KtorRequestContextFactory` to `WogeKtorHandlers`. Read
+the principal and verified security decisions from your installed Ktor plugins and translate only
+the immutable facts that application authorization needs. Both the page and deferred-patch routes
+must repeat the same authorization decision.
+
+## Understand cancellation and failures
+
+Ktor's response coroutine owns page collection and all deferred-region children. Cancelling that
+coroutine or failing a channel write cancels unfinished region work. A peer disappearing while the
+response is completely idle becomes observable on a later write; use protocol heartbeats only when
+a future long-lived feature requires a bounded detection delay.
+
+A typed `PageResult.Failure` returns its client-safe status without a body. An unexpected use-case
+exception before streaming is logged and becomes a bodyless 500. After bytes have started, a failure
+terminates the response because its status can no longer change.
+
+Run the maintained example with:
+
+```shell
+./gradlew :woge-reference-ktor:run
+```
+
+Then open `http://localhost:8080/projects/woge`. The same `ProjectPage`, HTML, CSS and JavaScript are
+also exercised by both Spring Boot launchers.
+
+See [ADR 0033](../adr/0033-suspending-ktor-adapter.md) for the lifecycle and buffering tradeoffs.

--- a/docs/guides/quickstart-spring-boot.md
+++ b/docs/guides/quickstart-spring-boot.md
@@ -111,7 +111,8 @@ public class ProjectPage :
 ```
 
 This is the application-side port in a ports-and-adapters architecture. The same class already runs
-through the [Spring MVC launcher](spring-mvc-adapter.md); issue #24 adds Ktor and the cross-host gate.
+through the [Spring MVC](spring-mvc-adapter.md) and [Ktor](ktor-adapter.md) launchers; issue #24 adds
+the cross-host browser gate.
 
 Spring-specific code stays in
 [`ProjectRoutes.kt`](../../examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/ProjectRoutes.kt).

--- a/docs/guides/server-host-spi.md
+++ b/docs/guides/server-host-spi.md
@@ -1,7 +1,7 @@
 # Write a framework-neutral page use case
 
 The host SPI is the small seam between your Woge application and a server such as Spring Boot or
-Ktor. It is implemented now; the actual server adapters are still M1 work.
+Ktor. All three maintained server adapters implement it.
 
 If you know controllers or route handlers, `PageUseCase<Input>` has the same job: it receives decoded
 input and returns a response. The difference is that its types belong to Woge, so the same application
@@ -129,15 +129,15 @@ For an expected failure, return a safe category and the existing correlation ID:
 failure(FailureCategory.NOT_FOUND, request.context.correlationId)
 ```
 
-There is deliberately no public message, request payload or exception field. The future host adapters
-will map this to the shared error response. Unexpected exceptions still propagate so the adapter can
-handle them according to whether response output has started.
+There is deliberately no public message, request payload or exception field. Host adapters map this
+to the shared error response. Unexpected exceptions still propagate so the adapter can handle them
+according to whether response output has started.
 
 ## What comes next
 
-The shared adapter TCK will run one use case through an in-memory harness and real Spring MVC, Spring
-WebFlux and Ktor servers. Spring Boot remains the primary setup path. Action and live-update ports are
-added only when their typed descriptors and Patch IR can be tested end to end.
+The shared adapter TCK runs one use case through real Spring MVC, Spring WebFlux and Ktor servers.
+Spring Boot remains the primary setup path. Action and live-update ports are added only when their
+typed descriptors and Patch IR can be tested end to end.
 
 The current executable examples are the
 [`woge-host-spi` tests](../../modules/woge-host-spi/src/test/kotlin/dev/woge/host/PageUseCaseTest.kt).

--- a/examples/reference-application/README.md
+++ b/examples/reference-application/README.md
@@ -3,20 +3,21 @@
 This directory is the maintained consumer of Woge's public modules. Its project-operations domain and
 journeys are defined in [ADR 0004](../../docs/adr/0004-project-operations-reference-application.md).
 
-Run either Spring Boot host with:
+Run a maintained host with:
 
 ```shell
 ./gradlew :woge-reference-spring-webflux:bootRun
 ./gradlew :woge-reference-spring-mvc:bootRun
+./gradlew :woge-reference-ktor:run
 ```
 
 Then open `http://localhost:8080/projects/woge`.
 
 [`shared`](shared) contains the host-neutral `ProjectPage`, semantic HTML, region work and web assets.
-[`spring-webflux`](spring-webflux) and [`spring-mvc`](spring-mvc) contain only their Spring Boot
-startup, routes and real-server integration tests. The example consumes root projects and is verified by
-`./gradlew check`; it is executable documentation, not a published Woge artifact.
+[`spring-webflux`](spring-webflux), [`spring-mvc`](spring-mvc) and [`ktor`](ktor) contain only their
+host-specific startup, routes and real-server integration tests. The example consumes root projects
+and is verified by `./gradlew check`; it is executable documentation, not a published Woge artifact.
 
 The [quickstart](../../docs/guides/quickstart-spring-boot.md) explains the observable web behavior.
-Issue [#24](https://github.com/christian-draeger/woge/issues/24) adds the Ktor launcher and the final
-cross-host browser gate around the same `shared` code.
+Issue [#24](https://github.com/christian-draeger/woge/issues/24) adds the final cross-host browser gate
+around the same `shared` code.

--- a/examples/reference-application/ktor/build.gradle.kts
+++ b/examples/reference-application/ktor/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    application
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Executable Ktor portability example for Woge."
+
+application {
+    mainClass.set("dev.woge.example.ktor.WogeKtorQuickstartKt")
+}
+
+dependencies {
+    implementation(project(":woge-reference-shared"))
+    implementation(project(":woge-ktor"))
+    implementation(libs.ktorServerNetty)
+
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/examples/reference-application/ktor/src/main/kotlin/dev/woge/example/ktor/WogeKtorQuickstart.kt
+++ b/examples/reference-application/ktor/src/main/kotlin/dev/woge/example/ktor/WogeKtorQuickstart.kt
@@ -1,0 +1,56 @@
+package dev.woge.example.ktor
+
+import dev.woge.example.project.ProjectPage
+import dev.woge.example.project.ProjectPageInput
+import dev.woge.example.project.ProjectPageView
+import dev.woge.ktor.KtorPageInput
+import dev.woge.ktor.WogeKtorHandlers
+import io.ktor.server.application.Application
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.http.content.staticResources
+import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.routing.get
+import io.ktor.server.routing.head
+import io.ktor.server.routing.routing
+
+/** Installs the Ktor routes around the same portable page used by both Spring Boot examples. */
+public fun Application.wogeReferenceModule() {
+    val projectPage = ProjectPage()
+    val handlers = WogeKtorHandlers()
+    val page =
+        handlers.page(
+            projectPage,
+            KtorPageInput { call ->
+                ProjectPageInput(
+                    project = requireNotNull(call.parameters["project"]),
+                    view = parseView(call.request.queryParameters["view"].orEmpty()),
+                )
+            },
+        )
+    val patches =
+        handlers.deferred(
+            projectPage,
+            KtorPageInput { call -> ProjectPageInput(requireNotNull(call.parameters["project"])) },
+        )
+
+    routing {
+        get("/projects/{project}") { page.handle(call) }
+        head("/projects/{project}") { page.handle(call) }
+        get("/projects/{project}/woge-patches") { patches.handle(call) }
+        staticResources("/assets", "static/assets")
+    }
+}
+
+/** Runs the Ktor portability example with Netty on port 8080. */
+public fun main() {
+    embeddedServer(Netty, host = "0.0.0.0", port = 8080, module = Application::wogeReferenceModule)
+        .start(wait = true)
+}
+
+private fun parseView(value: String): ProjectPageView =
+    when (value) {
+        "" -> ProjectPageView.SHELL
+        "complete" -> ProjectPageView.COMPLETE
+        else -> throw BadRequestException("Unknown project view")
+    }

--- a/examples/reference-application/ktor/src/test/kotlin/dev/woge/example/ktor/WogeKtorQuickstartTest.kt
+++ b/examples/reference-application/ktor/src/test/kotlin/dev/woge/example/ktor/WogeKtorQuickstartTest.kt
@@ -1,0 +1,98 @@
+package dev.woge.example.ktor
+
+import dev.woge.protocol.PatchStreamEvent
+import dev.woge.protocol.PatchStreamV1
+import dev.woge.protocol.ReplacePatch
+import io.ktor.server.application.Application
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class WogeKtorQuickstartTest {
+    @Test
+    fun `Ktor serves the same shell patches navigation and assets`() {
+        val server =
+            embeddedServer(Netty, host = "127.0.0.1", port = 0, module = Application::wogeReferenceModule)
+                .start(wait = false)
+        try {
+            val port =
+                runBlocking {
+                    server.engine
+                        .resolvedConnectors()
+                        .single()
+                        .port
+                }
+            verifyApplication("http://127.0.0.1:$port")
+        } finally {
+            server.stop(1_000, 1_000)
+        }
+    }
+
+    private fun verifyApplication(origin: String) {
+        val shell = get(origin, "/projects/woge")
+        assertEquals(200, shell.statusCode())
+        assertTrue(shell.header("content-type").startsWith("text/html"))
+        assertTrue(shell.body().startsWith("<!doctype html><html lang=\"en\">"))
+        assertTrue(shell.body().contains("data-woge-region=\"summary\""))
+        assertTrue(shell.body().contains("action=\"/projects/woge\" method=\"get\""))
+        assertFalse(shell.body().contains("Publish the first web-first guide"))
+
+        val patchResponse = getBytes(origin, "/projects/woge/woge-patches")
+        assertEquals(200, patchResponse.statusCode())
+        assertTrue(patchResponse.header("content-type").startsWith("application/vnd.woge.patch-stream"))
+        val events = decode(patchResponse.body())
+        val frames = events.filterIsInstance<PatchStreamEvent.PatchFrame>()
+        assertEquals(setOf("summary", "tasks", "activity"), frames.map { it.patch.target.region.value }.toSet())
+        assertEquals(PatchStreamEvent.Complete(3), events.last())
+        assertTrue(frames.any { (it.patch as ReplacePatch).html.value.contains("Publish the first web-first guide") })
+
+        val complete = get(origin, "/projects/woge?view=complete")
+        assertTrue(complete.body().contains("Publish the first web-first guide"))
+        assertFalse(complete.body().contains("data-woge-region"))
+        assertEquals(404, get(origin, "/projects/missing").statusCode())
+        assertEquals(400, get(origin, "/projects/woge?view=unknown").statusCode())
+
+        assertTrue(get(origin, "/assets/application.css").body().contains("@container (width >= 32rem)"))
+        assertTrue(get(origin, "/assets/application.js").body().contains("createWogePatchRuntime"))
+        assertTrue(get(origin, "/assets/woge/index.js").body().contains("export function createWogePatchRuntime"))
+    }
+
+    private fun decode(bytes: ByteArray): List<PatchStreamEvent> {
+        val decoder = PatchStreamV1.decoder()
+        val events = decoder.feed(bytes)
+        decoder.finish()
+        return events
+    }
+
+    private fun get(
+        origin: String,
+        path: String,
+    ): HttpResponse<String> =
+        CLIENT.send(
+            HttpRequest.newBuilder(URI.create(origin + path)).GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun getBytes(
+        origin: String,
+        path: String,
+    ): HttpResponse<ByteArray> =
+        CLIENT.send(
+            HttpRequest.newBuilder(URI.create(origin + path)).GET().build(),
+            HttpResponse.BodyHandlers.ofByteArray(),
+        )
+
+    private fun <T> HttpResponse<T>.header(name: String): String = headers().firstValue(name).orElseThrow()
+
+    private companion object {
+        private val CLIENT: HttpClient = HttpClient.newHttpClient()
+    }
+}

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt
@@ -29,7 +29,7 @@ public data class ProjectPageInput(
     public val view: ProjectPageView = ProjectPageView.SHELL,
 )
 
-/** Host-neutral project page used unchanged by the Spring MVC, WebFlux and future Ktor launchers. */
+/** Host-neutral project page used unchanged by the Spring MVC, WebFlux and Ktor launchers. */
 public class ProjectPage :
     PageUseCase<ProjectPageInput>,
     DeferredRegionsUseCase<ProjectPageInput> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ junitPlatform = "1.13.4"
 jmhGradle = "0.7.3"
 jsoup = "1.23.2"
 jetbrainsAnnotations = "26.1.0"
+ktor = "3.5.2"
 kotlin = "2.4.10"
 ktlintGradle = "14.2.0"
 serialization = "1.11.0"
@@ -30,6 +31,8 @@ kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-cor
 kotlinxCoroutinesReactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
 kotlinxCoroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+ktorServerCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
+ktorServerNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ktlintGradlePlugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlintGradle" }
 reactorNettyHttp = { module = "io.projectreactor.netty:reactor-netty-http" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,3 +38,6 @@ project(":woge-reference-spring-webflux").projectDir = file("examples/reference-
 
 include(":woge-reference-spring-mvc")
 project(":woge-reference-spring-mvc").projectDir = file("examples/reference-application/spring-mvc")
+
+include(":woge-reference-ktor")
+project(":woge-reference-ktor").projectDir = file("examples/reference-application/ktor")


### PR DESCRIPTION
## Outcome

Implements the first-class Ktor adapter and proves that the same Woge page, markup, deferred regions and assets run unchanged on Spring WebFlux, Spring MVC and Ktor.

- adds idiomatic suspending Ktor page/deferred handlers with route-local input decoding
- maps safe request context, status, headers, cookies, redirects, UTF-8 HTML and patch media types
- flushes each HTML frame and encoded patch chunk through Ktor's `ByteWriteChannel`
- maps unexpected pre-stream use-case failures to a safe bodyless 500
- propagates response cancellation and downstream write failures into structured region children
- runs the shared adapter TCK over a real ephemeral Netty listener
- adds an executable Ktor reference launcher that reuses the shared Spring application and assets
- keeps Spring Boot as the primary quickstart and keeps RPC outside the adapter boundary

## Verification

- [x] Relevant local checks pass
- [x] Public examples compile or execute
- [x] Security, accessibility and no-JavaScript behavior were considered
- [x] Documentation is updated with the implementation

`./gradlew clean check --no-build-cache --stacktrace` passed (216 tasks).

## Architecture decision

- Related ADR: [ADR 0033](https://github.com/christian-draeger/woge/blob/feat/ktor-adapter/docs/adr/0033-suspending-ktor-adapter.md)
- Why required: this adds a public adapter API and fixes the Ktor streaming, failure, cancellation and passive-disconnect compatibility contract.

## Compatibility

Adds the ABI-checked `woge-ktor` public surface and Ktor 3.5.2 dependency. Portable core and protocol APIs do not change. The browser receives the same HTML and patch protocol as from Spring. Netty's idle passive disconnect is documented honestly: cancellation is deterministic when the request coroutine is cancelled or a later write fails, but an idle peer close is not advertised as an immediate TCK capability.

Closes #68
