### PR TITLE
Add framework-neutral semantic observability

### DIFF
--- a/adapters/woge-ktor/api/woge-ktor.api
+++ b/adapters/woge-ktor/api/woge-ktor.api
@@ -16,8 +16,8 @@ public final class dev/woge/ktor/WogeKtorDeferredHandler {
 }
 
 public final class dev/woge/ktor/WogeKtorHandlers {
-	public synthetic fun <init> (Ldev/woge/ktor/KtorRequestContextFactory;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/woge/ktor/KtorRequestContextFactory;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/ktor/KtorRequestContextFactory;IJLdev/woge/host/WogeObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/ktor/KtorRequestContextFactory;IJLdev/woge/host/WogeObserver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deferred (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/ktor/KtorPageInput;)Ldev/woge/ktor/WogeKtorDeferredHandler;
 	public final fun page (Ldev/woge/host/PageUseCase;Ldev/woge/ktor/KtorPageInput;)Ldev/woge/ktor/WogeKtorPageHandler;
 }

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorResponses.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/KtorResponses.kt
@@ -4,12 +4,16 @@ import dev.woge.host.PageResult
 import dev.woge.host.ResponseCookie
 import dev.woge.host.ResponseMetadata
 import dev.woge.host.SameSite
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
 import dev.woge.html.DEFAULT_HTML_CHUNK_CHARS
 import dev.woge.html.HtmlSink
 import dev.woge.html.StreamingHtmlSink
 import dev.woge.protocol.HtmlFrame
 import dev.woge.protocol.PatchStreamV1
 import dev.woge.runtime.EncodedPatchChunk
+import dev.woge.runtime.observeCollection
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
@@ -27,9 +31,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import java.nio.charset.StandardCharsets
 
-internal suspend fun ApplicationCall.respondWogePage(result: PageResult) {
+internal suspend fun ApplicationCall.respondWogePage(
+    result: PageResult,
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
+) {
     when (result) {
-        is PageResult.Document -> respondDocument(result)
+        is PageResult.Document -> respondDocument(result, observer, observationContext)
         is PageResult.Redirect -> {
             applyMetadata(result.metadata)
             response.headers.append(HttpHeaders.Location, result.location.value)
@@ -63,7 +71,11 @@ internal suspend fun ApplicationCall.respondWogePreStreamFailure(failure: Throwa
     respond(BodylessContent)
 }
 
-private suspend fun ApplicationCall.respondDocument(document: PageResult.Document) {
+private suspend fun ApplicationCall.respondDocument(
+    document: PageResult.Document,
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
+) {
     applyMetadata(document.metadata)
     if (request.httpMethod == HttpMethod.Head) {
         response.headers.append(HttpHeaders.ContentType, requireNotNull(document.metadata.contentType).value)
@@ -75,7 +87,7 @@ private suspend fun ApplicationCall.respondDocument(document: PageResult.Documen
         contentType = ContentType.parse(requireNotNull(document.metadata.contentType).value),
         status = HttpStatusCode.fromValue(document.metadata.status.code),
     ) {
-        document.frames.collect { frame ->
+        document.frames.observeCollection(observer, WogeOperation.SHELL_RENDER, observationContext).collect { frame ->
             frame.renderChunks().forEach { bytes -> writeFully(bytes) }
             flush()
         }

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorDeferredHandler.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorDeferredHandler.kt
@@ -2,6 +2,7 @@ package dev.woge.ktor
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageRequest
+import dev.woge.host.WogeObserver
 import dev.woge.protocol.PatchId
 import dev.woge.runtime.DeferredRegionExecutor
 import dev.woge.runtime.DeferredRegionPolicy
@@ -17,13 +18,16 @@ public class WogeKtorDeferredHandler<Input : Any> internal constructor(
     private val contexts: KtorRequestContextFactory,
     maxConcurrency: Int,
     regionTimeout: Duration,
+    observer: WogeObserver,
 ) {
-    private val executor = DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency, regionTimeout))
+    private val executor = DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency, regionTimeout), observer)
+    private val observer = observer
 
     /** Re-authorizes the request before returning an incrementally flushed patch response. */
     @Suppress("TooGenericExceptionCaught")
     public suspend fun handle(call: ApplicationCall) {
-        val pageRequest = PageRequest(input.decode(call), contexts.create(call))
+        val context = contexts.create(call)
+        val pageRequest = PageRequest(input.decode(call), context)
         val declaredRegions =
             try {
                 regions.regions(pageRequest).toList()
@@ -35,10 +39,16 @@ public class WogeKtorDeferredHandler<Input : Any> internal constructor(
             }
         var patchNumber = 0
         val chunks =
-            executor.execute(declaredRegions).encodeDeferredPatchStream {
-                patchNumber += 1
-                PatchId.of("deferred-$patchNumber")
-            }
+            executor
+                .execute(declaredRegions, context.trace)
+                .encodeDeferredPatchStream(
+                    patchId = {
+                        patchNumber += 1
+                        PatchId.of("deferred-$patchNumber")
+                    },
+                    observer = observer,
+                    requestTrace = context.trace,
+                )
         call.respondWogePatches(chunks)
     }
 }

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorHandlers.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorHandlers.kt
@@ -2,6 +2,7 @@ package dev.woge.ktor
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObserver
 import dev.woge.runtime.DeferredRegionPolicy
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -11,6 +12,7 @@ public class WogeKtorHandlers(
     private val contexts: KtorRequestContextFactory = DefaultKtorRequestContextFactory,
     private val maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
     private val regionTimeout: Duration = 30.seconds,
+    private val observer: WogeObserver = WogeObserver.NONE,
 ) {
     init {
         DeferredRegionPolicy(maxConcurrency, regionTimeout)
@@ -20,7 +22,7 @@ public class WogeKtorHandlers(
     public fun <Input : Any> page(
         useCase: PageUseCase<Input>,
         input: KtorPageInput<Input>,
-    ): WogeKtorPageHandler<Input> = WogeKtorPageHandler(useCase, input, contexts)
+    ): WogeKtorPageHandler<Input> = WogeKtorPageHandler(useCase, input, contexts, observer)
 
     /** Creates a handler for one typed deferred-region stream and its route-local input decoder. */
     public fun <Input : Any> deferred(
@@ -33,5 +35,6 @@ public class WogeKtorHandlers(
             contexts = contexts,
             maxConcurrency = maxConcurrency,
             regionTimeout = regionTimeout,
+            observer = observer,
         )
 }

--- a/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorPageHandler.kt
+++ b/adapters/woge-ktor/src/main/kotlin/dev/woge/ktor/WogeKtorPageHandler.kt
@@ -2,6 +2,11 @@ package dev.woge.ktor
 
 import dev.woge.host.PageRequest
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.runtime.observationOutcome
+import dev.woge.runtime.observeOperation
 import io.ktor.server.application.ApplicationCall
 import kotlinx.coroutines.CancellationException
 
@@ -10,20 +15,29 @@ public class WogeKtorPageHandler<Input : Any> internal constructor(
     private val page: PageUseCase<Input>,
     private val input: KtorPageInput<Input>,
     private val contexts: KtorRequestContextFactory,
+    private val observer: WogeObserver,
 ) {
     /** Decodes, executes and maps the page without an application-owned transport controller. */
     @Suppress("TooGenericExceptionCaught")
     public suspend fun handle(call: ApplicationCall) {
-        val pageRequest = PageRequest(input.decode(call), contexts.create(call))
+        val context = contexts.create(call)
+        val observationContext = WogeObservationContext(requestTrace = context.trace)
+        val pageRequest = PageRequest(input.decode(call), context)
         val result =
             try {
-                page.open(pageRequest)
+                observer.observeOperation(
+                    operation = WogeOperation.PAGE_REQUEST,
+                    context = observationContext,
+                    successfulOutcome = { it.observationOutcome() },
+                ) {
+                    page.open(pageRequest)
+                }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (failure: Throwable) {
                 call.respondWogePreStreamFailure(failure)
                 return
             }
-        call.respondWogePage(result)
+        call.respondWogePage(result, observer, observationContext)
     }
 }

--- a/adapters/woge-ktor/src/test/kotlin/dev/woge/ktor/WogeKtorAdapterTckTest.kt
+++ b/adapters/woge-ktor/src/test/kotlin/dev/woge/ktor/WogeKtorAdapterTckTest.kt
@@ -31,14 +31,14 @@ private object KtorTckHarnessFactory : AdapterTckHarnessFactory {
 
     override fun start(application: AdapterTckApplication): AdapterTckServer {
         val page =
-            WogeKtorHandlers().page(
+            WogeKtorHandlers(observer = application.observer).page(
                 application.pages,
                 KtorPageInput { call ->
                     AdapterTckPageScenario.fromPath(requireNotNull(call.parameters["scenario"]))
                 },
             )
         val deferred =
-            WogeKtorHandlers().deferred(
+            WogeKtorHandlers(observer = application.observer).deferred(
                 application.deferredRegions,
                 KtorPageInput { call ->
                     AdapterTckDeferredScenario.fromPath(requireNotNull(call.parameters["scenario"]))

--- a/adapters/woge-spring-mvc/api/woge-spring-mvc.api
+++ b/adapters/woge-spring-mvc/api/woge-spring-mvc.api
@@ -20,8 +20,8 @@ public final class dev/woge/spring/mvc/WogeSpringMvcDeferredHandler : org/spring
 }
 
 public final class dev/woge/spring/mvc/WogeSpringMvcHandlers {
-	public synthetic fun <init> (Ldev/woge/spring/mvc/SpringMvcRequestContextFactory;Lkotlinx/coroutines/CoroutineDispatcher;JIJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/woge/spring/mvc/SpringMvcRequestContextFactory;Lkotlinx/coroutines/CoroutineDispatcher;JIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/spring/mvc/SpringMvcRequestContextFactory;Lkotlinx/coroutines/CoroutineDispatcher;JIJLdev/woge/host/WogeObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/spring/mvc/SpringMvcRequestContextFactory;Lkotlinx/coroutines/CoroutineDispatcher;JIJLdev/woge/host/WogeObserver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deferred (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/mvc/SpringMvcPageInput;)Ldev/woge/spring/mvc/WogeSpringMvcDeferredHandler;
 	public final fun page (Ldev/woge/host/PageUseCase;Ldev/woge/spring/mvc/SpringMvcPageInput;)Ldev/woge/spring/mvc/WogeSpringMvcPageHandler;
 }

--- a/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/ServletAsyncResponse.kt
+++ b/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/ServletAsyncResponse.kt
@@ -4,11 +4,15 @@ import dev.woge.host.PageResult
 import dev.woge.host.ResponseCookie
 import dev.woge.host.ResponseMetadata
 import dev.woge.host.SameSite
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
 import dev.woge.html.DEFAULT_HTML_CHUNK_CHARS
 import dev.woge.html.HtmlSink
 import dev.woge.html.StreamingHtmlSink
 import dev.woge.protocol.PatchStreamV1
 import dev.woge.runtime.EncodedPatchChunk
+import dev.woge.runtime.observeCollection
 import jakarta.servlet.AsyncEvent
 import jakarta.servlet.AsyncListener
 import jakarta.servlet.http.HttpServletRequest
@@ -97,12 +101,14 @@ private class ServletCoroutineListener(
 internal suspend fun PageResult.writeToServlet(
     request: HttpServletRequest,
     response: HttpServletResponse,
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
 ) {
     when (this) {
         is PageResult.Document -> {
             response.applyMetadata(metadata)
             if (!request.method.equals("HEAD", ignoreCase = true)) {
-                writeDocument(response)
+                writeDocument(response, observer, observationContext)
             }
         }
 
@@ -127,7 +133,11 @@ internal suspend fun Flow<EncodedPatchChunk>.writeToServlet(response: HttpServle
     }
 }
 
-private suspend fun PageResult.Document.writeDocument(response: HttpServletResponse) {
+private suspend fun PageResult.Document.writeDocument(
+    response: HttpServletResponse,
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
+) {
     val output = response.outputStream
     val context = kotlinx.coroutines.currentCoroutineContext()
     val chunks =
@@ -139,7 +149,7 @@ private suspend fun PageResult.Document.writeDocument(response: HttpServletRespo
                 },
             maxChunkChars = DEFAULT_HTML_CHUNK_CHARS,
         )
-    frames.collect { frame ->
+    frames.observeCollection(observer, WogeOperation.SHELL_RENDER, observationContext).collect { frame ->
         context.ensureActive()
         frame.writeTo(chunks)
         chunks.flush()

--- a/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/WogeSpringMvcDeferredHandler.kt
+++ b/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/WogeSpringMvcDeferredHandler.kt
@@ -2,6 +2,7 @@ package dev.woge.spring.mvc
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageRequest
+import dev.woge.host.WogeObserver
 import dev.woge.protocol.PatchId
 import dev.woge.runtime.DeferredRegionExecutor
 import dev.woge.runtime.DeferredRegionPolicy
@@ -12,6 +13,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.springframework.web.HttpRequestHandler
 
 /** Executes page-scoped deferred work through one asynchronous Servlet response. */
+@Suppress("LongParameterList")
 public class WogeSpringMvcDeferredHandler<Input : Any> internal constructor(
     private val regions: DeferredRegionsUseCase<Input>,
     private val input: SpringMvcPageInput<Input>,
@@ -19,8 +21,10 @@ public class WogeSpringMvcDeferredHandler<Input : Any> internal constructor(
     private val dispatcher: CoroutineDispatcher,
     private val asyncTimeoutMillis: Long,
     policy: DeferredRegionPolicy,
+    observer: WogeObserver,
 ) : HttpRequestHandler {
-    private val executor = DeferredRegionExecutor(policy)
+    private val executor = DeferredRegionExecutor(policy, observer)
+    private val observer = observer
 
     /** Re-authorizes the request before writing each completed patch as one flush boundary. */
     override fun handleRequest(
@@ -31,16 +35,21 @@ public class WogeSpringMvcDeferredHandler<Input : Any> internal constructor(
             response.writeMethodNotAllowed(DEFERRED_METHODS)
             return
         }
-        val pageRequest = PageRequest(input.decode(request), contexts.create(request))
+        val context = contexts.create(request)
+        val pageRequest = PageRequest(input.decode(request), context)
         request.launchWogeResponse(response, dispatcher, asyncTimeoutMillis) {
             val declaredRegions = regions.regions(pageRequest).toList()
             var patchNumber = 0
             executor
-                .execute(declaredRegions)
-                .encodeDeferredPatchStream {
-                    patchNumber += 1
-                    PatchId.of("deferred-$patchNumber")
-                }.writeToServlet(response)
+                .execute(declaredRegions, context.trace)
+                .encodeDeferredPatchStream(
+                    patchId = {
+                        patchNumber += 1
+                        PatchId.of("deferred-$patchNumber")
+                    },
+                    observer = observer,
+                    requestTrace = context.trace,
+                ).writeToServlet(response)
         }
     }
 

--- a/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/WogeSpringMvcHandlers.kt
+++ b/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/WogeSpringMvcHandlers.kt
@@ -2,6 +2,7 @@ package dev.woge.spring.mvc
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObserver
 import dev.woge.runtime.DeferredRegionPolicy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +16,7 @@ public class WogeSpringMvcHandlers(
     private val asyncTimeout: Duration = 60.seconds,
     private val maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
     private val regionTimeout: Duration = 30.seconds,
+    private val observer: WogeObserver = WogeObserver.NONE,
 ) {
     private val policy = DeferredRegionPolicy(maxConcurrency, regionTimeout)
     private val asyncTimeoutMillis: Long
@@ -32,12 +34,12 @@ public class WogeSpringMvcHandlers(
         useCase: PageUseCase<Input>,
         input: SpringMvcPageInput<Input>,
     ): WogeSpringMvcPageHandler<Input> =
-        WogeSpringMvcPageHandler(useCase, input, contexts, dispatcher, asyncTimeoutMillis)
+        WogeSpringMvcPageHandler(useCase, input, contexts, dispatcher, asyncTimeoutMillis, observer)
 
     /** Creates a Servlet handler for one typed deferred-region stream and input decoder. */
     public fun <Input : Any> deferred(
         useCase: DeferredRegionsUseCase<Input>,
         input: SpringMvcPageInput<Input>,
     ): WogeSpringMvcDeferredHandler<Input> =
-        WogeSpringMvcDeferredHandler(useCase, input, contexts, dispatcher, asyncTimeoutMillis, policy)
+        WogeSpringMvcDeferredHandler(useCase, input, contexts, dispatcher, asyncTimeoutMillis, policy, observer)
 }

--- a/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/WogeSpringMvcPageHandler.kt
+++ b/adapters/woge-spring-mvc/src/main/kotlin/dev/woge/spring/mvc/WogeSpringMvcPageHandler.kt
@@ -2,6 +2,11 @@ package dev.woge.spring.mvc
 
 import dev.woge.host.PageRequest
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.runtime.observationOutcome
+import dev.woge.runtime.observeOperation
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.CoroutineDispatcher
@@ -14,6 +19,7 @@ public class WogeSpringMvcPageHandler<Input : Any> internal constructor(
     private val contexts: SpringMvcRequestContextFactory,
     private val dispatcher: CoroutineDispatcher,
     private val asyncTimeoutMillis: Long,
+    private val observer: WogeObserver,
 ) : HttpRequestHandler {
     /** Snapshots the request, releases its Servlet thread and streams the page asynchronously. */
     override fun handleRequest(
@@ -24,9 +30,19 @@ public class WogeSpringMvcPageHandler<Input : Any> internal constructor(
             response.writeMethodNotAllowed(PAGE_METHODS)
             return
         }
-        val pageRequest = PageRequest(input.decode(request), contexts.create(request))
+        val context = contexts.create(request)
+        val pageRequest = PageRequest(input.decode(request), context)
+        val observationContext = WogeObservationContext(requestTrace = context.trace)
         request.launchWogeResponse(response, dispatcher, asyncTimeoutMillis) {
-            page.open(pageRequest).writeToServlet(request, response)
+            val result =
+                observer.observeOperation(
+                    operation = WogeOperation.PAGE_REQUEST,
+                    context = observationContext,
+                    successfulOutcome = { it.observationOutcome() },
+                ) {
+                    page.open(pageRequest)
+                }
+            result.writeToServlet(request, response, observer, observationContext)
         }
     }
 

--- a/adapters/woge-spring-mvc/src/test/kotlin/dev/woge/spring/mvc/WogeSpringMvcAdapterTckTest.kt
+++ b/adapters/woge-spring-mvc/src/test/kotlin/dev/woge/spring/mvc/WogeSpringMvcAdapterTckTest.kt
@@ -106,7 +106,8 @@ private class SpringMvcTimeoutConfiguration {
 @EnableAutoConfiguration
 private class SpringMvcTckConfiguration {
     @Bean
-    fun wogeSpringMvcHandlers(): WogeSpringMvcHandlers = WogeSpringMvcHandlers()
+    fun wogeSpringMvcHandlers(application: AdapterTckApplication): WogeSpringMvcHandlers =
+        WogeSpringMvcHandlers(observer = application.observer)
 
     @Bean
     fun adapterTckRoutes(

--- a/adapters/woge-spring-webflux/api/woge-spring-webflux.api
+++ b/adapters/woge-spring-webflux/api/woge-spring-webflux.api
@@ -12,21 +12,21 @@ public abstract interface class dev/woge/spring/webflux/WebFluxRequestContextFac
 }
 
 public final class dev/woge/spring/webflux/WogeWebFluxDeferredHandler {
-	public synthetic fun <init> (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLdev/woge/host/WogeObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLdev/woge/host/WogeObserver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun handle (Lorg/springframework/web/reactive/function/server/ServerRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/woge/spring/webflux/WogeWebFluxHandlers {
-	public synthetic fun <init> (Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLdev/woge/host/WogeObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/spring/webflux/WebFluxRequestContextFactory;IJLdev/woge/host/WogeObserver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deferred (Ldev/woge/host/DeferredRegionsUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;)Ldev/woge/spring/webflux/WogeWebFluxDeferredHandler;
 	public final fun page (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;)Ldev/woge/spring/webflux/WogeWebFluxPageHandler;
 }
 
 public final class dev/woge/spring/webflux/WogeWebFluxPageHandler {
-	public fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;)V
-	public synthetic fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;Ldev/woge/host/WogeObserver;)V
+	public synthetic fun <init> (Ldev/woge/host/PageUseCase;Ldev/woge/spring/webflux/WebFluxPageInput;Ldev/woge/spring/webflux/WebFluxRequestContextFactory;Ldev/woge/host/WogeObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun handle (Lorg/springframework/web/reactive/function/server/ServerRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxResponses.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WebFluxResponses.kt
@@ -4,12 +4,16 @@ import dev.woge.host.PageResult
 import dev.woge.host.ResponseCookie
 import dev.woge.host.ResponseMetadata
 import dev.woge.host.SameSite
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
 import dev.woge.html.DEFAULT_HTML_CHUNK_CHARS
 import dev.woge.html.HtmlSink
 import dev.woge.html.StreamingHtmlSink
 import dev.woge.protocol.HtmlFrame
 import dev.woge.protocol.PatchStreamV1
 import dev.woge.runtime.EncodedPatchChunk
+import dev.woge.runtime.observeCollection
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
@@ -29,11 +33,14 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration as JavaDuration
 import org.springframework.http.ResponseCookie as SpringResponseCookie
 
-internal suspend fun PageResult.toWebFluxResponse(): ServerResponse =
+internal suspend fun PageResult.toWebFluxResponse(
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
+): ServerResponse =
     when (this) {
         is PageResult.Document ->
             responseBuilder(metadata)
-                .body(documentBody(this))
+                .body(documentBody(this, observer, observationContext))
                 .awaitSingle()
 
         is PageResult.Redirect ->
@@ -79,8 +86,12 @@ private fun ResponseCookie.toSpringCookie(): SpringResponseCookie {
 private val SameSite.httpValue: String
     get() = name.lowercase().replaceFirstChar(Char::uppercase)
 
-private fun documentBody(document: PageResult.Document): BodyInserter<Unit, ServerHttpResponse> =
-    flushingBody { response -> document.flushGroups(response) }
+private fun documentBody(
+    document: PageResult.Document,
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
+): BodyInserter<Unit, ServerHttpResponse> =
+    flushingBody { response -> document.flushGroups(response, observer, observationContext) }
 
 private fun patchBody(chunks: Flow<EncodedPatchChunk>): BodyInserter<Unit, ServerHttpResponse> =
     flushingBody { response ->
@@ -93,8 +104,13 @@ private fun flushingBody(
     groups: (ServerHttpResponse) -> Publisher<out Publisher<out DataBuffer>>,
 ): BodyInserter<Unit, ServerHttpResponse> = BodyInserter { response, _ -> response.writeAndFlushWith(groups(response)) }
 
-private fun PageResult.Document.flushGroups(response: ServerHttpResponse): Publisher<out Publisher<out DataBuffer>> =
+private fun PageResult.Document.flushGroups(
+    response: ServerHttpResponse,
+    observer: WogeObserver,
+    observationContext: WogeObservationContext,
+): Publisher<out Publisher<out DataBuffer>> =
     frames
+        .observeCollection(observer, WogeOperation.SHELL_RENDER, observationContext)
         .map { frame ->
             Flux
                 .fromIterable(frame.renderChunks())

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxDeferredHandler.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxDeferredHandler.kt
@@ -2,6 +2,7 @@ package dev.woge.spring.webflux
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageRequest
+import dev.woge.host.WogeObserver
 import dev.woge.protocol.PatchId
 import dev.woge.runtime.DeferredRegionExecutor
 import dev.woge.runtime.DeferredRegionPolicy
@@ -18,19 +19,28 @@ public class WogeWebFluxDeferredHandler<Input : Any>(
     private val contexts: WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory,
     maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
     regionTimeout: Duration = 30.seconds,
+    observer: WogeObserver = WogeObserver.NONE,
 ) {
-    private val executor = DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency, regionTimeout))
+    private val executor = DeferredRegionExecutor(DeferredRegionPolicy(maxConcurrency, regionTimeout), observer)
+    private val observer = observer
 
     /** Re-authorizes the request before returning an incrementally flushed patch response. */
     public suspend fun handle(request: ServerRequest): ServerResponse {
-        val pageRequest = PageRequest(input.decode(request), contexts.create(request))
+        val context = contexts.create(request)
+        val pageRequest = PageRequest(input.decode(request), context)
         val declaredRegions = regions.regions(pageRequest).toList()
         var patchNumber = 0
         val chunks =
-            executor.execute(declaredRegions).encodeDeferredPatchStream {
-                patchNumber += 1
-                PatchId.of("deferred-$patchNumber")
-            }
+            executor
+                .execute(declaredRegions, context.trace)
+                .encodeDeferredPatchStream(
+                    patchId = {
+                        patchNumber += 1
+                        PatchId.of("deferred-$patchNumber")
+                    },
+                    observer = observer,
+                    requestTrace = context.trace,
+                )
         return chunks.toWebFluxPatchResponse()
     }
 }

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxHandlers.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxHandlers.kt
@@ -2,6 +2,7 @@ package dev.woge.spring.webflux
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObserver
 import dev.woge.runtime.DeferredRegionPolicy
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -11,6 +12,7 @@ public class WogeWebFluxHandlers(
     private val contexts: WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory,
     private val maxConcurrency: Int = DeferredRegionPolicy.DEFAULT_MAX_CONCURRENCY,
     private val regionTimeout: Duration = 30.seconds,
+    private val observer: WogeObserver = WogeObserver.NONE,
 ) {
     init {
         DeferredRegionPolicy(maxConcurrency, regionTimeout)
@@ -20,7 +22,7 @@ public class WogeWebFluxHandlers(
     public fun <Input : Any> page(
         useCase: PageUseCase<Input>,
         input: WebFluxPageInput<Input>,
-    ): WogeWebFluxPageHandler<Input> = WogeWebFluxPageHandler(useCase, input, contexts)
+    ): WogeWebFluxPageHandler<Input> = WogeWebFluxPageHandler(useCase, input, contexts, observer)
 
     /** Creates a handler for one typed deferred-region stream and its route-local input decoder. */
     public fun <Input : Any> deferred(
@@ -33,5 +35,6 @@ public class WogeWebFluxHandlers(
             contexts = contexts,
             maxConcurrency = maxConcurrency,
             regionTimeout = regionTimeout,
+            observer = observer,
         )
 }

--- a/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxPageHandler.kt
+++ b/adapters/woge-spring-webflux/src/main/kotlin/dev/woge/spring/webflux/WogeWebFluxPageHandler.kt
@@ -2,6 +2,11 @@ package dev.woge.spring.webflux
 
 import dev.woge.host.PageRequest
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.runtime.observationOutcome
+import dev.woge.runtime.observeOperation
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 
@@ -10,10 +15,21 @@ public class WogeWebFluxPageHandler<Input : Any>(
     private val page: PageUseCase<Input>,
     private val input: WebFluxPageInput<Input>,
     private val contexts: WebFluxRequestContextFactory = DefaultWebFluxRequestContextFactory,
+    private val observer: WogeObserver = WogeObserver.NONE,
 ) {
     /** Decodes, executes and maps the page without an application-owned controller. */
     public suspend fun handle(request: ServerRequest): ServerResponse {
-        val pageRequest = PageRequest(input.decode(request), contexts.create(request))
-        return page.open(pageRequest).toWebFluxResponse()
+        val context = contexts.create(request)
+        val observationContext = WogeObservationContext(requestTrace = context.trace)
+        val pageRequest = PageRequest(input.decode(request), context)
+        val result =
+            observer.observeOperation(
+                operation = WogeOperation.PAGE_REQUEST,
+                context = observationContext,
+                successfulOutcome = { it.observationOutcome() },
+            ) {
+                page.open(pageRequest)
+            }
+        return result.toWebFluxResponse(observer, observationContext)
     }
 }

--- a/adapters/woge-spring-webflux/src/test/kotlin/dev/woge/spring/webflux/WogeWebFluxAdapterTckTest.kt
+++ b/adapters/woge-spring-webflux/src/test/kotlin/dev/woge/spring/webflux/WogeWebFluxAdapterTckTest.kt
@@ -33,6 +33,7 @@ private object WebFluxTckHarnessFactory : AdapterTckHarnessFactory {
                 WebFluxPageInput { request ->
                     AdapterTckPageScenario.fromPath(request.pathVariable("scenario"))
                 },
+                observer = application.observer,
             )
         val deferred =
             WogeWebFluxDeferredHandler(
@@ -40,6 +41,7 @@ private object WebFluxTckHarnessFactory : AdapterTckHarnessFactory {
                 WebFluxPageInput { request ->
                     AdapterTckDeferredScenario.fromPath(request.pathVariable("scenario"))
                 },
+                observer = application.observer,
             )
         val routes =
             coRouter {

--- a/client/woge-fallback-client/browser-tests/runtime.spec.mjs
+++ b/client/woge-fallback-client/browser-tests/runtime.spec.mjs
@@ -213,6 +213,59 @@ test("cancels and unlocks an unfinished readable stream", async ({ page }) => {
   expect(result).toEqual({ error: "WOGE_CANCELLED", locked: false });
 });
 
+test("emits structured patch observations without exposing HTML", async ({ page }) => {
+  await resetPage(page);
+  const observations = await page.evaluate(async (values) => {
+    const events = [];
+    const runtime = globalThis.Woge.createWogePatchRuntime(document, {
+      observer: (event) => events.push(event),
+    });
+    await runtime.applyPatchStream(globalThis.byteStream(Uint8Array.from(values), 11));
+    return events;
+  }, Array.from(encodeStream([patchFrame({ html: "<p>private body</p>" }), completeFrame(1)])));
+
+  expect(observations).toHaveLength(2);
+  expect(observations[0]).toEqual({
+    observationId: 1,
+    phase: "started",
+    operation: "patch.apply",
+    context: { pageEpoch: "epoch-a", target: "summary-1", patchId: "patch-1" },
+  });
+  expect(observations[1]).toMatchObject({
+    observationId: 1,
+    phase: "finished",
+    operation: "patch.apply",
+    outcome: "succeeded",
+    context: { pageEpoch: "epoch-a", target: "summary-1", patchId: "patch-1" },
+  });
+  expect(observations[1].durationMs).toBeGreaterThanOrEqual(0);
+  expect(JSON.stringify(observations)).not.toContain("private body");
+});
+
+test("classifies stale patches and isolates observer failures", async ({ page }) => {
+  await resetPage(page);
+  const result = await page.evaluate(async (values) => {
+    const events = [];
+    const runtime = globalThis.Woge.createWogePatchRuntime(document, {
+      observer: (event) => {
+        events.push(event);
+        if (event.phase === "started") throw new Error("observer must be isolated");
+      },
+    });
+    let code;
+    try {
+      await runtime.applyPatchStream(globalThis.byteStream(Uint8Array.from(values), 7));
+    } catch (problem) {
+      code = problem.code;
+    }
+    return { code, events };
+  }, Array.from(encodeStream([patchFrame({ epoch: "old-page" }), completeFrame(1)])));
+
+  expect(result.code).toBe("WOGE_STALE_PAGE_EPOCH");
+  expect(result.events.map((event) => event.phase)).toEqual(["started", "finished"]);
+  expect(result.events[1].outcome).toBe("stale");
+});
+
 test("reports module and patch application timing", async ({ page }, testInfo) => {
   const regionCount = 20;
   await page.evaluate((count) => {

--- a/client/woge-fallback-client/src/index.d.ts
+++ b/client/woge-fallback-client/src/index.d.ts
@@ -18,6 +18,32 @@ export interface ApplyPatchStreamOptions {
   readonly signal?: AbortSignal;
 }
 
+export interface WogeObservationContext {
+  readonly pageEpoch: string;
+  readonly target: string;
+  readonly patchId: string;
+}
+
+export type WogeObservationEvent =
+  | {
+      readonly phase: "started";
+      readonly observationId: number;
+      readonly operation: "patch.apply";
+      readonly context: WogeObservationContext;
+    }
+  | {
+      readonly phase: "finished";
+      readonly observationId: number;
+      readonly operation: "patch.apply";
+      readonly outcome: "succeeded" | "failed" | "cancelled" | "rejected" | "stale";
+      readonly durationMs: number;
+      readonly context: WogeObservationContext;
+    };
+
+export interface WogePatchRuntimeOptions {
+  readonly observer?: (event: WogeObservationEvent) => void;
+}
+
 export interface WogePatchRuntime {
   applyPatchStream(
     stream: ReadableStream<Uint8Array>,
@@ -40,7 +66,7 @@ export class WogeRemotePatchError extends WogePatchError {
   readonly recovery: "none" | "reload";
 }
 
-export function createWogePatchRuntime(root?: Document): WogePatchRuntime;
+export function createWogePatchRuntime(root?: Document, options?: WogePatchRuntimeOptions): WogePatchRuntime;
 
 declare global {
   interface DocumentEventMap {

--- a/client/woge-fallback-client/src/index.js
+++ b/client/woge-fallback-client/src/index.js
@@ -9,9 +9,15 @@ import {
 /** Owns one active document's region registry and applies validated patch streams to it. */
 class WogePatchRuntime {
   #registry;
+  #observer;
+  #nextObservationId = 1;
 
-  constructor(root = document) {
+  constructor(root = document, { observer } = {}) {
+    if (observer !== undefined && typeof observer !== "function") {
+      fail("WOGE_INVALID_OBSERVER", "Patch observer must be a function");
+    }
     this.#registry = new PageRegionRegistry(root);
+    this.#observer = observer;
   }
 
   async applyPatchStream(stream, { signal } = {}) {
@@ -32,7 +38,7 @@ class WogePatchRuntime {
         if (signal?.aborted) fail("WOGE_CANCELLED", "Patch stream application was cancelled");
         if (done) break;
         for (const event of decoder.push(value)) {
-          if (event.type === "patch") this.#registry.applyReplace(event.patch);
+          if (event.type === "patch") this.#applyObserved(event.patch);
           if (event.type === "complete") completion = Object.freeze({ patchCount: event.patchCount });
           if (event.type === "error") throw new WogeRemotePatchError(event.failure);
         }
@@ -51,11 +57,57 @@ class WogePatchRuntime {
       reader.releaseLock();
     }
   }
+
+  #applyObserved(patch) {
+    const observationId = this.#nextObservationId++;
+    const context = Object.freeze({
+      pageEpoch: patch.epoch,
+      target: patch.target,
+      patchId: patch.patchId,
+    });
+    const started = performance.now();
+    this.#emit(Object.freeze({ observationId, phase: "started", operation: "patch.apply", context }));
+    try {
+      this.#registry.applyReplace(patch);
+      this.#emitFinished(observationId, context, "succeeded", started);
+    } catch (problem) {
+      this.#emitFinished(observationId, context, patchOutcome(problem), started);
+      throw problem;
+    }
+  }
+
+  #emitFinished(observationId, context, outcome, started) {
+    this.#emit(
+      Object.freeze({
+        observationId,
+        phase: "finished",
+        operation: "patch.apply",
+        outcome,
+        durationMs: Math.max(0, performance.now() - started),
+        context,
+      }),
+    );
+  }
+
+  #emit(event) {
+    try {
+      this.#observer?.(event);
+    } catch {
+      // Observability is best effort and must never alter patch behavior.
+    }
+  }
 }
 
 /** Creates one runtime and active page-local region registry. */
-export function createWogePatchRuntime(root = document) {
-  return new WogePatchRuntime(root);
+export function createWogePatchRuntime(root = document, options = {}) {
+  return new WogePatchRuntime(root, options);
+}
+
+function patchOutcome(problem) {
+  if (problem?.code === "WOGE_CANCELLED") return "cancelled";
+  if (problem?.code === "WOGE_STALE_PAGE_EPOCH") return "stale";
+  if (typeof problem?.code === "string" && problem.code.startsWith("WOGE_")) return "rejected";
+  return "failed";
 }
 
 export {

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Run a Woge page with Spring MVC](guides/spring-mvc-adapter.md)
 - [Run a Woge page with Ktor](guides/ktor-adapter.md)
 - [Configure Woge with Spring Boot](guides/spring-boot-starter.md)
+- [Observe Woge without parsing logs](guides/semantic-observability.md)
 
 ## Performance evidence
 

--- a/docs/adr/0035-framework-neutral-semantic-observation-port.md
+++ b/docs/adr/0035-framework-neutral-semantic-observation-port.md
@@ -1,0 +1,77 @@
+# ADR 0035: Use a framework-neutral semantic observation port
+
+- Status: Accepted
+- Date: 2026-09-06
+- Decision owners: @christian-draeger
+- Related issues: [#123](https://github.com/christian-draeger/woge/issues/123)
+
+## Context
+
+Woge requests cross application code, a server adapter, patch encoding and the browser. Logs from one
+framework cannot describe that lifecycle consistently, and parsing human-readable messages would be
+fragile for tests, development tools and AI agents. Spring Boot should integrate naturally with
+Micrometer and OpenTelemetry, while the portable host API and Ktor must not depend on either vendor.
+
+Observability must also respect Woge's trust boundaries. Commands, form values, cookies, rendered
+HTML, tokens, exception messages and stack traces can contain secrets. Identifiers useful for tracing
+have high cardinality and would be dangerous as metric labels.
+
+## Decision
+
+Woge defines `WogeObserver` in `woge-host-spi` as a synchronous, framework-neutral port with a no-op
+default. It receives immutable started and finished events. Every pair shares a process-local
+`WogeObservationId`; a finished event carries a monotonic duration and one stable outcome.
+
+The operation and outcome names are the bounded semantic vocabulary used for metric dimensions.
+`WogeObservationContext` contains only typed request, target and patch identifiers. Those identifiers
+are trace correlation, never metric dimensions. The model has no arbitrary attribute map or payload
+escape hatch.
+
+The vocabulary reserves page requests, shell rendering, deferred regions, actions, patch encoding,
+patch application, live subscriptions and recovery. Implementations emit only operations they
+actually perform. The M1 server runtime emits page, shell, deferred and encoding events; the fallback
+browser emits patch-application events. Later action, live and recovery work uses the same port.
+
+Spring Boot contributes a conditional no-op bean and injects any application-provided `WogeObserver`
+into MVC or WebFlux. Ktor accepts the same port directly. Vendor adapters map these events at the
+outside edge. Observer failures are isolated from application traffic.
+
+Production request events and the development lifecycle planned in issue #140 use separate event
+types and vocabularies. They may share correlation IDs, but a build/restart event is not a page
+request event.
+
+## Alternatives considered
+
+- **Depend directly on Micrometer or OpenTelemetry:** Familiar in some applications, but leaks vendor
+  APIs into the portable boundary and makes Ktor or custom telemetry adapters second-class.
+- **Emit structured log messages only:** Easy initially, but forces tools and tests to parse text and
+  couples behavior to logging configuration.
+- **Expose an arbitrary string attribute map:** Flexible, but makes spelling, type safety, redaction
+  and metric cardinality impossible to enforce.
+- **Use one global event bus:** Convenient discovery, but hides ownership and makes tests and
+  multi-application processes interfere with each other.
+
+## Consequences
+
+### Positive
+
+- Spring MVC, WebFlux and Ktor expose one testable semantic lifecycle.
+- Metrics, traces, development tools and agents consume values instead of log prose.
+- Kotlin types prevent payloads from accidentally entering the standard event model.
+- Applications pay almost nothing when no observer is installed.
+
+### Negative
+
+- Vendor adapters must pair started and finished events by observation ID.
+- The callback is synchronous, so adapters must enqueue expensive export work themselves.
+- New correlation concepts require typed API evolution rather than arbitrary attributes.
+- Best-effort isolation means observer exceptions are intentionally not propagated to requests.
+
+## Follow-up
+
+- Implement action and live-subscription events with their corresponding runtime slices.
+- Correlate the separate development lifecycle from issue #140 without merging its vocabulary into
+  production telemetry.
+- Add first-party Micrometer/OpenTelemetry adapters only after real application evidence shows which
+  mappings deserve stable artifacts.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0032](0032-async-servlet-spring-mvc-adapter.md) | Accepted | Stream Spring MVC responses through adapter-owned Servlet async handlers |
 | [0033](0033-suspending-ktor-adapter.md) | Accepted | Bind Woge to idiomatic suspending Ktor routes |
 | [0034](0034-generate-html-element-wrappers-from-webref.md) | Accepted | Generate HTML element wrappers from pinned Webref data |
+| [0035](0035-framework-neutral-semantic-observation-port.md) | Accepted | Use a framework-neutral semantic observation port |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/guides/browser-replace-runtime.md
+++ b/docs/guides/browser-replace-runtime.md
@@ -46,6 +46,10 @@ Create one runtime for one active document. A full navigation creates a new page
 new runtime. Fetch/form interception is deliberately deferred; normal links and forms remain the
 baseline until the action enhancer installs this call.
 
+Pass an optional `observer` when structured tooling needs patch timing or rejected/stale outcomes.
+The callback receives no patch HTML; its operation names match the server observation port. See
+[Observe Woge without parsing logs](semantic-observability.md).
+
 ## Keep normal CSS and custom elements
 
 Replace keeps the region element and replaces only its children. Classes, inline standards CSS,

--- a/docs/guides/semantic-observability.md
+++ b/docs/guides/semantic-observability.md
@@ -1,0 +1,85 @@
+# Observe Woge without parsing logs
+
+Woge reports meaningful web operations as Kotlin values. An observer can feed metrics, traces, a
+development overlay or a test without knowing whether Spring MVC, WebFlux or Ktor handled the HTTP
+request.
+
+## Install one observer
+
+With Spring Boot, declare a normal bean:
+
+```kotlin
+@Bean
+fun wogeObserver(meterRegistry: MeterRegistry): WogeObserver =
+    WogeObserver { event ->
+        if (event is WogeOperationFinished) {
+            Timer.builder("woge.operation")
+                .tag("operation", event.operation.semanticName)
+                .tag("outcome", event.outcome.semanticName)
+                .register(meterRegistry)
+                .record(event.duration.toJavaDuration())
+        }
+    }
+```
+
+Boot replaces its no-op default and supplies this observer to the selected MVC or WebFlux handler
+factory. Ktor applications pass the same value to `WogeKtorHandlers(observer = observer)`.
+
+The snippet shows the important Micrometer mapping rule: only `operation` and `outcome` are metric
+tags. Request, page, region and patch IDs belong on a trace span or structured diagnostic record;
+using them as tags would create unbounded metric cardinality.
+
+An OpenTelemetry adapter follows the same shape: start a span for `WogeOperationStarted`, retain it by
+`observationId`, add typed correlation as span attributes, and end it with the duration and outcome
+from the matching `WogeOperationFinished`. Keep export work off the request callback.
+
+## Understand the events
+
+Every operation emits exactly two events:
+
+1. `WogeOperationStarted` identifies the operation and its safe correlation context.
+2. `WogeOperationFinished` repeats the observation ID and adds a monotonic duration plus a terminal
+   outcome.
+
+Operations may overlap. Pair them by `observationId`, not by arrival order. Cancellation, timeouts,
+expected policy rejection, stale browser work and unexpected failure are distinct outcomes.
+
+The current implementation emits:
+
+| Operation | Emitted by | Boundary |
+| --- | --- | --- |
+| `page.request` | all server adapters | portable page use-case execution |
+| `shell.render` | all server adapters | actual cold HTML-frame collection |
+| `deferred.region` | shared server runtime | one region's bounded child task |
+| `patch.encode` | shared server runtime | one semantic patch encoded for transport |
+| `patch.apply` | fallback browser runtime | one validated patch applied or rejected |
+
+`action`, `live.subscription` and `recovery` are stable vocabulary for later slices; Woge does not
+pretend to emit them before that behavior exists.
+
+## Observe the browser
+
+The browser API uses plain JavaScript objects with the same semantic names:
+
+```js
+const runtime = createWogePatchRuntime(document, {
+  observer(event) {
+    diagnosticsChannel.postMessage(event);
+  },
+});
+```
+
+Patch events contain only an observation ID, page epoch, target and patch ID. Patch HTML is absent.
+A stale epoch finishes with `stale`; other protocol or DOM policy refusals finish with `rejected`.
+Observer exceptions cannot stop a valid patch.
+
+## Keep private data elsewhere
+
+The standard context intentionally has no generic attributes, request body, input, HTML, cookie,
+token, exception or message field. If an application needs private diagnostics, keep that data in its
+secured logging/tracing adapter and link it with the correlation ID. Do not widen the shared event or
+send server-only facts to the browser.
+
+See [ADR 0035](../adr/0035-framework-neutral-semantic-observation-port.md) for the architectural
+tradeoffs and the [threat model](../security/threat-model.md) for the wider redaction boundary.
+

--- a/docs/guides/spring-boot-starter.md
+++ b/docs/guides/spring-boot-starter.md
@@ -92,6 +92,13 @@ its own matching bean that translates the
 authenticated principal, capabilities and verified request facts into Woge-owned values. The default
 backs off automatically.
 
+## Connect metrics, traces or development tools
+
+Spring Boot provides a no-op `WogeObserver` unless the application declares its own bean. The same
+typed events are emitted by MVC, WebFlux and Ktor, so an integration can map them to Micrometer or
+OpenTelemetry without changing portable page code. See the
+[semantic observability guide](semantic-observability.md) for a safe mapping and cardinality rules.
+
 ## Resolve mixed Spring stacks
 
 With one stack, `woge.adapter=auto` needs no property. If both Spring MVC and WebFlux are on the

--- a/integrations/woge-spring-boot-autoconfigure/api/woge-spring-boot-autoconfigure.api
+++ b/integrations/woge-spring-boot-autoconfigure/api/woge-spring-boot-autoconfigure.api
@@ -6,6 +6,7 @@ public final class dev/woge/spring/boot/autoconfigure/WogeApplicationCatalog {
 public final class dev/woge/spring/boot/autoconfigure/WogeAutoConfiguration {
 	public fun <init> ()V
 	public final fun wogeApplicationCatalog (Lorg/springframework/beans/factory/ListableBeanFactory;)Ldev/woge/spring/boot/autoconfigure/WogeApplicationCatalog;
+	public final fun wogeObserver ()Ldev/woge/host/WogeObserver;
 	public final fun wogeRuntimeInfo (Ldev/woge/spring/boot/autoconfigure/WogeProperties;Ldev/woge/spring/boot/autoconfigure/WogeApplicationCatalog;Lorg/springframework/core/io/ResourceLoader;Lorg/springframework/context/ApplicationContext;)Ldev/woge/spring/boot/autoconfigure/WogeRuntimeInfo;
 }
 

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfiguration.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfiguration.kt
@@ -2,6 +2,7 @@ package dev.woge.spring.boot.autoconfigure
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObserver
 import dev.woge.protocol.PatchProtocolVersion
 import org.apache.commons.logging.LogFactory
 import org.springframework.beans.factory.ListableBeanFactory
@@ -21,6 +22,11 @@ import org.springframework.core.io.ResourceLoader
 @EnableConfigurationProperties(WogeProperties::class)
 @Import(WogeSpringMvcAutoConfiguration::class, WogeWebFluxAutoConfiguration::class)
 public class WogeAutoConfiguration {
+    /** Framework-neutral no-op that applications can replace with Micrometer or OpenTelemetry. */
+    @Bean
+    @ConditionalOnMissingBean
+    public fun wogeObserver(): WogeObserver = WogeObserver.NONE
+
     /** Discovers only Woge host entry points; HTML components remain ordinary Kotlin values/functions. */
     @Bean
     @ConditionalOnMissingBean

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeSpringMvcAutoConfiguration.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeSpringMvcAutoConfiguration.kt
@@ -1,5 +1,6 @@
 package dev.woge.spring.boot.autoconfigure
 
+import dev.woge.host.WogeObserver
 import dev.woge.spring.mvc.DefaultSpringMvcRequestContextFactory
 import dev.woge.spring.mvc.SpringMvcRequestContextFactory
 import dev.woge.spring.mvc.WogeSpringMvcHandlers
@@ -28,6 +29,7 @@ internal class WogeSpringMvcAutoConfiguration {
         properties: WogeProperties,
         contexts: SpringMvcRequestContextFactory,
         runtimeInfo: WogeRuntimeInfo,
+        observer: WogeObserver,
     ): WogeSpringMvcHandlers {
         check(runtimeInfo.adapter == WogeSpringAdapter.MVC) {
             "Servlet Woge configuration requires 'woge.adapter=mvc'."
@@ -37,6 +39,7 @@ internal class WogeSpringMvcAutoConfiguration {
             asyncTimeout = properties.mvc.asyncTimeout.toKotlinDuration(),
             maxConcurrency = properties.deferred.maxConcurrency,
             regionTimeout = properties.deferred.regionTimeout.toKotlinDuration(),
+            observer = observer,
         )
     }
 }

--- a/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeWebFluxAutoConfiguration.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/main/kotlin/dev/woge/spring/boot/autoconfigure/WogeWebFluxAutoConfiguration.kt
@@ -1,5 +1,6 @@
 package dev.woge.spring.boot.autoconfigure
 
+import dev.woge.host.WogeObserver
 import dev.woge.spring.webflux.DefaultWebFluxRequestContextFactory
 import dev.woge.spring.webflux.WebFluxRequestContextFactory
 import dev.woge.spring.webflux.WogeWebFluxHandlers
@@ -27,6 +28,7 @@ internal class WogeWebFluxAutoConfiguration {
         properties: WogeProperties,
         contexts: WebFluxRequestContextFactory,
         runtimeInfo: WogeRuntimeInfo,
+        observer: WogeObserver,
     ): WogeWebFluxHandlers {
         check(runtimeInfo.adapter == WogeSpringAdapter.WEBFLUX) {
             "Reactive Woge configuration requires 'woge.adapter=webflux'."
@@ -35,6 +37,7 @@ internal class WogeWebFluxAutoConfiguration {
             contexts = contexts,
             maxConcurrency = properties.deferred.maxConcurrency,
             regionTimeout = properties.deferred.regionTimeout.toKotlinDuration(),
+            observer = observer,
         )
     }
 }

--- a/integrations/woge-spring-boot-autoconfigure/src/test/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfigurationTest.kt
+++ b/integrations/woge-spring-boot-autoconfigure/src/test/kotlin/dev/woge/spring/boot/autoconfigure/WogeAutoConfigurationTest.kt
@@ -2,6 +2,7 @@ package dev.woge.spring.boot.autoconfigure
 
 import dev.woge.host.DeferredRegionsUseCase
 import dev.woge.host.PageUseCase
+import dev.woge.host.WogeObserver
 import dev.woge.spring.mvc.SpringMvcRequestContextFactory
 import dev.woge.spring.mvc.WogeSpringMvcHandlers
 import dev.woge.spring.webflux.WebFluxRequestContextFactory
@@ -68,6 +69,16 @@ class WogeAutoConfigurationTest {
                     CustomContextConfiguration.contexts,
                     context.getBean(WebFluxRequestContextFactory::class.java),
                 )
+            }
+    }
+
+    @Test
+    fun `backs off for an application observation adapter`() {
+        webFluxRunner()
+            .withUserConfiguration(CustomObserverConfiguration::class.java)
+            .run { context ->
+                assertNull(context.startupFailure)
+                assertSame(CustomObserverConfiguration.observer, context.getBean(WogeObserver::class.java))
             }
     }
 
@@ -244,6 +255,16 @@ class WogeAutoConfigurationTest {
 
         companion object {
             val contexts = WebFluxRequestContextFactory { error("not executed during startup") }
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    internal class CustomObserverConfiguration {
+        @Bean
+        fun customWogeObserver(): WogeObserver = observer
+
+        companion object {
+            val observer = WogeObserver { }
         }
     }
 

--- a/modules/woge-host-spi/api/woge-host-spi.api
+++ b/modules/woge-host-spi/api/woge-host-spi.api
@@ -619,3 +619,116 @@ public final class dev/woge/host/SameSite : java/lang/Enum {
 	public static fun values ()[Ldev/woge/host/SameSite;
 }
 
+public final class dev/woge/host/WogeObservationContext {
+	public synthetic fun <init> (Ldev/woge/host/RequestTrace;Ldev/woge/protocol/PatchTarget;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/woge/host/RequestTrace;Ldev/woge/protocol/PatchTarget;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/woge/host/RequestTrace;
+	public final fun component2 ()Ldev/woge/protocol/PatchTarget;
+	public final fun component3-ZOx1KSU ()Ljava/lang/String;
+	public final fun copy-qCmI8D0 (Ldev/woge/host/RequestTrace;Ldev/woge/protocol/PatchTarget;Ljava/lang/String;)Ldev/woge/host/WogeObservationContext;
+	public static synthetic fun copy-qCmI8D0$default (Ldev/woge/host/WogeObservationContext;Ldev/woge/host/RequestTrace;Ldev/woge/protocol/PatchTarget;Ljava/lang/String;ILjava/lang/Object;)Ldev/woge/host/WogeObservationContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPatchId-ZOx1KSU ()Ljava/lang/String;
+	public final fun getRequestTrace ()Ldev/woge/host/RequestTrace;
+	public final fun getTarget ()Ldev/woge/protocol/PatchTarget;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/woge/host/WogeObservationEvent {
+	public abstract fun getContext ()Ldev/woge/host/WogeObservationContext;
+	public abstract fun getObservationId-f8Zs9lE ()J
+	public abstract fun getOperation ()Ldev/woge/host/WogeOperation;
+}
+
+public final class dev/woge/host/WogeObservationId {
+	public static final field Companion Ldev/woge/host/WogeObservationId$Companion;
+	public static final synthetic fun box-impl (J)Ldev/woge/host/WogeObservationId;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class dev/woge/host/WogeObservationId$Companion {
+	public final fun of-GKOvDJo (J)J
+}
+
+public abstract interface class dev/woge/host/WogeObserver {
+	public static final field Companion Ldev/woge/host/WogeObserver$Companion;
+	public abstract fun onEvent (Ldev/woge/host/WogeObservationEvent;)V
+}
+
+public final class dev/woge/host/WogeObserver$Companion {
+	public final fun getNONE ()Ldev/woge/host/WogeObserver;
+}
+
+public final class dev/woge/host/WogeOperation : java/lang/Enum {
+	public static final field ACTION Ldev/woge/host/WogeOperation;
+	public static final field DEFERRED_REGION Ldev/woge/host/WogeOperation;
+	public static final field LIVE_SUBSCRIPTION Ldev/woge/host/WogeOperation;
+	public static final field PAGE_REQUEST Ldev/woge/host/WogeOperation;
+	public static final field PATCH_APPLY Ldev/woge/host/WogeOperation;
+	public static final field PATCH_ENCODE Ldev/woge/host/WogeOperation;
+	public static final field RECOVERY Ldev/woge/host/WogeOperation;
+	public static final field SHELL_RENDER Ldev/woge/host/WogeOperation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSemanticName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/woge/host/WogeOperation;
+	public static fun values ()[Ldev/woge/host/WogeOperation;
+}
+
+public final class dev/woge/host/WogeOperationFinished : dev/woge/host/WogeObservationEvent {
+	public synthetic fun <init> (JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeOutcome;JLdev/woge/host/WogeObservationContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeOutcome;JLdev/woge/host/WogeObservationContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-f8Zs9lE ()J
+	public final fun component2 ()Ldev/woge/host/WogeOperation;
+	public final fun component3 ()Ldev/woge/host/WogeOutcome;
+	public final fun component4-UwyO8pc ()J
+	public final fun component5 ()Ldev/woge/host/WogeObservationContext;
+	public final fun copy-FTmXOsM (JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeOutcome;JLdev/woge/host/WogeObservationContext;)Ldev/woge/host/WogeOperationFinished;
+	public static synthetic fun copy-FTmXOsM$default (Ldev/woge/host/WogeOperationFinished;JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeOutcome;JLdev/woge/host/WogeObservationContext;ILjava/lang/Object;)Ldev/woge/host/WogeOperationFinished;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContext ()Ldev/woge/host/WogeObservationContext;
+	public final fun getDuration-UwyO8pc ()J
+	public fun getObservationId-f8Zs9lE ()J
+	public fun getOperation ()Ldev/woge/host/WogeOperation;
+	public final fun getOutcome ()Ldev/woge/host/WogeOutcome;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/host/WogeOperationStarted : dev/woge/host/WogeObservationEvent {
+	public synthetic fun <init> (JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeObservationContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeObservationContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-f8Zs9lE ()J
+	public final fun component2 ()Ldev/woge/host/WogeOperation;
+	public final fun component3 ()Ldev/woge/host/WogeObservationContext;
+	public final fun copy-SIAuTq8 (JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeObservationContext;)Ldev/woge/host/WogeOperationStarted;
+	public static synthetic fun copy-SIAuTq8$default (Ldev/woge/host/WogeOperationStarted;JLdev/woge/host/WogeOperation;Ldev/woge/host/WogeObservationContext;ILjava/lang/Object;)Ldev/woge/host/WogeOperationStarted;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContext ()Ldev/woge/host/WogeObservationContext;
+	public fun getObservationId-f8Zs9lE ()J
+	public fun getOperation ()Ldev/woge/host/WogeOperation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/woge/host/WogeOutcome : java/lang/Enum {
+	public static final field CANCELLED Ldev/woge/host/WogeOutcome;
+	public static final field FAILED Ldev/woge/host/WogeOutcome;
+	public static final field REJECTED Ldev/woge/host/WogeOutcome;
+	public static final field STALE Ldev/woge/host/WogeOutcome;
+	public static final field SUCCEEDED Ldev/woge/host/WogeOutcome;
+	public static final field TIMED_OUT Ldev/woge/host/WogeOutcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSemanticName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/woge/host/WogeOutcome;
+	public static fun values ()[Ldev/woge/host/WogeOutcome;
+}
+

--- a/modules/woge-host-spi/src/main/kotlin/dev/woge/host/WogeObservation.kt
+++ b/modules/woge-host-spi/src/main/kotlin/dev/woge/host/WogeObservation.kt
@@ -1,0 +1,101 @@
+package dev.woge.host
+
+import dev.woge.protocol.PatchId
+import dev.woge.protocol.PatchTarget
+import kotlin.time.Duration
+
+/** Process-local identity used to pair overlapping started and finished events. */
+@JvmInline
+public value class WogeObservationId private constructor(
+    public val value: Long,
+) {
+    public companion object {
+        public fun of(value: Long): WogeObservationId {
+            require(value > 0) { "Observation ID must be positive" }
+            return WogeObservationId(value)
+        }
+    }
+}
+
+/** Stable, low-cardinality semantic operations shared by Woge hosts and tooling. */
+public enum class WogeOperation(
+    public val semanticName: String,
+) {
+    PAGE_REQUEST("page.request"),
+    SHELL_RENDER("shell.render"),
+    DEFERRED_REGION("deferred.region"),
+    ACTION("action"),
+    PATCH_ENCODE("patch.encode"),
+    PATCH_APPLY("patch.apply"),
+    LIVE_SUBSCRIPTION("live.subscription"),
+    RECOVERY("recovery"),
+}
+
+/** Stable terminal outcomes. These values are safe to use as metric dimensions. */
+public enum class WogeOutcome(
+    public val semanticName: String,
+) {
+    SUCCEEDED("succeeded"),
+    FAILED("failed"),
+    CANCELLED("cancelled"),
+    TIMED_OUT("timed_out"),
+    REJECTED("rejected"),
+    STALE("stale"),
+}
+
+/**
+ * Safe correlation carried by semantic events.
+ *
+ * Every field is high-cardinality and must be attached to traces or diagnostics, never used as a
+ * metric label. There is deliberately no route, user input, HTML, command, token, or exception
+ * message field.
+ */
+public data class WogeObservationContext(
+    public val requestTrace: RequestTrace? = null,
+    public val target: PatchTarget? = null,
+    public val patchId: PatchId? = null,
+)
+
+/** One structured semantic lifecycle event emitted by a Woge runtime boundary. */
+public interface WogeObservationEvent {
+    public val observationId: WogeObservationId
+    public val operation: WogeOperation
+    public val context: WogeObservationContext
+}
+
+/** Marks the beginning of one semantic operation. */
+public data class WogeOperationStarted(
+    override val observationId: WogeObservationId,
+    override val operation: WogeOperation,
+    override val context: WogeObservationContext = WogeObservationContext(),
+) : WogeObservationEvent
+
+/** Marks the single terminal outcome of one previously started semantic operation. */
+public data class WogeOperationFinished(
+    override val observationId: WogeObservationId,
+    override val operation: WogeOperation,
+    public val outcome: WogeOutcome,
+    public val duration: Duration,
+    override val context: WogeObservationContext = WogeObservationContext(),
+) : WogeObservationEvent {
+    init {
+        require(duration.isFinite() && duration >= Duration.ZERO) {
+            "Observed duration must be non-negative and finite"
+        }
+    }
+}
+
+/**
+ * Framework-neutral destination for Woge semantic events.
+ *
+ * Implementations should return quickly and must not throw. Woge runtime call sites additionally
+ * isolate observer failures so diagnostics cannot change an application response.
+ */
+public fun interface WogeObserver {
+    public fun onEvent(event: WogeObservationEvent)
+
+    public companion object {
+        /** Shared no-op default used when an application installs no observation adapter. */
+        public val NONE: WogeObserver = WogeObserver { }
+    }
+}

--- a/modules/woge-host-spi/src/test/kotlin/dev/woge/host/WogeObservationTest.kt
+++ b/modules/woge-host-spi/src/test/kotlin/dev/woge/host/WogeObservationTest.kt
@@ -1,0 +1,78 @@
+package dev.woge.host
+
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchId
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+class WogeObservationTest {
+    @Test
+    fun `semantic names and outcomes are stable low-cardinality values`() {
+        assertEquals("page.request", WogeOperation.PAGE_REQUEST.semanticName)
+        assertEquals("patch.apply", WogeOperation.PATCH_APPLY.semanticName)
+        assertEquals("timed_out", WogeOutcome.TIMED_OUT.semanticName)
+    }
+
+    @Test
+    fun `context contains correlation identifiers but no payload field`() {
+        val context =
+            WogeObservationContext(
+                requestTrace = RequestTrace(RequestId.of("request-1"), CorrelationId.of("correlation-1")),
+                target = PatchTarget(PageEpoch.of("page-1"), RegionTargetId.of("summary")),
+                patchId = PatchId.of("patch-1"),
+            )
+        val event =
+            WogeOperationFinished(
+                WogeObservationId.of(1),
+                WogeOperation.PATCH_ENCODE,
+                WogeOutcome.SUCCEEDED,
+                2.milliseconds,
+                context,
+            )
+
+        assertEquals(
+            "correlation-1",
+            event.context.requestTrace
+                ?.correlationId
+                ?.value,
+        )
+        assertEquals(
+            "summary",
+            event.context.target
+                ?.region
+                ?.value,
+        )
+        assertFalse(WogeObservationContext::class.java.declaredFields.any { it.name in PAYLOAD_FIELD_NAMES })
+    }
+
+    @Test
+    fun `finished event rejects unusable durations`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            WogeOperationFinished(
+                WogeObservationId.of(1),
+                WogeOperation.PAGE_REQUEST,
+                WogeOutcome.SUCCEEDED,
+                Duration.INFINITE,
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            WogeOperationFinished(
+                WogeObservationId.of(1),
+                WogeOperation.PAGE_REQUEST,
+                WogeOutcome.SUCCEEDED,
+                (-1).milliseconds,
+            )
+        }
+    }
+
+    private companion object {
+        val PAYLOAD_FIELD_NAMES: Set<String> =
+            setOf("body", "command", "cookie", "exception", "headers", "html", "input", "message", "token")
+    }
+}

--- a/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/DeferredRegionExecutor.kt
+++ b/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/DeferredRegionExecutor.kt
@@ -2,6 +2,11 @@ package dev.woge.runtime
 
 import dev.woge.host.DeferredRegion
 import dev.woge.host.DeferredRegionFailure
+import dev.woge.host.RequestTrace
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.host.WogeOutcome
 import dev.woge.protocol.PatchHtml
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -54,6 +59,7 @@ public sealed interface DeferredRegionUpdate {
 /** Runs deferred regions as children of the collecting request scope. */
 public class DeferredRegionExecutor(
     public val policy: DeferredRegionPolicy = DeferredRegionPolicy(),
+    private val observer: WogeObserver = WogeObserver.NONE,
 ) {
     /**
      * Returns a cold flow that emits updates in completion order.
@@ -61,7 +67,10 @@ public class DeferredRegionExecutor(
      * Cancelling collection cancels active and waiting region children. A content failure is
      * isolated to its region; failure-fallback rendering itself remains fail-stop.
      */
-    public fun execute(regions: Iterable<DeferredRegion>): Flow<DeferredRegionUpdate> =
+    public fun execute(
+        regions: Iterable<DeferredRegion>,
+        requestTrace: RequestTrace? = null,
+    ): Flow<DeferredRegionUpdate> =
         channelFlow {
             val declaredRegions = regions.toList()
             validateRegionSet(declaredRegions)
@@ -70,25 +79,51 @@ public class DeferredRegionExecutor(
             declaredRegions.forEach { region ->
                 launch {
                     concurrency.withPermit {
-                        send(resolve(region))
+                        send(resolve(region, requestTrace))
                     }
                 }
             }
         }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun resolve(region: DeferredRegion): DeferredRegionUpdate =
+    private suspend fun resolve(
+        region: DeferredRegion,
+        requestTrace: RequestTrace?,
+    ): DeferredRegionUpdate {
+        val observation =
+            observer.startOperation(
+                WogeOperation.DEFERRED_REGION,
+                WogeObservationContext(requestTrace = requestTrace, target = region.target),
+            )
+        return resolveObserved(region, observation)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun resolveObserved(
+        region: DeferredRegion,
+        observation: WogeOperationObservation,
+    ): DeferredRegionUpdate =
         try {
             val content = withTimeoutOrNull(policy.regionTimeout) { region.renderContent() }
             if (content == null) {
                 failed(region, DeferredRegionFailure.TIMED_OUT, cause = null)
+                    .also { observation.finish(WogeOutcome.TIMED_OUT) }
             } else {
-                DeferredRegionUpdate.Resolved(region, content)
+                DeferredRegionUpdate
+                    .Resolved(region, content)
+                    .also { observation.finish(WogeOutcome.SUCCEEDED) }
             }
         } catch (cancelled: CancellationException) {
+            observation.finish(WogeOutcome.CANCELLED)
             throw cancelled
         } catch (cause: Exception) {
-            failed(region, DeferredRegionFailure.FAILED, cause)
+            try {
+                failed(region, DeferredRegionFailure.FAILED, cause)
+                    .also { observation.finish(WogeOutcome.FAILED) }
+            } catch (fallbackFailure: Throwable) {
+                observation.finish(WogeOutcome.FAILED)
+                throw fallbackFailure
+            }
         }
 
     private fun failed(

--- a/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/EncodedPatchChunk.kt
+++ b/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/EncodedPatchChunk.kt
@@ -1,5 +1,10 @@
 package dev.woge.runtime
 
+import dev.woge.host.RequestTrace
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.host.WogeOutcome
 import dev.woge.protocol.ByteSink
 import dev.woge.protocol.InteractionSequence
 import dev.woge.protocol.PatchId
@@ -41,7 +46,10 @@ public fun DeferredRegionUpdate.toReplacePatch(patchId: PatchId): ReplacePatch =
  * The first chunk also contains the stream preamble. Upstream, patch-ID, or encoder failures are
  * propagated without manufacturing a successful terminal frame.
  */
+@Suppress("TooGenericExceptionCaught")
 public fun Flow<DeferredRegionUpdate>.encodeDeferredPatchStream(
+    observer: WogeObserver = WogeObserver.NONE,
+    requestTrace: RequestTrace? = null,
     patchId: (DeferredRegionUpdate) -> PatchId,
 ): Flow<EncodedPatchChunk> =
     flow {
@@ -49,9 +57,28 @@ public fun Flow<DeferredRegionUpdate>.encodeDeferredPatchStream(
         val encoder = PatchStreamV1.encoder(ByteSink(pending::write))
 
         collect { update ->
-            encoder.write(update.toReplacePatch(patchId(update)))
-            emit(EncodedPatchChunk(pending.toByteArray(), terminal = false))
-            pending.reset()
+            val id = patchId(update)
+            val observation =
+                observer.startOperation(
+                    WogeOperation.PATCH_ENCODE,
+                    WogeObservationContext(
+                        requestTrace = requestTrace,
+                        target = update.region.target,
+                        patchId = id,
+                    ),
+                )
+            try {
+                encoder.write(update.toReplacePatch(id))
+                emit(EncodedPatchChunk(pending.toByteArray(), terminal = false))
+                pending.reset()
+                observation.finish(WogeOutcome.SUCCEEDED)
+            } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                observation.finish(WogeOutcome.CANCELLED)
+                throw cancelled
+            } catch (failure: Throwable) {
+                observation.finish(WogeOutcome.FAILED)
+                throw failure
+            }
         }
 
         encoder.complete()

--- a/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/WogeOperationObservation.kt
+++ b/modules/woge-server-runtime/src/main/kotlin/dev/woge/runtime/WogeOperationObservation.kt
@@ -1,0 +1,110 @@
+package dev.woge.runtime
+
+import dev.woge.host.FailureCategory
+import dev.woge.host.PageResult
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObservationId
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.host.WogeOperationFinished
+import dev.woge.host.WogeOperationStarted
+import dev.woge.host.WogeOutcome
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.TimeSource
+
+/** One failure-isolated semantic operation span used by server adapters and runtimes. */
+public class WogeOperationObservation internal constructor(
+    private val observer: WogeObserver,
+    private val observationId: WogeObservationId,
+    private val operation: WogeOperation,
+    private val context: WogeObservationContext,
+) {
+    private val started = TimeSource.Monotonic.markNow()
+    private var finished = false
+
+    init {
+        observer.emitSafely(WogeOperationStarted(observationId, operation, context))
+    }
+
+    /** Emits this operation's terminal event exactly once. */
+    public fun finish(outcome: WogeOutcome) {
+        if (finished) return
+        finished = true
+        observer.emitSafely(WogeOperationFinished(observationId, operation, outcome, started.elapsedNow(), context))
+    }
+}
+
+/** Starts one operation. Observer failures are isolated from application work. */
+public fun WogeObserver.startOperation(
+    operation: WogeOperation,
+    context: WogeObservationContext = WogeObservationContext(),
+): WogeOperationObservation = WogeOperationObservation(this, nextObservationId(), operation, context)
+
+/** Runs suspending work with one started event and exactly one classified terminal event. */
+@Suppress("TooGenericExceptionCaught")
+public suspend fun <Result> WogeObserver.observeOperation(
+    operation: WogeOperation,
+    context: WogeObservationContext = WogeObservationContext(),
+    successfulOutcome: (Result) -> WogeOutcome = { WogeOutcome.SUCCEEDED },
+    block: suspend () -> Result,
+): Result {
+    val observation = startOperation(operation, context)
+    return try {
+        block().also { observation.finish(successfulOutcome(it)) }
+    } catch (cancelled: CancellationException) {
+        observation.finish(WogeOutcome.CANCELLED)
+        throw cancelled
+    } catch (failure: Throwable) {
+        observation.finish(WogeOutcome.FAILED)
+        throw failure
+    }
+}
+
+/** Observes actual cold-flow collection rather than flow construction. */
+public fun <Value> Flow<Value>.observeCollection(
+    observer: WogeObserver,
+    operation: WogeOperation,
+    context: WogeObservationContext = WogeObservationContext(),
+): Flow<Value> =
+    flow {
+        observer.observeOperation(operation, context) {
+            collect(::emit)
+        }
+    }
+
+/** Classifies an explicit page outcome without inspecting application payloads. */
+public fun PageResult.observationOutcome(): WogeOutcome =
+    when (this) {
+        is PageResult.Document,
+        is PageResult.Redirect,
+        -> WogeOutcome.SUCCEEDED
+
+        is PageResult.Failure ->
+            when (failure.category) {
+                FailureCategory.INTERNAL,
+                FailureCategory.UNAVAILABLE,
+                -> WogeOutcome.FAILED
+
+                else -> WogeOutcome.REJECTED
+            }
+    }
+
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
+private fun WogeObserver.emitSafely(event: dev.woge.host.WogeObservationEvent) {
+    try {
+        onEvent(event)
+    } catch (_: Exception) {
+        // Observability is best effort and must never alter application behavior.
+    }
+}
+
+private fun nextObservationId(): WogeObservationId {
+    val value = observationSequence.incrementAndGet()
+    check(value > 0) { "Woge observation ID space exhausted" }
+    return WogeObservationId.of(value)
+}
+
+private val observationSequence: AtomicLong = AtomicLong()

--- a/modules/woge-server-runtime/src/test/kotlin/dev/woge/runtime/DeferredRegionExecutorTest.kt
+++ b/modules/woge-server-runtime/src/test/kotlin/dev/woge/runtime/DeferredRegionExecutorTest.kt
@@ -2,6 +2,11 @@ package dev.woge.runtime
 
 import dev.woge.host.DeferredRegion
 import dev.woge.host.DeferredRegionFailure
+import dev.woge.host.WogeObservationEvent
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperationFinished
+import dev.woge.host.WogeOperationStarted
+import dev.woge.host.WogeOutcome
 import dev.woge.host.deferredRegion
 import dev.woge.protocol.PageEpoch
 import dev.woge.protocol.PatchHtml
@@ -224,6 +229,30 @@ class DeferredRegionExecutorTest {
             DeferredRegionPolicy(regionTimeout = Duration.INFINITE)
         }
     }
+
+    @Test
+    fun `region observations preserve lifecycle and classify timeout`() =
+        runTest {
+            val events = mutableListOf<WogeObservationEvent>()
+            val updates =
+                DeferredRegionExecutor(
+                    policy = DeferredRegionPolicy(regionTimeout = 1.seconds),
+                    observer = WogeObserver(events::add),
+                ).execute(listOf(region("waiting") { awaitCancellation() }))
+                    .toList()
+
+            assertEquals(1, updates.size)
+            assertEquals(2, events.size)
+            assertTrue(events.first() is WogeOperationStarted)
+            val finished = events.last() as WogeOperationFinished
+            assertEquals(WogeOutcome.TIMED_OUT, finished.outcome)
+            assertEquals(
+                "waiting",
+                finished.context.target
+                    ?.region
+                    ?.value,
+            )
+        }
 }
 
 private fun region(

--- a/modules/woge-server-runtime/src/test/kotlin/dev/woge/runtime/SemanticObservationTest.kt
+++ b/modules/woge-server-runtime/src/test/kotlin/dev/woge/runtime/SemanticObservationTest.kt
@@ -1,0 +1,74 @@
+package dev.woge.runtime
+
+import dev.woge.host.CorrelationId
+import dev.woge.host.RequestId
+import dev.woge.host.RequestTrace
+import dev.woge.host.WogeObservationContext
+import dev.woge.host.WogeObservationEvent
+import dev.woge.host.WogeObserver
+import dev.woge.host.WogeOperation
+import dev.woge.host.WogeOperationFinished
+import dev.woge.host.WogeOperationStarted
+import dev.woge.host.WogeOutcome
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SemanticObservationTest {
+    @Test
+    fun `operation emits ordered start and successful finish with correlation`() =
+        runTest {
+            val events = mutableListOf<WogeObservationEvent>()
+            val context =
+                WogeObservationContext(
+                    requestTrace = RequestTrace(RequestId.of("request-1"), CorrelationId.of("correlation-1")),
+                )
+
+            val result =
+                WogeObserver(events::add).observeOperation(WogeOperation.PAGE_REQUEST, context) {
+                    "result"
+                }
+
+            assertEquals("result", result)
+            assertEquals(2, events.size)
+            assertTrue(events[0] is WogeOperationStarted)
+            val finished = events[1] as WogeOperationFinished
+            assertEquals(WogeOutcome.SUCCEEDED, finished.outcome)
+            assertEquals(context, finished.context)
+            assertTrue(finished.duration.isFinite() && finished.duration >= kotlin.time.Duration.ZERO)
+        }
+
+    @Test
+    fun `flow collection classifies cancellation and emits one finish`() =
+        runTest {
+            val events = mutableListOf<WogeObservationEvent>()
+
+            val thrown =
+                runCatching {
+                    flowOf("before")
+                        .observeCollection(WogeObserver(events::add), WogeOperation.SHELL_RENDER)
+                        .collect { throw CancellationException("client disconnected") }
+                }.exceptionOrNull()
+
+            assertTrue(thrown is CancellationException)
+            assertEquals(listOf(WogeOperation.SHELL_RENDER, WogeOperation.SHELL_RENDER), events.map { it.operation })
+            assertEquals(WogeOutcome.CANCELLED, (events.last() as WogeOperationFinished).outcome)
+        }
+
+    @Test
+    fun `observer failure never changes successful or failed application work`() =
+        runTest {
+            val observer = WogeObserver { error("telemetry unavailable") }
+            assertEquals(42, observer.observeOperation(WogeOperation.ACTION) { 42 })
+
+            val applicationFailure = IllegalStateException("application failure")
+            val thrown =
+                runCatching {
+                    observer.observeOperation(WogeOperation.ACTION) { throw applicationFailure }
+                }.exceptionOrNull()
+            assertEquals(applicationFailure, thrown)
+        }
+}

--- a/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/AdapterTckApplication.kt
+++ b/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/AdapterTckApplication.kt
@@ -13,6 +13,8 @@ import dev.woge.host.RequestMethod
 import dev.woge.host.ResponseHeaders
 import dev.woge.host.ResponseMetadata
 import dev.woge.host.ResponseStatus
+import dev.woge.host.WogeObservationEvent
+import dev.woge.host.WogeObserver
 import dev.woge.host.deferredRegion
 import dev.woge.host.failure
 import dev.woge.host.httpHeader
@@ -69,6 +71,7 @@ public enum class AdapterTckDeferredScenario(
 public class AdapterTckApplication internal constructor() {
     private val state: AdapterTckFixtureState = AdapterTckFixtureState()
 
+    public val observer: WogeObserver = WogeObserver(state::observe)
     public val pages: PageUseCase<AdapterTckPageScenario> = PageUseCase(state::openPage)
     public val deferredRegions: DeferredRegionsUseCase<AdapterTckDeferredScenario> =
         DeferredRegionsUseCase(state::deferredRegions)
@@ -81,6 +84,13 @@ internal class AdapterTckFixtureState {
     val slowRegion: CompletableDeferred<PatchHtml> = CompletableDeferred()
     val cancelledRegion: CompletableDeferred<Unit> = CompletableDeferred()
     private val observedContexts: ConcurrentLinkedQueue<RequestContext> = ConcurrentLinkedQueue()
+    private val observationEvents: ConcurrentLinkedQueue<WogeObservationEvent> = ConcurrentLinkedQueue()
+
+    fun observe(event: WogeObservationEvent) {
+        observationEvents += event
+    }
+
+    fun observations(): List<WogeObservationEvent> = observationEvents.toList()
 
     suspend fun openPage(request: PageRequest<AdapterTckPageScenario>): PageResult {
         observedContexts += request.context

--- a/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/ServerAdapterContract.kt
+++ b/testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/ServerAdapterContract.kt
@@ -2,6 +2,11 @@ package dev.woge.tck
 
 import dev.woge.host.RequestMethod
 import dev.woge.host.ResponseStatus
+import dev.woge.host.WogeObservationEvent
+import dev.woge.host.WogeOperation
+import dev.woge.host.WogeOperationFinished
+import dev.woge.host.WogeOperationStarted
+import dev.woge.host.WogeOutcome
 import dev.woge.protocol.PatchStreamEvent
 import dev.woge.protocol.PatchStreamV1
 import kotlinx.coroutines.withTimeout
@@ -74,6 +79,7 @@ public class ServerAdapterContract(
     ): AdapterTckViolation = AdapterTckViolation(owner, factory.adapterName, contract, detail, cause)
 }
 
+@Suppress("TooManyFunctions")
 private class AdapterTckVerification(
     private val adapterName: String,
     private val server: AdapterTckServer,
@@ -88,6 +94,7 @@ private class AdapterTckVerification(
         if (AdapterTckCapability.CLIENT_ABORT_CANCELLATION in server.capabilities) {
             verifyClientAbortCancellation()
         }
+        verifySemanticObservations()
     }
 
     private suspend fun verifyDocumentGetAndHead() {
@@ -243,6 +250,67 @@ private class AdapterTckVerification(
             response.body().use { body -> body.readThrough("Ready region") }
             withTimeout(CLIENT_ABORT_TIMEOUT) { fixture.cancelledRegion.await() }
         }
+    }
+
+    private suspend fun verifySemanticObservations() {
+        runContract("semantic-observations") {
+            val events = fixture.observations()
+            expect(events.isNotEmpty(), "semantic-observations", "adapter emitted no semantic events")
+            expectPairedLifecycle(events)
+            expectOutcome(events, WogeOperation.PAGE_REQUEST, WogeOutcome.REJECTED)
+            expectOutcome(events, WogeOperation.PAGE_REQUEST, WogeOutcome.FAILED)
+            expectOutcome(events, WogeOperation.SHELL_RENDER, WogeOutcome.SUCCEEDED)
+            expectOutcome(events, WogeOperation.DEFERRED_REGION, WogeOutcome.SUCCEEDED)
+            expectOutcome(events, WogeOperation.PATCH_ENCODE, WogeOutcome.SUCCEEDED)
+            expect(
+                events.all { it.context.requestTrace?.correlationId != null },
+                "semantic-observations",
+                "server event is missing request correlation",
+            )
+            expect(
+                !events.toString().contains(PRE_STREAM_PRIVATE_DETAIL),
+                "semantic-observations",
+                "private exception detail entered structured observations",
+            )
+        }
+    }
+
+    private fun expectPairedLifecycle(events: List<WogeObservationEvent>) {
+        val open = mutableMapOf<Long, WogeOperationStarted>()
+        events.forEach { event ->
+            when (event) {
+                is WogeOperationStarted -> {
+                    expect(
+                        open.put(event.observationId.value, event) == null,
+                        "semantic-observations",
+                        "duplicate observation ID ${event.observationId.value}",
+                    )
+                }
+                is WogeOperationFinished -> {
+                    val started = open.remove(event.observationId.value)
+                    expect(
+                        started?.operation == event.operation && started.context == event.context,
+                        "semantic-observations",
+                        "${event.operation.semanticName} finished without a matching start",
+                    )
+                }
+            }
+        }
+        expect(open.isEmpty(), "semantic-observations", "semantic operation did not emit a terminal event")
+    }
+
+    private fun expectOutcome(
+        events: List<WogeObservationEvent>,
+        operation: WogeOperation,
+        outcome: WogeOutcome,
+    ) {
+        expect(
+            events.filterIsInstance<WogeOperationFinished>().any {
+                it.operation == operation && it.outcome == outcome
+            },
+            "semantic-observations",
+            "missing ${operation.semanticName}/${outcome.semanticName} outcome",
+        )
     }
 
     private fun expectDocumentMetadata(


### PR DESCRIPTION
Closes #123

## What changed
- adds a typed, vendor-neutral observer port with stable operations, outcomes, correlation-only context, paired observation IDs, monotonic durations, and a no-op default
- emits page, shell, deferred-region, and patch-encoding events consistently across Spring MVC, WebFlux, and Ktor; Spring Boot conditionally wires application observers
- emits structured patch-application events in the fallback browser runtime, including rejected and stale outcomes without HTML payloads
- extends the shared real-HTTP adapter TCK for lifecycle parity, redaction, correlation, and outcome checks
- records ADR 0035 and adds a web-developer-oriented Micrometer/OpenTelemetry mapping guide

## Verification
- ./gradlew check
- npm run build
- npm run test:unit
- npm run test:browser (36 tests across Chromium, Firefox, and WebKit)
- npm run measure
- documentation, ADR, module-boundary, Detekt, ktlint, and ABI checks