### PR TITLE
Publish fallback client artifacts

### DIFF
--- a/.github/workflows/fallback-client.yml
+++ b/.github/workflows/fallback-client.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - "client/woge-fallback-client/**"
+      - "integrations/woge-fallback-client-assets/**"
+      - "modules/woge-protocol/src/main/kotlin/dev/woge/protocol/Patch.kt"
+      - "modules/woge-protocol/src/main/kotlin/dev/woge/protocol/PatchStreamValues.kt"
       - "modules/woge-protocol/src/test/resources/fixtures/**"
       - ".github/workflows/fallback-client.yml"
   push:
@@ -11,6 +14,9 @@ on:
       - main
     paths:
       - "client/woge-fallback-client/**"
+      - "integrations/woge-fallback-client-assets/**"
+      - "modules/woge-protocol/src/main/kotlin/dev/woge/protocol/Patch.kt"
+      - "modules/woge-protocol/src/main/kotlin/dev/woge/protocol/PatchStreamValues.kt"
       - "modules/woge-protocol/src/test/resources/fixtures/**"
       - ".github/workflows/fallback-client.yml"
 
@@ -41,5 +47,8 @@ jobs:
           if-no-files-found: warn
           path: |
             client/woge-fallback-client/build/size-metrics.json
+            client/woge-fallback-client/build/package-test-result.json
+            client/woge-fallback-client/build/pack-a/*.tgz
+            client/woge-fallback-client/dist/manifest.json
             client/woge-fallback-client/playwright-report/**
             client/woge-fallback-client/test-results/**

--- a/client/woge-fallback-client/README.md
+++ b/client/woge-fallback-client/README.md
@@ -31,11 +31,22 @@ the initial page/deferred-work sequence and defaults to `0`.
 
 The production entry point is an ES module:
 
+```shell
+npm install @woge/fallback-client
+```
+
 ```js
-import { createWogePatchRuntime } from "@woge/fallback-client";
+import {
+  createWogePatchRuntime,
+  WOGE_PATCH_PROTOCOL_VERSION,
+} from "@woge/fallback-client";
 
 const runtime = createWogePatchRuntime(document);
-const response = await fetch("/projects/42/summary");
+const response = await fetch("/projects/42/summary", {
+  headers: {
+    Accept: `application/vnd.woge.patch-stream; version=${WOGE_PATCH_PROTOCOL_VERSION}`,
+  },
+});
 
 if (!response.body) throw new Error("The response has no body");
 await runtime.applyPatchStream(response.body);
@@ -43,6 +54,14 @@ await runtime.applyPatchStream(response.body);
 
 The package ships TypeScript declarations for the runtime, completion value, error types and
 lifecycle-event details, so JavaScript and TypeScript IDEs can autocomplete the small public API.
+It also ships a manifest containing package/protocol versions, output hashes, sizes and SRI integrity.
+There are no runtime dependencies and no CSS files.
+
+Spring Boot and Ktor projects that do not otherwise need Node can consume the
+`dev.woge:woge-fallback-client-assets` JVM artifact. It exposes the same canonical modules as
+classpath resources below `/assets/woge/`. The
+[installation guide](../../docs/guides/fallback-client-installation.md) compares both paths and
+covers static deployment, caching, source maps, CSP and SRI.
 
 Fetch/form interception is intentionally not part of this module yet. Issue
 [#31](https://github.com/christian-draeger/woge/issues/31) will add that progressive-enhancement
@@ -68,9 +87,11 @@ npx playwright install chromium firefox webkit
 npm run check
 ```
 
-`npm run check` builds the minified ES module, runs decoder tests, runs the browser contract in
+`npm run check` builds the minified ES module, verifies protocol alignment, packs two byte-identical
+artifacts, installs one into a fresh external consumer, runs decoder and browser tests in
 Chromium/Firefox/WebKit and reports source, minified, gzip and Brotli sizes. Browser tests attach and
-print module-load/parse/evaluation and patch-application timings.
+print module-load/parse/evaluation and patch-application timings. `npm publish` runs the same gate
+before it can publish.
 
 See the [browser runtime guide](../../docs/guides/browser-replace-runtime.md) and
 [ADR 0025](../../docs/adr/0025-browser-replace-runtime-and-lifecycle.md) for the complete boundary.

--- a/client/woge-fallback-client/browser-tests/package-consumer-fixture.html
+++ b/client/woge-fallback-client/browser-tests/package-consumer-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="woge-page-epoch" content="package-page">
+    <title>Installed Woge package consumer</title>
+  </head>
+  <body>
+    <main data-woge-region="package-region" data-woge-revision="0"><p>External fallback</p></main>
+    <script type="module" src="/package-consumer.js"></script>
+  </body>
+</html>

--- a/client/woge-fallback-client/browser-tests/package-consumer.spec.mjs
+++ b/client/woge-fallback-client/browser-tests/package-consumer.spec.mjs
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { completeFrame, encodeStream, patchFrame } from "../test-support/protocol-fixture.mjs";
+
+test("applies a patch through a freshly packed installed and bundled consumer", async ({ page }) => {
+  await page.goto("/package-consumer");
+  await page.waitForFunction(() => globalThis.WogePackageConsumer !== undefined);
+  const bytes = encodeStream([
+    patchFrame({
+      epoch: "package-page",
+      target: "package-region",
+      html: "<p>Installed package works</p>",
+    }),
+    completeFrame(1),
+  ]);
+
+  const result = await page.evaluate(async (values) => {
+    const runtime = globalThis.WogePackageConsumer.createWogePatchRuntime(document);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(Uint8Array.from(values));
+        controller.close();
+      },
+    });
+    const completion = await runtime.applyPatchStream(stream);
+    return {
+      protocolVersion: globalThis.WogePackageConsumer.protocolVersion,
+      patchCount: completion.patchCount,
+    };
+  }, Array.from(bytes));
+
+  expect(result).toEqual({ protocolVersion: 1, patchCount: 1 });
+  await expect(page.getByText("Installed package works")).toBeVisible();
+});

--- a/client/woge-fallback-client/browser-tests/server.mjs
+++ b/client/woge-fallback-client/browser-tests/server.mjs
@@ -9,6 +9,14 @@ const routes = new Map([
     { path: new URL("./deferred-bootstrap.mjs", import.meta.url), type: "text/javascript; charset=utf-8" },
   ],
   ["/woge-fallback.js", { path: new URL("../dist/woge-fallback.js", import.meta.url), type: "text/javascript; charset=utf-8" }],
+  [
+    "/package-consumer",
+    { path: new URL("./package-consumer-fixture.html", import.meta.url), type: "text/html; charset=utf-8" },
+  ],
+  [
+    "/package-consumer.js",
+    { path: new URL("../build/package-consumer/consumer-bundle.js", import.meta.url), type: "text/javascript; charset=utf-8" },
+  ],
 ]);
 
 const deferredStream = await readDeferredStream();

--- a/client/woge-fallback-client/package-lock.json
+++ b/client/woge-fallback-client/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "@woge/fallback-client",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@playwright/test": "1.62.1",
         "esbuild": "0.28.2"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/client/woge-fallback-client/package.json
+++ b/client/woge-fallback-client/package.json
@@ -1,29 +1,55 @@
 {
   "name": "@woge/fallback-client",
   "version": "0.1.0",
-  "private": true,
   "description": "Small standards-native browser adapter for Woge patch streams",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/christian-draeger/woge#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/christian-draeger/woge.git",
+    "directory": "client/woge-fallback-client"
+  },
+  "bugs": "https://github.com/christian-draeger/woge/issues",
+  "keywords": [
+    "hypermedia",
+    "kotlin",
+    "progressive-enhancement",
+    "server-driven-ui"
+  ],
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/woge-fallback.js"
-    }
+    },
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "woge": {
+    "patchProtocolVersion": 1
   },
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "scripts": {
     "build": "node scripts/build.mjs",
+    "verify:contract": "node scripts/verify-contract.mjs",
     "test:unit": "node --test tests/*.test.mjs",
+    "test:package": "node scripts/test-package.mjs",
+    "pretest:browser": "npm run test:package",
     "test:browser": "playwright test",
     "test:reference": "playwright test --config=playwright.reference.config.mjs",
     "measure": "node scripts/measure.mjs",
-    "check": "npm run build && npm run test:unit && npm run test:browser && npm run measure"
+    "prepack": "npm run build && npm run verify:contract",
+    "prepublishOnly": "npm run check",
+    "check": "npm run build && npm run verify:contract && npm run test:unit && npm run test:browser && npm run measure"
   },
   "devDependencies": {
     "@playwright/test": "1.62.1",

--- a/client/woge-fallback-client/scripts/build.mjs
+++ b/client/woge-fallback-client/scripts/build.mjs
@@ -1,18 +1,55 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { build } from "esbuild";
+import { WOGE_PATCH_PROTOCOL_VERSION } from "../src/version.js";
 
-await rm(new URL("../dist/", import.meta.url), { recursive: true, force: true });
-await mkdir(new URL("../dist/", import.meta.url), { recursive: true });
+const distDirectory = new URL("../dist/", import.meta.url);
+const moduleFile = new URL("woge-fallback.js", distDirectory);
+const sourceMapFile = new URL("woge-fallback.js.map", distDirectory);
+const declarationFile = new URL("index.d.ts", distDirectory);
+const packageMetadata = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+
+await rm(distDirectory, { recursive: true, force: true });
+await mkdir(distDirectory, { recursive: true });
 
 await build({
   entryPoints: [new URL("../src/index.js", import.meta.url).pathname],
-  outfile: new URL("../dist/woge-fallback.js", import.meta.url).pathname,
+  outfile: moduleFile.pathname,
   bundle: true,
   format: "esm",
   target: "es2022",
   minify: true,
   legalComments: "none",
-  sourcemap: false,
+  sourcemap: "external",
 });
 
-await copyFile(new URL("../src/index.d.ts", import.meta.url), new URL("../dist/index.d.ts", import.meta.url));
+await copyFile(new URL("../src/index.d.ts", import.meta.url), declarationFile);
+await copyFile(new URL("../../../LICENSE", import.meta.url), new URL("LICENSE", distDirectory));
+
+const files = {};
+for (const [name, url] of [
+  ["module", moduleFile],
+  ["sourceMap", sourceMapFile],
+  ["types", declarationFile],
+]) {
+  const bytes = await readFile(url);
+  files[name] = Object.freeze({
+    path: url.pathname.split("/").at(-1),
+    bytes: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+  });
+}
+
+const moduleBytes = await readFile(moduleFile);
+const manifest = {
+  schemaVersion: 1,
+  packageVersion: packageMetadata.version,
+  patchProtocolVersion: WOGE_PATCH_PROTOCOL_VERSION,
+  format: "es-module",
+  target: "es2022",
+  runtimeDependencies: [],
+  cssFiles: [],
+  integrity: `sha256-${createHash("sha256").update(moduleBytes).digest("base64")}`,
+  files,
+};
+await writeFile(new URL("manifest.json", distDirectory), `${JSON.stringify(manifest, null, 2)}\n`);

--- a/client/woge-fallback-client/scripts/measure.mjs
+++ b/client/woge-fallback-client/scripts/measure.mjs
@@ -2,17 +2,23 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { brotliCompressSync, gzipSync } from "node:zlib";
 
-const sourceFiles = ["index.js", "protocol.js", "dom.js"];
+const sourceFiles = ["index.js", "protocol.js", "dom.js", "version.js"];
 const sources = await Promise.all(
   sourceFiles.map((name) => readFile(new URL(`../src/${name}`, import.meta.url))),
 );
 const bundle = await readFile(new URL("../dist/woge-fallback.js", import.meta.url));
+const manifest = JSON.parse(await readFile(new URL("../dist/manifest.json", import.meta.url), "utf8"));
+const bundleHash = createHash("sha256").update(bundle).digest("hex");
+if (manifest.files.module.sha256 !== bundleHash) {
+  throw new Error("Fallback-client manifest hash does not match the measured module");
+}
 const metrics = {
   sourceBytes: sources.reduce((size, source) => size + source.byteLength, 0),
   minifiedBundleBytes: bundle.byteLength,
   gzipBytes: gzipSync(bundle, { level: 9 }).byteLength,
   brotliBytes: brotliCompressSync(bundle).byteLength,
-  sha256: createHash("sha256").update(bundle).digest("hex"),
+  sha256: bundleHash,
+  integrity: manifest.integrity,
 };
 
 await mkdir(new URL("../build/", import.meta.url), { recursive: true });

--- a/client/woge-fallback-client/scripts/test-package.mjs
+++ b/client/woge-fallback-client/scripts/test-package.mjs
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { build } from "esbuild";
+
+const execute = promisify(execFile);
+const packageDirectory = new URL("../", import.meta.url);
+const buildDirectory = new URL("../build/", import.meta.url);
+const firstPackDirectory = new URL("pack-a/", buildDirectory);
+const secondPackDirectory = new URL("pack-b/", buildDirectory);
+const consumerDirectory = new URL("package-consumer/", buildDirectory);
+const npmCacheDirectory = new URL("npm-cache/", buildDirectory);
+
+await Promise.all(
+  [firstPackDirectory, secondPackDirectory, consumerDirectory, npmCacheDirectory].map(async (directory) => {
+    await rm(directory, { recursive: true, force: true });
+    await mkdir(directory, { recursive: true });
+  }),
+);
+
+const firstTarball = await pack(firstPackDirectory);
+const secondTarball = await pack(secondPackDirectory);
+const firstHash = await sha256(firstTarball);
+const secondHash = await sha256(secondTarball);
+if (firstHash !== secondHash) throw new Error("Two clean fallback-client packs produced different tarballs");
+
+const { stdout: archiveOutput } = await execute("tar", ["-tzf", firstTarball.pathname]);
+const archiveFiles = archiveOutput.trim().split("\n").sort();
+const expectedFiles = [
+  "package/README.md",
+  "package/dist/LICENSE",
+  "package/dist/index.d.ts",
+  "package/dist/manifest.json",
+  "package/dist/woge-fallback.js",
+  "package/dist/woge-fallback.js.map",
+  "package/package.json",
+].sort();
+if (JSON.stringify(archiveFiles) !== JSON.stringify(expectedFiles)) {
+  throw new Error(`Unexpected fallback-client package contents:\n${archiveFiles.join("\n")}`);
+}
+
+await writeFile(
+  new URL("package.json", consumerDirectory),
+  `${JSON.stringify({ name: "woge-external-consumer", private: true, type: "module" }, null, 2)}\n`,
+);
+await execute(
+  "npm",
+  [
+    "install",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    "--cache",
+    npmCacheDirectory.pathname,
+    firstTarball.pathname,
+  ],
+  { cwd: consumerDirectory.pathname },
+);
+
+const entryFile = new URL("entry.js", consumerDirectory);
+await writeFile(
+  entryFile,
+  [
+    'import { createWogePatchRuntime, WOGE_PATCH_PROTOCOL_VERSION } from "@woge/fallback-client";',
+    "if (WOGE_PATCH_PROTOCOL_VERSION !== 1) throw new Error(\"Installed protocol version mismatch\");",
+    "globalThis.WogePackageConsumer = { createWogePatchRuntime, protocolVersion: WOGE_PATCH_PROTOCOL_VERSION };",
+    "",
+  ].join("\n"),
+);
+await execute("node", [entryFile.pathname], { cwd: consumerDirectory.pathname });
+await build({
+  absWorkingDir: consumerDirectory.pathname,
+  entryPoints: [entryFile.pathname],
+  outfile: new URL("consumer-bundle.js", consumerDirectory).pathname,
+  bundle: true,
+  format: "esm",
+  target: "es2022",
+  sourcemap: "external",
+});
+
+const installedPackage = JSON.parse(
+  await readFile(new URL("node_modules/@woge/fallback-client/package.json", consumerDirectory), "utf8"),
+);
+const installedManifest = JSON.parse(
+  await readFile(new URL("node_modules/@woge/fallback-client/dist/manifest.json", consumerDirectory), "utf8"),
+);
+if (installedPackage.version !== installedManifest.packageVersion) {
+  throw new Error("Installed package and asset manifest versions differ");
+}
+await writeFile(
+  new URL("package-test-result.json", buildDirectory),
+  `${JSON.stringify(
+    {
+      package: `${installedPackage.name}@${installedPackage.version}`,
+      patchProtocolVersion: installedManifest.patchProtocolVersion,
+      tarballSha256: firstHash,
+      archiveFiles,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+console.log(
+  `[woge-package] installed=${installedPackage.name}@${installedPackage.version} ` +
+    `protocol=${installedManifest.patchProtocolVersion} tarball_sha256=${firstHash}`,
+);
+
+async function pack(destination) {
+  await execute(
+    "npm",
+    [
+      "pack",
+      "--silent",
+      "--cache",
+      npmCacheDirectory.pathname,
+      "--pack-destination",
+      destination.pathname,
+    ],
+    { cwd: packageDirectory.pathname },
+  );
+  const archives = (await readdir(destination)).filter((name) => name.endsWith(".tgz"));
+  if (archives.length !== 1) throw new Error("Expected npm pack to produce exactly one tarball");
+  return new URL(archives[0], destination);
+}
+
+async function sha256(file) {
+  return createHash("sha256").update(await readFile(file)).digest("hex");
+}

--- a/client/woge-fallback-client/scripts/verify-contract.mjs
+++ b/client/woge-fallback-client/scripts/verify-contract.mjs
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import { WOGE_PATCH_PROTOCOL_VERSION } from "../src/version.js";
+
+const packageMetadata = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+const manifest = JSON.parse(await readFile(new URL("../dist/manifest.json", import.meta.url), "utf8"));
+const kotlinPatch = await readFile(
+  new URL("../../../modules/woge-protocol/src/main/kotlin/dev/woge/protocol/Patch.kt", import.meta.url),
+  "utf8",
+);
+const kotlinPatchStream = await readFile(
+  new URL("../../../modules/woge-protocol/src/main/kotlin/dev/woge/protocol/PatchStreamValues.kt", import.meta.url),
+  "utf8",
+);
+
+const versions = {
+  package: packageMetadata.woge?.patchProtocolVersion,
+  browser: WOGE_PATCH_PROTOCOL_VERSION,
+  manifest: manifest.patchProtocolVersion,
+  patchIr: matchVersion(kotlinPatch, /CURRENT: PatchProtocolVersion = PatchProtocolVersion\((\d+)\)/u, "Patch IR"),
+  patchStream: matchVersion(kotlinPatchStream, /const val VERSION: Int = (\d+)/u, "patch stream"),
+};
+
+if (new Set(Object.values(versions)).size !== 1) {
+  throw new Error(`Woge patch protocol versions differ: ${JSON.stringify(versions)}`);
+}
+if (packageMetadata.dependencies && Object.keys(packageMetadata.dependencies).length > 0) {
+  throw new Error("The fallback client must not have runtime package dependencies");
+}
+if (manifest.runtimeDependencies.length > 0 || manifest.cssFiles.length > 0) {
+  throw new Error("The fallback client manifest must not declare a framework or CSS runtime");
+}
+if (manifest.packageVersion !== packageMetadata.version) {
+  throw new Error("Fallback-client manifest and package versions differ");
+}
+
+console.log(
+  `[woge-package] package=${packageMetadata.name}@${packageMetadata.version} protocol=${WOGE_PATCH_PROTOCOL_VERSION}`,
+);
+
+function matchVersion(content, pattern, source) {
+  const value = Number(pattern.exec(content)?.[1]);
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`Could not read protocol version from ${source}`);
+  return value;
+}

--- a/client/woge-fallback-client/src/index.d.ts
+++ b/client/woge-fallback-client/src/index.d.ts
@@ -1,5 +1,6 @@
 export const BEFORE_REPLACE_EVENT: "woge:before-replace";
 export const AFTER_REPLACE_EVENT: "woge:after-replace";
+export const WOGE_PATCH_PROTOCOL_VERSION: 1;
 
 export interface ReplaceLifecycleDetail {
   readonly operation: "replace";

--- a/client/woge-fallback-client/src/index.js
+++ b/client/woge-fallback-client/src/index.js
@@ -5,6 +5,7 @@ import {
   WogeRemotePatchError,
   fail,
 } from "./protocol.js";
+import { WOGE_PATCH_PROTOCOL_VERSION } from "./version.js";
 
 /** Owns one active document's region registry and applies validated patch streams to it. */
 class WogePatchRuntime {
@@ -115,4 +116,5 @@ export {
   BEFORE_REPLACE_EVENT,
   WogePatchError,
   WogeRemotePatchError,
+  WOGE_PATCH_PROTOCOL_VERSION,
 };

--- a/client/woge-fallback-client/src/protocol.js
+++ b/client/woge-fallback-client/src/protocol.js
@@ -1,6 +1,7 @@
+import { WOGE_PATCH_PROTOCOL_VERSION } from "./version.js";
+
 const PREAMBLE_MAGIC = Uint8Array.of(0x57, 0x4f, 0x47, 0x45);
 const PREAMBLE_BYTES = 5;
-const VERSION = 1;
 const HEADER_BYTES = 10;
 const PATCH = 1;
 const COMPLETE = 2;
@@ -146,7 +147,7 @@ export class PatchStreamDecoder {
         fail("WOGE_INVALID_PREAMBLE", "Patch stream preamble magic is invalid");
       }
     }
-    if (preamble[PREAMBLE_MAGIC.byteLength] !== VERSION) {
+    if (preamble[PREAMBLE_MAGIC.byteLength] !== WOGE_PATCH_PROTOCOL_VERSION) {
       fail("WOGE_UNSUPPORTED_VERSION", "Patch stream version is unsupported");
     }
     this.#buffer.discard(PREAMBLE_BYTES);
@@ -248,7 +249,9 @@ function decodeReplaceMetadata(value) {
   const match = replaceMetadataPattern.exec(value);
   if (!match) fail("WOGE_INVALID_METADATA", "Patch frame metadata is invalid or non-canonical");
   const version = Number(match[1]);
-  if (version !== VERSION) fail("WOGE_UNSUPPORTED_VERSION", "Patch metadata version is unsupported");
+  if (version !== WOGE_PATCH_PROTOCOL_VERSION) {
+    fail("WOGE_UNSUPPORTED_VERSION", "Patch metadata version is unsupported");
+  }
   if (match[2] !== "replace") fail("WOGE_INVALID_METADATA", "Patch operation is unsupported");
 
   const interactionSequence = parseLong(match[6]);

--- a/client/woge-fallback-client/src/version.js
+++ b/client/woge-fallback-client/src/version.js
@@ -1,0 +1,2 @@
+/** Patch-stream protocol version implemented by this browser package. */
+export const WOGE_PATCH_PROTOCOL_VERSION = 1;

--- a/config/architecture/module-boundaries.tsv
+++ b/config/architecture/module-boundaries.tsv
@@ -4,6 +4,7 @@ woge-ui-headless	ui	public	modules/woge-ui-headless	woge-core	-
 woge-protocol	protocol	public	modules/woge-protocol	woge-core	-
 woge-host-spi	port	public	modules/woge-host-spi	woge-core,woge-protocol	-
 woge-server-runtime	runtime	internal	modules/woge-server-runtime	woge-core,woge-protocol,woge-host-spi	-
+woge-fallback-client-assets	integration	public	integrations/woge-fallback-client-assets	-	-
 woge-adapter-tck	test-support	support	testing/woge-adapter-tck	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
 woge-spring-mvc	adapter	public	adapters/woge-spring-mvc	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
 woge-spring-webflux	adapter	public	adapters/woge-spring-webflux	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
 - [AI-DX evaluation corpus](ai-dx/corpus-v0.1.md)
 - [Build and test Woge](development/build-and-test.md)
+- [Install and deploy the fallback browser client](guides/fallback-client-installation.md)
 - [Repository scaffold provenance](development/scaffold-provenance.md)
 
 ## Implemented API guides
@@ -41,6 +42,7 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Describe a visible update with Patch IR](guides/patch-ir.md)
 - [Encode and decode fallback patch streams](guides/patch-stream-codec.md)
 - [Apply a patch stream in the browser](guides/browser-replace-runtime.md)
+- [Install and deploy the fallback browser client](guides/fallback-client-installation.md)
 - [Render independent page regions](guides/deferred-regions.md)
 - [Run a Woge page with Spring WebFlux](guides/spring-webflux-adapter.md)
 - [Run a Woge page with Spring MVC](guides/spring-mvc-adapter.md)

--- a/docs/adr/0036-dual-fallback-client-distribution.md
+++ b/docs/adr/0036-dual-fallback-client-distribution.md
@@ -1,0 +1,83 @@
+# ADR 0036: Distribute one fallback client through npm and a JVM asset adapter
+
+- Status: Accepted
+- Date: 2026-09-06
+- Decision owners: @christian-draeger
+- Related issues: [#132](https://github.com/christian-draeger/woge/issues/132)
+
+## Context
+
+The fallback browser client was initially copied from repository source into the reference
+application. That proved behavior but was not a versioned consumer contract. Applications with Vite,
+esbuild or another frontend pipeline expect a normal ES module package. Spring Boot and Ktor
+applications that otherwise need no JavaScript build should not be forced to install Node merely to
+serve a small standards-native module.
+
+Both installation paths must speak the exact protocol implemented by `woge-protocol`. A published
+artifact assembled from different source, or a JVM and npm release with silent version skew, would
+turn deployment order into browser failures.
+
+## Decision
+
+`client/woge-fallback-client/src` is the single source of the browser runtime. It has no framework,
+hydration or CSS runtime dependency and exports `WOGE_PATCH_PROTOCOL_VERSION` with its public API.
+
+Woge distributes that source in two forms:
+
+- `@woge/fallback-client` is a public npm package for frontend asset pipelines. Its default export
+  path is one minified ES2022 module with TypeScript declarations, an external source map and a
+  machine-readable manifest containing package/protocol versions, byte counts, SHA-256 hashes and
+  SRI integrity. `npm pack` includes only documented files.
+- `dev.woge:woge-fallback-client-assets` is a framework-neutral JVM artifact. It places the canonical
+  unbundled ES modules below `static/assets/woge`, where Spring Boot and compatible Ktor static
+  resource setups can serve them from the classpath. Package metadata is retained below `META-INF`.
+  Building or consuming this artifact does not execute Node.
+
+The npm build, JVM asset check and shared tests compare the npm metadata, JavaScript constant,
+`PatchProtocolVersion.CURRENT` and `PatchStreamV1.VERSION`. Different values fail the build. The
+browser rejects an incompatible stream before changing the DOM.
+
+Package verification builds twice, requires byte-identical tarballs, installs one tarball in a fresh
+external project, imports and bundles only the public package entry, and executes that bundle in the
+browser contract. The Spring Boot reference application consumes the JVM artifact through its public
+runtime dependency instead of copying source in its build.
+
+Publishing remains an explicit release action. `prepublishOnly` runs the complete browser package
+gate, but ordinary repository checks never publish or require credentials.
+
+## Alternatives considered
+
+- **Require npm for every application:** familiar to frontend teams, but adds a second toolchain to a
+  Spring/Ktor application whose only browser code is Woge's small adapter.
+- **Publish only a JVM webjar:** convenient for server-centric applications, but awkward for normal
+  bundlers, tree-shaking metadata and TypeScript tooling.
+- **Maintain separate bundled and classpath sources:** easy to package initially, but permits behavior
+  and protocol drift between consumers.
+- **Load the runtime from a public CDN by default:** quick for a demo, but delegates availability,
+  privacy, CSP and release selection to an external origin.
+- **Hide protocol negotiation inside a generated bootstrap:** removes one visible constant, but makes
+  deployment compatibility harder to inspect and test.
+
+## Consequences
+
+### Positive
+
+- Frontend and JVM-centric teams each use a native dependency workflow.
+- Spring Boot remains a first-class Node-free path without making Spring part of the browser runtime.
+- Types, manifests, hashes and a fresh-consumer smoke make artifacts legible to IDEs, CI and coding
+  agents.
+- One source and one explicit protocol constant make version skew fail early.
+
+### Negative
+
+- Releases produce and verify two artifacts from one source tree.
+- The JVM path serves multiple unbundled requests unless an application fingerprints or bundles them.
+- Applications, not Woge core, still own public asset URLs and production cache headers.
+- External source maps can expose readable source and need a deliberate production deployment policy.
+
+## Follow-up
+
+- Add release signing, provenance and registry publication in the public-release milestone.
+- Exercise rolling-version compatibility and deployment ordering in
+  [#118](https://github.com/christian-draeger/woge/issues/118).
+- Add production cache/proxy evidence in [#61](https://github.com/christian-draeger/woge/issues/61).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,6 +62,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0033](0033-suspending-ktor-adapter.md) | Accepted | Bind Woge to idiomatic suspending Ktor routes |
 | [0034](0034-generate-html-element-wrappers-from-webref.md) | Accepted | Generate HTML element wrappers from pinned Webref data |
 | [0035](0035-framework-neutral-semantic-observation-port.md) | Accepted | Use a framework-neutral semantic observation port |
+| [0036](0036-dual-fallback-client-distribution.md) | Accepted | Distribute one fallback client through npm and a JVM asset adapter |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/architecture/module-graph.md
+++ b/docs/architecture/module-graph.md
@@ -8,6 +8,7 @@ owns the current boundary decision.
 ```mermaid
 flowchart BT
     UI[woge-ui-headless] --> Core[woge-core]
+    Assets[woge-fallback-client-assets<br/>classpath web assets]
     Protocol[woge-protocol] --> Core
     SPI[woge-host-spi] --> Core
     SPI --> Protocol
@@ -50,7 +51,8 @@ the Spring adapters cannot depend on each other, and Ktor never wraps Spring con
 | Shared execution machinery | `woge-server-runtime` | Adapters reuse implementation without making it public API |
 | Adapter parity fixtures | `woge-adapter-tck` | Every host proves the same observable contract |
 | Spring Boot setup | auto-configuration and starter | Spring is first-class without becoming the core abstraction |
-| Browser patch application | [`client/woge-fallback-client`](../../client/woge-fallback-client/README.md) | It is a small web artifact, not a JVM or component runtime |
+| Browser patch application | npm `@woge/fallback-client` | It is a small web artifact, not a JVM or component runtime |
+| Browser assets without a Node application build | `woge-fallback-client-assets` | A framework-neutral classpath adapter serves the same canonical ES modules |
 | Multi-host proof | [`examples/reference-application`](../../examples/reference-application/README.md) | It consumes public artifacts and never becomes their dependency |
 
 ## Deferred boundaries
@@ -60,6 +62,11 @@ the Spring adapters cannot depend on each other, and Ktor never wraps Spring con
 - Kotlin/JS and Kotlin/Wasm remain optional local-island choices, not application-wide runtimes.
 - CSS scoping, Tailwind build integration and the source-component registry remain build tooling, not
   server or browser runtime dependencies.
+
+The two browser distribution paths are defined in
+[ADR 0036](../adr/0036-dual-fallback-client-distribution.md). They are alternatives for installing
+the same runtime, not separate implementations: npm supplies a bundled ES module for frontend asset
+pipelines, while the JVM artifact supplies canonical unbundled modules as classpath resources.
 
 The boundary validator fails on missing modules, unknown or cyclic edges, Gradle/manifest drift,
 forbidden host references in portable production source and MVC/WebFlux cross-dependencies. Negative

--- a/docs/development/build-and-test.md
+++ b/docs/development/build-and-test.md
@@ -65,6 +65,20 @@ and HTML reports are grouped by host below `client/woge-fallback-client/test-res
 and `client/woge-fallback-client/playwright-report/reference-application`. GitHub Actions uploads
 those paths and all JVM test reports even when a gate fails.
 
+The fallback client also proves the artifact a consumer will receive, rather than importing its
+repository source directly:
+
+```shell
+cd client/woge-fallback-client
+npm run test:package
+```
+
+That task creates two byte-identical tarballs, installs one into a fresh external project, imports
+its public entry point, bundles the consumer, and writes `build/package-test-result.json`. The normal
+browser gate then loads that generated consumer bundle in a real browser. `npm publish` runs the full
+client gate through `prepublishOnly`; publishing credentials and release authorization remain
+outside ordinary builds.
+
 Public declarations in `woge-core`, `woge-protocol` and `woge-host-spi` are tracked by Kotlin's
 built-in ABI validator. `checkKotlinAbi` compares current declarations with the committed dump. Run
 the corresponding module's `updateKotlinAbi` task only after reviewing and accepting an intentional

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -30,6 +30,9 @@ events, strict validation and host-adapter lifecycle.
 The [browser Replace runtime guide](browser-replace-runtime.md) starts from normal HTML and explains
 page-local regions, streamed application, delegated lifecycle events and safe failure behavior.
 
+The [fallback-client installation guide](fallback-client-installation.md) covers npm bundlers, the
+Node-free JVM asset, static deployment, version alignment, caching, source maps, CSP and SRI.
+
 The [deferred-region guide](deferred-regions.md) shows ordinary loading HTML, independently completing
 server work, bounded concurrency and request-owned cancellation.
 

--- a/docs/guides/fallback-client-installation.md
+++ b/docs/guides/fallback-client-installation.md
@@ -1,0 +1,99 @@
+# Install and deploy the fallback browser client
+
+The fallback client is a small ES module that applies Woge patch streams to server-rendered HTML. It
+does not render your page, provide components, manage CSS or require hydration. Choose one install
+path; do not load both on the same page.
+
+## Use a frontend asset pipeline
+
+Install the package with the package manager already used by your application:
+
+```shell
+npm install @woge/fallback-client
+```
+
+Import it from application JavaScript or TypeScript. A bundler resolves the public package entry and
+can fingerprint the resulting application asset:
+
+```js
+import {
+  createWogePatchRuntime,
+  WOGE_PATCH_PROTOCOL_VERSION,
+} from "@woge/fallback-client";
+
+const response = await fetch("/projects/woge/woge-patches", {
+  headers: {
+    Accept: `application/vnd.woge.patch-stream; version=${WOGE_PATCH_PROTOCOL_VERSION}`,
+  },
+});
+
+if (!response.ok || !response.body) throw new Error(`Patch request failed: ${response.status}`);
+await createWogePatchRuntime(document).applyPatchStream(response.body);
+```
+
+The package has no runtime dependencies or CSS files. `dist/manifest.json` records the package and
+patch-protocol versions, output hashes, sizes and the bundled module's SRI value. TypeScript
+declarations are exported from the same package entry.
+
+## Use Spring Boot without Node
+
+Add the JVM web-asset adapter next to the Woge server adapter:
+
+```kotlin
+dependencies {
+    implementation("dev.woge:woge-spring-boot-starter:<woge-version>")
+    runtimeOnly("dev.woge:woge-fallback-client-assets:<woge-version>")
+}
+```
+
+Spring Boot serves the classpath modules below `/assets/woge/`. Your own small application module can
+import the public entry directly:
+
+```js
+import { createWogePatchRuntime } from "/assets/woge/index.js";
+```
+
+This is the path used by the maintained reference application. The asset artifact itself is
+framework-neutral: a Ktor application may expose the same classpath directory through its normal
+static-resource configuration. The server framework still owns routing and cache policy.
+
+For a plain static deployment without a bundler, either vendor the npm package's single
+`dist/woge-fallback.js` file at a versioned URL or serve the JVM artifact's complete
+`static/assets/woge` directory. Never copy only `index.js` from the unbundled form because its module
+imports are relative.
+
+## Keep browser and server versions aligned
+
+Install the npm or JVM browser artifact with the same Woge release as `woge-protocol`. The browser
+exports its protocol version so application requests can advertise the matching media type. It also
+validates the stream preamble and every patch's metadata before DOM mutation; an incompatible stream
+fails closed instead of being partially applied.
+
+Artifact versions and wire-protocol versions are different concepts. A patch release may improve
+diagnostics without changing the protocol. Do not infer protocol compatibility by parsing the npm or
+Maven version string.
+
+## Set production asset policy
+
+Prefer a content-hashed public URL for a bundled module. Serve that immutable file with a long-lived
+policy such as `Cache-Control: public, max-age=31536000, immutable`. HTML, import maps, bootstraps and
+the package manifest select an asset version, so serve those with revalidation rather than the same
+immutable policy. Patch-stream responses contain page-specific state and remain `Cache-Control:
+no-store`.
+
+Source maps do not execute in the browser, but they expose readable implementation source to anyone
+who can fetch them. Publish maps when that debugging tradeoff is acceptable, or keep them in an
+authenticated error-monitoring pipeline. Removing the `.map` file does not change runtime behavior.
+
+A same-origin external module works with a strict policy such as `script-src 'self'`; the client does
+not use inline scripts, `eval` or dynamic code generation. Add nonces or hashes only for
+application-owned inline bootstraps. If the bundled module is loaded directly with a `script` tag,
+copy the `integrity` value from `manifest.json` to its `integrity` attribute. Cross-origin SRI also
+requires compatible CORS headers. Imported child modules are separate fetches, so prefer the single
+npm bundle when SRI must cover the complete runtime graph.
+
+The runtime does not impose a CSS policy. Plain CSS, CSS Modules, Tailwind and component-owned styles
+continue through the application's normal asset pipeline.
+
+Next, read [Apply Replace patches in the browser](browser-replace-runtime.md) for the page/region
+contract and lifecycle events.

--- a/docs/guides/quickstart-spring-boot.md
+++ b/docs/guides/quickstart-spring-boot.md
@@ -17,9 +17,11 @@ From the repository root, run:
 
 Open `http://localhost:8080/projects/woge`. Stop the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 
-The command needs no Node.js installation. Gradle includes the maintained, unbundled Woge browser
-module in this development example. A normal published application will consume a versioned browser
-package through its own asset pipeline once that distribution contract ships.
+The command needs no Node.js installation. The example consumes the versioned
+`dev.woge:woge-fallback-client-assets` JVM artifact, whose ES modules Spring Boot serves from
+`/assets/woge/`. Applications with a frontend build can instead install `@woge/fallback-client` from
+npm. Both paths contain the same runtime and protocol version; see the
+[installation guide](fallback-client-installation.md).
 
 ## Read the page as normal web traffic
 

--- a/docs/reviews/first-web-developer-quickstart.md
+++ b/docs/reviews/first-web-developer-quickstart.md
@@ -15,7 +15,7 @@ Each confusing point below has either been fixed in #73 or assigned to a concret
 | `suspend`, receiver lambdas, named arguments and `?: return` interrupted the web task | Added the task-scoped [Kotlin bridge](../guides/kotlin-for-web-developers.md) and avoided a general language detour |
 | `PageUseCase` and `DeferredRegionsUseCase` sounded framework-internal | The guide defines them once as the host-neutral application port and shows Spring routes separately |
 | Page epoch, region ID and patch URL reconstruction is visible but repetitive | Keep it explicit in the first slice; generated host-neutral descriptors remain owned by [#27](https://github.com/christian-draeger/woge/issues/27) |
-| Copying browser source into example resources is not a normal consumer installation story | The guide labels it development-only; versioned browser-package consumption is tracked by [#132](https://github.com/christian-draeger/woge/issues/132) |
+| Browser source needs a normal consumer installation story | Resolved by the versioned npm package and Node-free JVM asset defined in [ADR 0036](../adr/0036-dual-fallback-client-distribution.md) |
 | A loading shell could be mistaken for the no-JavaScript end state | Added a visible GET form and `noscript` link to the complete server-rendered response, plus an explicit disable-JavaScript walkthrough |
 
 The first independent reviewer should run only the public quickstart and record time-to-page, terms

--- a/examples/reference-application/README.md
+++ b/examples/reference-application/README.md
@@ -44,6 +44,8 @@ depend on Spring.
 [`spring-webflux`](spring-webflux), [`spring-mvc`](spring-mvc) and [`ktor`](ktor) contain only their
 host-specific startup, routes and real-server integration tests. The example consumes root projects
 and is verified by `./gradlew check`; it is executable documentation, not a published Woge artifact.
+Its runtime classpath includes the public `woge-fallback-client-assets` integration instead of copying
+browser-runtime source into the example build.
 
 The same Playwright source verifies enhanced and no-JavaScript journeys on all three hosts in
 Chromium, Firefox and WebKit:

--- a/examples/reference-application/shared/build.gradle.kts
+++ b/examples/reference-application/shared/build.gradle.kts
@@ -1,20 +1,12 @@
-import org.gradle.language.jvm.tasks.ProcessResources
-
 plugins {
     id("dev.woge.kotlin-jvm-library")
-}
-
-tasks.named<ProcessResources>("processResources") {
-    from(rootProject.layout.projectDirectory.dir("client/woge-fallback-client/src")) {
-        include("*.js")
-        into("static/assets/woge")
-    }
 }
 
 description = "Host-neutral project page used by the executable Woge reference application."
 
 dependencies {
     api(project(":woge-host-spi"))
+    runtimeOnly(project(":woge-fallback-client-assets"))
 
     testImplementation(libs.junitJupiter)
     testRuntimeOnly(libs.junitPlatformLauncher)

--- a/examples/reference-application/shared/src/main/resources/static/assets/application.js
+++ b/examples/reference-application/shared/src/main/resources/static/assets/application.js
@@ -1,4 +1,4 @@
-import { createWogePatchRuntime } from "./woge/index.js";
+import { createWogePatchRuntime, WOGE_PATCH_PROTOCOL_VERSION } from "./woge/index.js";
 
 const page = document.querySelector("[data-woge-patch-url]");
 
@@ -9,7 +9,7 @@ if (page) {
 async function loadDeferredRegions(url) {
   try {
     const response = await fetch(url, {
-      headers: { Accept: "application/vnd.woge.patch-stream; version=1" },
+      headers: { Accept: `application/vnd.woge.patch-stream; version=${WOGE_PATCH_PROTOCOL_VERSION}` },
     });
     if (!response.ok || !response.body) {
       throw new Error(`Deferred request failed with HTTP ${response.status}`);

--- a/integrations/woge-fallback-client-assets/build.gradle.kts
+++ b/integrations/woge-fallback-client-assets/build.gradle.kts
@@ -1,0 +1,104 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.language.jvm.tasks.ProcessResources
+
+abstract class VerifyPatchProtocolAlignment : DefaultTask() {
+    @get:InputFile
+    abstract val packageMetadata: RegularFileProperty
+
+    @get:InputFile
+    abstract val browserVersionSource: RegularFileProperty
+
+    @get:InputFile
+    abstract val kotlinPatchSource: RegularFileProperty
+
+    @get:InputFile
+    abstract val kotlinPatchStreamSource: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val packageVersion =
+            requireVersion(packageMetadata, "\\\"patchProtocolVersion\\\"\\s*:\\s*(\\d+)", "package metadata")
+        val browserVersion =
+            requireVersion(browserVersionSource, "WOGE_PATCH_PROTOCOL_VERSION\\s*=\\s*(\\d+)", "browser module")
+        val irVersion =
+            requireVersion(
+                kotlinPatchSource,
+                "CURRENT: PatchProtocolVersion = PatchProtocolVersion\\((\\d+)\\)",
+                "Patch IR",
+            )
+        val streamVersion =
+            requireVersion(kotlinPatchStreamSource, "const val VERSION: Int = (\\d+)", "patch stream")
+
+        check(setOf(packageVersion, browserVersion, irVersion, streamVersion).size == 1) {
+            "Woge patch protocol versions differ: package=$packageVersion, browser=$browserVersion, " +
+                "IR=$irVersion, stream=$streamVersion"
+        }
+    }
+
+    private fun requireVersion(
+        source: RegularFileProperty,
+        pattern: String,
+        label: String,
+    ): Int =
+        requireNotNull(
+            Regex(pattern)
+                .find(source.get().asFile.readText())
+                ?.groupValues
+                ?.get(1)
+                ?.toIntOrNull(),
+        ) {
+            "Could not read patch protocol version from $label"
+        }
+}
+
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Framework-neutral classpath assets for the Woge fallback browser client."
+
+val clientDirectory = rootProject.layout.projectDirectory.dir("client/woge-fallback-client")
+val browserSources = clientDirectory.dir("src")
+val packageMetadataFile = clientDirectory.file("package.json")
+val projectLicense = rootProject.layout.projectDirectory.file("LICENSE")
+val kotlinPatch =
+    rootProject.layout.projectDirectory.file(
+        "modules/woge-protocol/src/main/kotlin/dev/woge/protocol/Patch.kt",
+    )
+val kotlinPatchStream =
+    rootProject.layout.projectDirectory.file(
+        "modules/woge-protocol/src/main/kotlin/dev/woge/protocol/PatchStreamValues.kt",
+    )
+
+tasks.named<ProcessResources>("processResources") {
+    from(browserSources) {
+        include("*.js")
+        into("static/assets/woge")
+    }
+    from(browserSources.file("index.d.ts")) {
+        into("META-INF/woge/fallback-client")
+    }
+    from(packageMetadataFile) {
+        into("META-INF/woge/fallback-client")
+    }
+    from(projectLicense) {
+        into("META-INF")
+    }
+}
+
+val verifyPatchProtocolAlignment =
+    tasks.register<VerifyPatchProtocolAlignment>("verifyPatchProtocolAlignment") {
+        group = "verification"
+        description = "Checks browser-package, JVM IR and patch-stream protocol versions agree."
+        packageMetadata.set(packageMetadataFile)
+        browserVersionSource.set(browserSources.file("version.js"))
+        kotlinPatchSource.set(kotlinPatch)
+        kotlinPatchStreamSource.set(kotlinPatchStream)
+    }
+
+tasks.named("check") {
+    dependsOn(verifyPatchProtocolAlignment)
+}

--- a/modules/woge-protocol/api/woge-protocol.api
+++ b/modules/woge-protocol/api/woge-protocol.api
@@ -188,6 +188,7 @@ public final class dev/woge/protocol/PatchStreamV1 {
 	public static final field MAX_METADATA_BYTES I
 	public static final field MAX_PAYLOAD_BYTES I
 	public static final field MEDIA_TYPE Ljava/lang/String;
+	public static final field VERSION I
 	public final fun decoder ()Ldev/woge/protocol/PatchStreamDecoder;
 	public final fun encode (Ljava/lang/Iterable;)[B
 	public final fun encoder (Ldev/woge/protocol/ByteSink;)Ldev/woge/protocol/PatchStreamEncoder;

--- a/modules/woge-protocol/src/main/kotlin/dev/woge/protocol/PatchStreamValues.kt
+++ b/modules/woge-protocol/src/main/kotlin/dev/woge/protocol/PatchStreamValues.kt
@@ -102,6 +102,7 @@ public interface PatchStreamDecoder {
 
 /** Public constants and factories for Woge's version-1 fallback patch stream. */
 public object PatchStreamV1 {
+    public const val VERSION: Int = 1
     public const val MEDIA_TYPE: String = "application/vnd.woge.patch-stream; version=1"
     public const val MAX_METADATA_BYTES: Int = 64 * 1024
     public const val MAX_PAYLOAD_BYTES: Int = 8 * 1024 * 1024


### PR DESCRIPTION
Closes #132

## Outcome
- publish-ready `@woge/fallback-client` ESM package with types, source map, deterministic manifest, hashes, SRI and no runtime dependencies
- framework-neutral `woge-fallback-client-assets` JVM artifact for Node-free Spring Boot and Ktor consumers
- one explicit patch-protocol version checked across JavaScript, package metadata and Kotlin
- fresh packed external consumer build exercised in Chromium, Firefox and WebKit
- ADR 0036 plus bundler, static, caching, source-map, CSP and SRI guidance

## Verification
- `npm run check` (39 browser tests)
- `./gradlew check` (208 tasks)
- `./gradlew referenceBrowserSmoke` (18 host/browser/mode journeys)