### PR TITLE
Ship the multi-host walking-skeleton reference slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 Woge is an HTML-first Kotlin framework for typed, server-driven and progressively enhanced web applications.
 
-The M0 architecture and product-validation baseline is complete. The first M1 Spring Boot WebFlux
-and MVC vertical slices are executable from the repository; Woge is not ready for production use yet.
+The M0 architecture and product-validation baseline is complete. The first M1 multi-host vertical
+slice is executable on Spring Boot WebFlux, Spring MVC and Ktor; Woge is not ready for production use
+yet.
 
 Run the maintained example with `./gradlew :woge-reference-spring-webflux:bootRun`, then open
 `http://localhost:8080/projects/woge`. The [web-first quickstart](docs/guides/quickstart-spring-boot.md)
 explains the page, its full-navigation fallback and the small amount of Kotlin it uses.
 The same portable page runs on MVC with `./gradlew :woge-reference-spring-mvc:bootRun` and on Ktor
 with `./gradlew :woge-reference-ktor:run`.
+`./gradlew referenceBrowserSmoke` runs the same enhanced and no-JavaScript journeys through all three
+hosts in Chromium, Firefox and WebKit.
 
 ## Direction
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,11 +42,34 @@ val validateDocumentation = registerValidation(
     "Validates local documentation links and executable snippet references.",
     "scripts/validate-documentation.sh",
 )
-tasks.register<Exec>("referenceBrowserSmoke") {
+fun registerReferenceBrowserSmoke(
+    name: String,
+    host: String,
+    configuration: Exec.() -> Unit = {},
+) = tasks.register<Exec>(name) {
     group = "verification"
-    description = "Runs the Spring Boot reference application in the supported Playwright engines."
+    description = "Runs the $host reference application in the supported Playwright engines."
     workingDir(layout.projectDirectory.dir("client/woge-fallback-client"))
+    environment("WOGE_REFERENCE_HOST", host)
     commandLine("npm", "run", "test:reference")
+    configuration()
+}
+
+val referenceBrowserSmokeWebFlux =
+    registerReferenceBrowserSmoke("referenceBrowserSmokeWebFlux", "spring-webflux")
+val referenceBrowserSmokeMvc =
+    registerReferenceBrowserSmoke("referenceBrowserSmokeMvc", "spring-mvc") {
+        mustRunAfter(referenceBrowserSmokeWebFlux)
+    }
+val referenceBrowserSmokeKtor =
+    registerReferenceBrowserSmoke("referenceBrowserSmokeKtor", "ktor") {
+        mustRunAfter(referenceBrowserSmokeMvc)
+    }
+
+tasks.register("referenceBrowserSmoke") {
+    group = "verification"
+    description = "Runs the shared browser journeys through every maintained server adapter."
+    dependsOn(referenceBrowserSmokeWebFlux, referenceBrowserSmokeMvc, referenceBrowserSmokeKtor)
 }
 
 val test = registerAggregate("test", "Runs tests in every production build project.", "test")

--- a/client/woge-fallback-client/playwright.reference.config.mjs
+++ b/client/woge-fallback-client/playwright.reference.config.mjs
@@ -1,6 +1,23 @@
 import { defineConfig } from "@playwright/test";
 
 const browsers = ["chromium", "firefox", "webkit"];
+const hostName = process.env.WOGE_REFERENCE_HOST ?? "spring-webflux";
+const hosts = {
+  "spring-webflux": {
+    command: "../../gradlew -p ../.. :woge-reference-spring-webflux:bootRun --console=plain",
+  },
+  "spring-mvc": {
+    command: "../../gradlew -p ../.. :woge-reference-spring-mvc:bootRun --console=plain",
+  },
+  ktor: {
+    command: "../../gradlew -p ../.. :woge-reference-ktor:run --console=plain",
+  },
+};
+const host = hosts[hostName];
+
+if (!host) {
+  throw new Error(`Unknown WOGE_REFERENCE_HOST '${hostName}'`);
+}
 
 export default defineConfig({
   testDir: "./reference-browser-tests",
@@ -8,10 +25,10 @@ export default defineConfig({
   forbidOnly: true,
   retries: 0,
   workers: process.env.CI ? 3 : undefined,
-  outputDir: "test-results/reference-application",
+  outputDir: `test-results/reference-application/${hostName}`,
   reporter: [
     ["line"],
-    ["html", { open: "never", outputFolder: "playwright-report/reference-application" }],
+    ["html", { open: "never", outputFolder: `playwright-report/reference-application/${hostName}` }],
   ],
   use: {
     baseURL: "http://127.0.0.1:8080",
@@ -20,7 +37,7 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: "../../gradlew -p ../.. :woge-reference-spring-webflux:bootRun --console=plain",
+    command: host.command,
     url: "http://127.0.0.1:8080/projects/woge",
     reuseExistingServer: false,
     timeout: 120_000,

--- a/client/woge-fallback-client/reference-browser-tests/enhanced.spec.mjs
+++ b/client/woge-fallback-client/reference-browser-tests/enhanced.spec.mjs
@@ -29,7 +29,7 @@ test("renders the useful shell before applying every deferred region", async ({ 
 
   await expect(page.locator('[data-woge-region][data-woge-revision="1"]')).toHaveCount(3);
   await expect(page.getByRole("table", { name: "Current tasks for Woge" })).toBeVisible();
-  await expect(page.getByText("Spring Boot adapter selected")).toBeVisible();
+  await expect(page.getByText("Server adapter contract verified")).toBeVisible();
   await expect(page.getByText("Loading from the server…")).toHaveCount(0);
   await expect(page.locator(".is-loading")).toHaveCount(0);
   expect(browserProblems).toEqual([]);

--- a/client/woge-fallback-client/reference-browser-tests/no-javascript.spec.mjs
+++ b/client/woge-fallback-client/reference-browser-tests/no-javascript.spec.mjs
@@ -13,7 +13,7 @@ test("uses an ordinary full navigation when JavaScript is unavailable", async ({
 
   await expect(page).toHaveURL(/\/projects\/woge\?view=complete$/);
   await expect(page.getByRole("table", { name: "Current tasks for Woge" })).toBeVisible();
-  await expect(page.getByText("Spring Boot adapter selected")).toBeVisible();
+  await expect(page.getByText("Server adapter contract verified")).toBeVisible();
   await expect(page.locator("[data-woge-region]")).toHaveCount(0);
   await expect(page.getByText("Loading from the server…")).toHaveCount(0);
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ The documentation grows with executable product slices. Pages describing unimple
 
 ## Performance evidence
 
+- [M1 multi-host walking-skeleton baseline](performance/m1-multi-host-baseline.md)
 - [Fallback client implementation baseline](performance/fallback-client-baseline.md)
 - [HTML sink baseline](performance/html-sinks-baseline.md)
 

--- a/docs/ai-dx/corpus-v0.1.md
+++ b/docs/ai-dx/corpus-v0.1.md
@@ -2,6 +2,15 @@
 
 This corpus defines model-neutral tasks and observable results. It deliberately does not prescribe Kotlin API names: the evaluated release's public quick start and API must make the canonical names discoverable. Tasks are cumulative and begin from the same clean Spring Boot consumer scaffold.
 
+## Canonical M1 fixture
+
+ADX-01, ADX-04 and the plain-CSS half of ADX-08 begin with the maintained
+[`ProjectPage`](../../examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt),
+its [semantic document](../../examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectDocument.kt)
+and the [Spring Boot quickstart](../guides/quickstart-spring-boot.md). The same source is compiled by
+all three launchers and exercised by JVM and cross-host browser tests. Evaluation tasks extend those
+files; they do not reconstruct an uncompiled copy from the prose examples.
+
 ## ADX-01 — First page
 
 Build a page at `/projects/{project}` with a document title, skip link, navigation landmark, one `h1` and the selected project's name. Link to it from the application home page using an ordinary URL.

--- a/docs/development/build-and-test.md
+++ b/docs/development/build-and-test.md
@@ -48,7 +48,7 @@ the deterministic negative compiler fixtures, JVM tests, formatting, static anal
 module-boundary checks, ADR metadata and documentation/snippet-link validation. It never calls an AI
 model.
 
-The Spring Boot reference application has a separate browser gate. Install its pinned Node and
+The multi-host reference application has a separate browser gate. Install its pinned Node and
 Playwright dependencies once, then invoke the same Gradle task as CI:
 
 ```shell
@@ -59,11 +59,11 @@ cd ../..
 ./gradlew referenceBrowserSmoke
 ```
 
-The task starts the compiled WebFlux example and verifies deferred enhancement plus the normal
-no-JavaScript navigation in Chromium, Firefox and WebKit. Failure traces and screenshots are written
-below `client/woge-fallback-client/test-results/reference-application`; the HTML report is below
-`client/woge-fallback-client/playwright-report/reference-application`. GitHub Actions uploads those
-paths and all JVM test reports even when a gate fails.
+The task starts WebFlux, MVC and Ktor in sequence and runs the same deferred-enhancement and normal
+no-JavaScript journeys in Chromium, Firefox and WebKit against each host. Failure traces, screenshots
+and HTML reports are grouped by host below `client/woge-fallback-client/test-results/reference-application`
+and `client/woge-fallback-client/playwright-report/reference-application`. GitHub Actions uploads
+those paths and all JVM test reports even when a gate fails.
 
 Public declarations in `woge-core`, `woge-protocol` and `woge-host-spi` are tracked by Kotlin's
 built-in ABI validator. `checkKotlinAbi` compares current declarations with the committed dump. Run

--- a/docs/guides/ktor-adapter.md
+++ b/docs/guides/ktor-adapter.md
@@ -8,18 +8,26 @@ to verify that application code stays independent from either server framework.
 
 ## Keep page code portable
 
-Define the page against Woge's typed host boundary:
+The maintained `ProjectPage` implements both the initial document and deferred work against Woge's
+typed host boundary:
+
+<!-- snippet: examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt -->
 
 ```kotlin
-data class ProjectInput(val project: String)
+public class ProjectPage :
+    PageUseCase<ProjectPageInput>,
+    DeferredRegionsUseCase<ProjectPageInput> {
+    override suspend fun open(request: PageRequest<ProjectPageInput>): PageResult {
+        val project =
+            findProject(request.input.project)
+                ?: return failure(FailureCategory.NOT_FOUND, request.context.correlationId)
+        return htmlPage { renderProjectDocument(project, request.input.view) }
+    }
 
-class ProjectPage : PageUseCase<ProjectInput> {
-    override suspend fun open(request: PageRequest<ProjectInput>): PageResult =
-        htmlPage {
-            element("main") {
-                element("h1") { text("Project ${request.input.project}") }
-            }
-        }
+    override suspend fun regions(request: PageRequest<ProjectPageInput>): Iterable<DeferredRegion> {
+        val project = findProject(request.input.project) ?: return emptyList()
+        return deferredRegions(project)
+    }
 }
 ```
 
@@ -28,20 +36,35 @@ keeps accidental host coupling visible.
 
 ## Connect ordinary Ktor routes
 
-Create handlers once while installing your application module:
+Create handlers once while installing your application module. This is the compiled launcher used by
+the integration and browser tests:
+
+<!-- snippet: examples/reference-application/ktor/src/main/kotlin/dev/woge/example/ktor/WogeKtorQuickstart.kt -->
 
 ```kotlin
-fun Application.projectModule() {
+public fun Application.wogeReferenceModule() {
     val projectPage = ProjectPage()
     val handlers = WogeKtorHandlers()
-    val input = KtorPageInput<ProjectInput> { call ->
-        ProjectInput(requireNotNull(call.parameters["project"]))
-    }
-    val page = handlers.page(projectPage, input)
+    val page =
+        handlers.page(
+            projectPage,
+            KtorPageInput { call ->
+                ProjectPageInput(
+                    project = requireNotNull(call.parameters["project"]),
+                    view = parseView(call.request.queryParameters["view"].orEmpty()),
+                )
+            },
+        )
+    val patches =
+        handlers.deferred(
+            projectPage,
+            KtorPageInput { call -> ProjectPageInput(requireNotNull(call.parameters["project"])) },
+        )
 
     routing {
         get("/projects/{project}") { page.handle(call) }
         head("/projects/{project}") { page.handle(call) }
+        get("/projects/{project}/woge-patches") { patches.handle(call) }
         staticResources("/assets", "static/assets")
     }
 }
@@ -50,16 +73,6 @@ fun Application.projectModule() {
 The route still owns its URL and input decoding. The handler maps the portable result to status,
 headers, cookies and `text/html; charset=UTF-8`. Each Woge HTML frame is flushed before the next one
 is requested.
-
-If the page also implements `DeferredRegionsUseCase<ProjectInput>`, add the patch route:
-
-```kotlin
-val patches = handlers.deferred(projectPage, input)
-
-routing {
-    get("/projects/{project}/woge-patches") { patches.handle(call) }
-}
-```
 
 The browser receives the same versioned patch stream as it does from either Spring adapter. No RPC
 layer or Ktor serialization format sits between the browser and the web-native page contract.

--- a/docs/guides/quickstart-spring-boot.md
+++ b/docs/guides/quickstart-spring-boot.md
@@ -111,8 +111,8 @@ public class ProjectPage :
 ```
 
 This is the application-side port in a ports-and-adapters architecture. The same class already runs
-through the [Spring MVC](spring-mvc-adapter.md) and [Ktor](ktor-adapter.md) launchers; issue #24 adds
-the cross-host browser gate.
+through the [Spring MVC](spring-mvc-adapter.md) and [Ktor](ktor-adapter.md) launchers. The shared
+cross-host browser gate verifies all three.
 
 Spring-specific code stays in
 [`ProjectRoutes.kt`](../../examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/ProjectRoutes.kt).

--- a/docs/performance/m1-multi-host-baseline.md
+++ b/docs/performance/m1-multi-host-baseline.md
@@ -1,0 +1,57 @@
+# M1 multi-host walking-skeleton baseline
+
+Recorded on 2026-09-06 for the maintained reference application. Run both commands from the
+repository root to reproduce the source measurements:
+
+```shell
+./spikes/spring-html-htmx-baseline/measure.sh
+./examples/reference-application/measure.sh
+```
+
+These are structural measurements, not throughput claims. Generated code, tests, build files and
+blank or comment-only lines are excluded. The M0 fixture already contains actions and SSE that the M1
+walking skeleton does not, so total source lines are not a like-for-like feature comparison. Host
+glue, duplicated route strings and selector-owned patch targets are the useful comparison here.
+
+## Recorded M1 values
+
+| Area | Nonblank application lines |
+| --- | ---: |
+| Shared Kotlin page, data and markup | 355 |
+| Shared application CSS and JavaScript bootstrap | 107 |
+| Spring MVC bootstrap and routes | 63 |
+| Spring WebFlux bootstrap and routes | 59 |
+| Ktor bootstrap and routes | 49 |
+| Total across all three hosts | 633 |
+
+The shared source has zero Spring, Servlet, Reactor or Ktor imports. Across all three launchers and
+the shared page there are 12 occurrences of the application-owned `/projects/` prefix and zero
+application-owned CSS/htmx selectors naming patch targets.
+
+## Comparison with the M0 hand-written Spring fixture
+
+| Measurement | M0 baseline | M1 Woge slice | Change |
+| --- | ---: | ---: | ---: |
+| Spring MVC host Kotlin | 208 | 63 | -69.7% |
+| Spring WebFlux host Kotlin | 206 | 59 | -71.4% |
+| Both Spring host layers | 414 | 122 | -70.5% |
+| Route-prefix occurrences | 27 across two hosts | 12 across three hosts | -55.6% while adding Ktor |
+| Application-owned patch-target selectors | 2 | 0 | removed |
+
+Woge does not remove normal route declarations: each host still visibly owns its URLs and input
+decoding. The reduction comes from sharing page execution, markup, deferred-region behavior,
+metadata and patch semantics behind the host port instead of duplicating controllers and templates.
+
+## Executable coverage
+
+The release gate compiles and runs one shared application through:
+
+- one real-server adapter TCK for Spring WebFlux, Spring MVC and Ktor;
+- one real-server integration test per executable launcher;
+- the same enhanced and no-JavaScript Playwright journeys on all three hosts in Chromium, Firefox
+  and WebKit—18 host/browser/mode combinations.
+
+This baseline does not yet claim production latency, allocation or throughput budgets. Those require
+a fixed deployment environment, warm-up policy and representative action/live-update workload. The
+current measurements establish the reproducible comparison point without turning workstation or CI
+timing noise into a compatibility promise.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,5 +4,5 @@ Maintained documentation examples live below this directory and join the root ve
 they are executable. They use supported public APIs and compile in `./gradlew check`.
 
 Do not copy spike packages into examples. The first maintained consumer is the
-[reference application](reference-application/README.md), whose Spring Boot WebFlux launcher and
-host-neutral page are part of the root build.
+[reference application](reference-application/README.md), whose host-neutral page and Spring Boot
+WebFlux, Spring MVC and Ktor launchers are part of the root build.

--- a/examples/reference-application/README.md
+++ b/examples/reference-application/README.md
@@ -2,8 +2,22 @@
 
 This directory is the maintained consumer of Woge's public modules. Its project-operations domain and
 journeys are defined in [ADR 0004](../../docs/adr/0004-project-operations-reference-application.md).
+It is deliberately a normal web application: a GET returns useful semantic HTML, CSS is served as an
+ordinary asset, and a small module optionally fetches independently completed region patches.
 
-Run a maintained host with:
+## Start the primary path
+
+From a fresh checkout with JDK 21, start the primary Spring Boot WebFlux application:
+
+```shell
+./gradlew :woge-reference-spring-webflux:bootRun
+```
+
+Then open `http://localhost:8080/projects/woge`.
+
+## Run another host
+
+All launchers expose the same paths and browser behavior:
 
 ```shell
 ./gradlew :woge-reference-spring-webflux:bootRun
@@ -11,13 +25,34 @@ Run a maintained host with:
 ./gradlew :woge-reference-ktor:run
 ```
 
-Then open `http://localhost:8080/projects/woge`.
+Run one command at a time; each uses port 8080. WebFlux is the primary documented non-blocking Spring
+path, MVC proves Servlet compatibility, and Ktor proves that the Woge application boundary does not
+depend on Spring.
+
+## Follow the web flow
+
+1. `GET /projects/woge` returns the heading, navigation, native complete-page link and three useful
+   loading regions immediately.
+2. `/assets/application.js` reads the page's declared patch URL and fetches
+   `GET /projects/woge/woge-patches`.
+3. Each completed region arrives as a versioned replace patch and becomes visible without waiting for
+   slower siblings.
+4. With JavaScript disabled, the **Load all project data as one complete page** link performs a normal
+   navigation to `/projects/woge?view=complete`; no patch runtime is required.
 
 [`shared`](shared) contains the host-neutral `ProjectPage`, semantic HTML, region work and web assets.
 [`spring-webflux`](spring-webflux), [`spring-mvc`](spring-mvc) and [`ktor`](ktor) contain only their
 host-specific startup, routes and real-server integration tests. The example consumes root projects
 and is verified by `./gradlew check`; it is executable documentation, not a published Woge artifact.
 
-The [quickstart](../../docs/guides/quickstart-spring-boot.md) explains the observable web behavior.
-Issue [#24](https://github.com/christian-draeger/woge/issues/24) adds the final cross-host browser gate
-around the same `shared` code.
+The same Playwright source verifies enhanced and no-JavaScript journeys on all three hosts in
+Chromium, Firefox and WebKit:
+
+```shell
+./gradlew referenceBrowserSmoke
+```
+
+The [Spring Boot quickstart](../../docs/guides/quickstart-spring-boot.md) introduces the required
+Kotlin syntax just in time. The [Ktor guide](../../docs/guides/ktor-adapter.md) explains the secondary
+bootstrap. Reproducible source measurements and comparison with the hand-written M0 Spring fixture
+live in the [M1 baseline](../../docs/performance/m1-multi-host-baseline.md).

--- a/examples/reference-application/measure.sh
+++ b/examples/reference-application/measure.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+reference_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$reference_root"
+
+count_source_lines() {
+    local source_path="$1"
+    shift
+    local files
+    files=$(rg --files "$source_path" "$@")
+    awk '
+        NF && $0 !~ /^[[:space:]]*(\/\/|\/\*|\*|<!--|-->)/ { count++ }
+        END { print count + 0 }
+    ' $files
+}
+
+count_matches() {
+    local pattern="$1"
+    shift
+    local matches
+    matches=$(rg -o "$pattern" "$@" || true)
+    printf '%s\n' "$matches" | awk 'NF { count++ } END { print count + 0 }'
+}
+
+shared_kotlin_loc=$(count_source_lines shared/src/main/kotlin -g '*.kt')
+shared_web_assets_loc=$(count_source_lines shared/src/main/resources -g '*.css' -g '*.js')
+mvc_host_kotlin_loc=$(count_source_lines spring-mvc/src/main/kotlin -g '*.kt')
+webflux_host_kotlin_loc=$(count_source_lines spring-webflux/src/main/kotlin -g '*.kt')
+ktor_host_kotlin_loc=$(count_source_lines ktor/src/main/kotlin -g '*.kt')
+route_string_occurrences=$(
+    count_matches '/projects/' \
+        shared/src/main/kotlin \
+        spring-mvc/src/main/kotlin \
+        spring-webflux/src/main/kotlin \
+        ktor/src/main/kotlin
+)
+framework_imports_in_shared=$(
+    count_matches '^import (org\.springframework|io\.ktor|jakarta\.servlet|reactor\.)' shared/src/main/kotlin
+)
+application_owned_patch_selector_occurrences=$(
+    count_matches "hx-target=|querySelector\\([\"']#" shared/src/main
+)
+
+printf 'shared_kotlin_loc=%s\n' "$shared_kotlin_loc"
+printf 'shared_web_assets_loc=%s\n' "$shared_web_assets_loc"
+printf 'mvc_host_kotlin_loc=%s\n' "$mvc_host_kotlin_loc"
+printf 'webflux_host_kotlin_loc=%s\n' "$webflux_host_kotlin_loc"
+printf 'ktor_host_kotlin_loc=%s\n' "$ktor_host_kotlin_loc"
+printf 'route_string_occurrences=%s\n' "$route_string_occurrences"
+printf 'framework_imports_in_shared=%s\n' "$framework_imports_in_shared"
+printf 'application_owned_patch_selector_occurrences=%s\n' "$application_owned_patch_selector_occurrences"

--- a/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectData.kt
+++ b/examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectData.kt
@@ -31,6 +31,6 @@ internal val REFERENCE_PROJECT: ProjectSnapshot =
         activity =
             listOf(
                 ProjectActivity("Standards-native CSS contract implemented", "2026-09-05"),
-                ProjectActivity("Spring Boot adapter selected", "2026-09-05"),
+                ProjectActivity("Server adapter contract verified", "2026-09-05"),
             ),
     )


### PR DESCRIPTION
## Outcome

Completes the multi-host M1 walking-skeleton slice around one portable project page.

- runs one canonical Playwright suite against Spring Boot WebFlux, Spring MVC and Ktor
- verifies enhanced and no-JavaScript journeys in Chromium, Firefox and WebKit (18 combinations)
- keeps each host's reports and failure artifacts separate
- documents the primary Spring Boot command, host roles, ordinary HTTP flow, enhancement and full-navigation fallback
- connects the compiled reference source explicitly to the AI-DX corpus and Ktor guide
- adds a reproducible source-measurement script and an honest M1-to-M0 comparison
- removes host-specific wording from shared fixture data

Measured against the hand-written M0 Spring fixture, host bootstrap/route Kotlin is 69.7% smaller for MVC and 71.4% smaller for WebFlux. Route-prefix occurrences fall from 27 across two hosts to 12 across three hosts, and application-owned patch-target selectors fall from 2 to 0. These are structural measurements, not throughput claims.

## Verification

- [x] Relevant local checks pass
- [x] Public examples compile or execute
- [x] Security, accessibility and no-JavaScript behavior were considered
- [x] Documentation is updated with the implementation

- `./gradlew referenceBrowserSmoke --stacktrace` passed all 18 host/browser/mode combinations
- `./gradlew clean check --no-build-cache --stacktrace` passed (216 tasks)
- both M0 and M1 measurement scripts reproduce the recorded values

## Architecture decision

- Related ADRs: ADR 0004, ADR 0031, ADR 0032 and ADR 0033
- A new ADR is not required: this change completes their already-decided shared-reference-app and cross-host verification model without changing public APIs, protocols or compatibility policy.

## Compatibility

No public JVM or browser API changes. The existing `referenceBrowserSmoke` task now verifies every maintained host instead of WebFlux only. Direct `npm run test:reference` remains a WebFlux-focused default unless `WOGE_REFERENCE_HOST` selects `spring-mvc` or `ktor`.

Closes #24
