### PR TITLE
Add compile-verified M1 API corpus

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ The documentation grows with executable product slices. Pages describing unimple
 - [Documentation style guide](documentation/style-guide.md)
 - [AI-assisted developer-experience criteria](ai-dx/evaluation.md)
 - [AI-DX evaluation corpus](ai-dx/corpus-v0.1.md)
+- [M1 compiler corpus and diagnostics](ai-dx/m1-compiler-corpus.md)
+- [Machine-readable Woge framework index](ai-dx/woge-framework-index.json)
 - [Build and test Woge](development/build-and-test.md)
 - [Install and deploy the fallback browser client](guides/fallback-client-installation.md)
 - [Repository scaffold provenance](development/scaffold-provenance.md)

--- a/docs/adr/0037-compile-verified-m1-corpus.md
+++ b/docs/adr/0037-compile-verified-m1-corpus.md
@@ -1,0 +1,77 @@
+# ADR 0037: Verify the public M1 surface with compiler fixtures and a framework index
+
+- Status: Accepted
+- Date: 2026-09-06
+- Decision owners: @christian-draeger
+- Related issues: [#74](https://github.com/christian-draeger/woge/issues/74)
+
+## Context
+
+The reference application proves complete runtime behavior, but it is intentionally larger than the
+small examples a developer or coding model needs while discovering one API. Prose-only snippets can
+omit imports, dependency context or stale failure behavior. Ordinary Kotlin type errors are useful,
+but their internal names and the library-owned safety guidance were not yet executable evidence.
+
+Tools also need one version-matched place to discover Woge modules, implemented concepts, examples
+and compatibility facts without guessing from filenames or scraping terminal output. That index must
+not pretend that planned M2 generated descriptors already exist.
+
+## Decision
+
+Woge maintains `woge-m1-api-corpus` as a normal root-build consumer. Its compact production sources
+compile complete examples for HTML/CSS values, buffered and streaming sinks, page/deferred-region
+ports, Patch IR/codec and the Spring WebFlux, Spring MVC and Ktor adapters. Documentation links to
+those sources rather than copying a second code body.
+
+Committed negative Kotlin fixtures run through the exact compiler version in the Woge version
+catalog with internal diagnostic names enabled. Tests require compilation failure, source location,
+the expected diagnostic kind and expected/received concept names. Fixtures have stable Woge corpus
+IDs. Where Woge owns the diagnostic, such as unsafe HTML opt-in, its message also carries a stable
+searchable ID. Kotlin-owned type mismatch text remains Kotlin's responsibility.
+
+`docs/ai-dx/woge-framework-index.json` is a schema-versioned public discovery index. A deterministic
+test compares it with Gradle, npm and protocol versions, the enforced module manifest and real source
+paths. Public module entries name Maven coordinates; internal/support entries do not claim published
+artifacts. Planned KSP diagnostics remain linked to issues #26, #27 and #28.
+
+The existing Webref element generator continues to prove deterministic output from its pinned input
+by generating twice. Clean CI rebuilds it, while incremental local builds use Gradle's declared
+inputs and cache. The corpus consumes that generated public surface in the same root gate.
+
+## Alternatives considered
+
+- **Keep examples only inside unit tests:** executable, but imports and assertions obscure the
+  smallest application-facing shape and adapters remain spread across modules.
+- **Assert diagnostic prose from documentation:** easy to write, but does not prove that invalid code
+  actually fails with the selected Kotlin compiler.
+- **Create a compiler plugin for custom errors:** can control every message, but is disproportionate
+  before KSP-generated M2 descriptors exist and would add compiler coupling to ordinary M1 APIs.
+- **Generate the index by reflection:** misses compile-time concepts and examples, requires built
+  artifacts and cannot represent planned ownership clearly.
+- **Add placeholder route/action descriptors for the AI corpus:** would produce implementation debt
+  and misleading guidance before their owning issues settle the real API.
+
+## Consequences
+
+### Positive
+
+- Every M1 public concept has short compile-verified discovery evidence with complete build context.
+- Regressions in type boundaries, safety opt-ins, versions and links fail deterministic CI.
+- Humans and tools share one index and one public API rather than agent-specific wrappers.
+- Host-framework leakage is demonstrated by an intentionally restricted portable classpath.
+
+### Negative
+
+- The test suite embeds the pinned Kotlin compiler and therefore adds dependency/download weight.
+- Kotlin diagnostic names may change on a compiler upgrade; the corpus must review that change rather
+  than silently accepting it.
+- The JSON index is committed metadata and requires a matching update when modules or versions move.
+- M1 can execute only the AI-DX tasks backed by implemented APIs; interaction tasks remain pending.
+
+## Follow-up
+
+- Add KSP-owned route, component, region and action diagnostics in issues #26, #27 and #28.
+- Reuse the framework index when generating the application-local guidance in
+  [#149](https://github.com/christian-draeger/woge/issues/149).
+- Run the first scored clean-consumer AI-DX evaluation in
+  [#93](https://github.com/christian-draeger/woge/issues/93).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,6 +63,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0034](0034-generate-html-element-wrappers-from-webref.md) | Accepted | Generate HTML element wrappers from pinned Webref data |
 | [0035](0035-framework-neutral-semantic-observation-port.md) | Accepted | Use a framework-neutral semantic observation port |
 | [0036](0036-dual-fallback-client-distribution.md) | Accepted | Distribute one fallback client through npm and a JVM asset adapter |
+| [0037](0037-compile-verified-m1-corpus.md) | Accepted | Verify the public M1 surface with compiler fixtures and a framework index |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/ai-dx/corpus-v0.1.md
+++ b/docs/ai-dx/corpus-v0.1.md
@@ -11,6 +11,11 @@ and the [Spring Boot quickstart](../guides/quickstart-spring-boot.md). The same 
 all three launchers and exercised by JVM and cross-host browser tests. Evaluation tasks extend those
 files; they do not reconstruct an uncompiled copy from the prose examples.
 
+The compact [M1 compiler corpus](m1-compiler-corpus.md) supplies complete import/build context,
+negative compiler fixtures and the version-matched machine-readable framework index. M1 runs ADX-01,
+ADX-04 and the plain-CSS part of ADX-08 now; generated route/action tasks retain their existing M2
+owners rather than being simulated by placeholder APIs.
+
 ## ADX-01 — First page
 
 Build a page at `/projects/{project}` with a document title, skip link, navigation landmark, one `h1` and the selected project's name. Link to it from the application home page using an ordinary URL.

--- a/docs/ai-dx/evaluation.md
+++ b/docs/ai-dx/evaluation.md
@@ -31,6 +31,8 @@ The versioned [v0.1 corpus](corpus-v0.1.md) asks a participant to:
 8. style a responsive screen with ordinary CSS and with the optional Tailwind path.
 
 Each task starts from the same published consumer scaffold and public documentation. Hidden repository context or maintainer-only prompts are not allowed.
+The [M1 compiler corpus](m1-compiler-corpus.md) provides the compile-verified examples, negative
+fixtures and machine-readable framework index available before generated M2 interactions land.
 
 ## Measurements
 

--- a/docs/ai-dx/m1-compiler-corpus.md
+++ b/docs/ai-dx/m1-compiler-corpus.md
@@ -1,0 +1,48 @@
+# M1 compiler corpus and diagnostics
+
+The [M1 API corpus](../../examples/m1-api-corpus/README.md) is a compact Gradle consumer compiled by
+the normal root build. It complements the full reference application: the reference proves runtime
+behavior, while the corpus makes imports, dependencies and compiler failure modes quick to inspect.
+
+## Find a complete positive example
+
+Use the machine-readable [Woge framework index](woge-framework-index.json) to locate the current
+module, public concept, guide and canonical source. Its tests compare versions with Gradle, npm and
+the patch codec; compare its module list with the enforced module manifest; and reject stale paths.
+
+The three corpus sources cover the complete implemented M1 surface:
+
+- [HTML, CSS and sinks](../../examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HtmlCssAndSinks.kt)
+- [Page, deferred regions and patch protocol](../../examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/ProtocolAndPage.kt)
+- [Spring WebFlux, Spring MVC and Ktor adapters](../../examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt)
+
+These links are the source. Documentation does not keep a second almost-identical code copy.
+
+## Repair an invalid shape
+
+The negative fixtures compile with Kotlin's internal diagnostic names enabled. The harness requires
+the source filename, expected and received concepts, and searchable diagnostic identifier.
+
+| Fixture | Meaning | Minimal valid direction |
+| --- | --- | --- |
+| `WOGE-COMPILE-HTML-001` | A `String` cannot become raw HTML | Keep data in `text(...)`; only audited sanitizer output uses `raw(unsafeHtml(...))` |
+| `WOGE-COMPILE-HTML-002` | A URL attribute does not accept a plain `String` | Use `applicationUrl(...)` or `externalUrl(...)` and pass that value to `url(...)` |
+| `WOGE-COMPILE-HTML-003` | An unsafe conversion lacks an audit marker | Add `@OptIn(UnsafeWogeHtmlApi::class)` at the narrow reviewed boundary, never merely to silence a failure |
+| `WOGE-COMPILE-PROTOCOL-001` | Page epoch and region ID were swapped | Construct `PatchTarget(PageEpoch, RegionTargetId)` with the two distinct types |
+| `WOGE-COMPILE-PORT-001` | Portable code imports a server framework | Move request decoding to the Spring/Ktor adapter and pass an application input to `PageUseCase` |
+
+Kotlin owns ordinary type-mismatch IDs such as `ARGUMENT_TYPE_MISMATCH`. Woge owns the stable
+`WOGE-HTML-UNSAFE-001` opt-in message because that safety boundary belongs to the library. Future KSP
+route, component, region and action diagnostics remain explicitly owned by issues #26, #27 and #28;
+the M1 corpus does not invent placeholder generated APIs.
+
+Run the deterministic compiler evidence with:
+
+```shell
+./gradlew :woge-m1-api-corpus:check
+```
+
+For an AI-DX run, provide the participant this page, the framework index, the public task text in
+[corpus v0.1](corpus-v0.1.md) and a clean consumer checkout. No maintainer prompt, private source
+search or hidden API list is required. M1 currently executes ADX-01, ADX-04 and the plain-CSS part of
+ADX-08; tasks requiring typed generated interactions become executable with their owning M2 issues.

--- a/docs/ai-dx/woge-framework-index.json
+++ b/docs/ai-dx/woge-framework-index.json
@@ -1,0 +1,176 @@
+{
+  "schemaVersion": 1,
+  "frameworkVersion": "0.1.0-SNAPSHOT",
+  "language": {
+    "kotlinVersion": "2.4.10",
+    "buildJdk": 21,
+    "jvmTarget": 17
+  },
+  "protocol": {
+    "patchStreamVersion": 1,
+    "mediaType": "application/vnd.woge.patch-stream; version=1"
+  },
+  "hosts": {
+    "primary": "spring-webflux",
+    "supported": [
+      "spring-webflux",
+      "spring-mvc",
+      "ktor"
+    ],
+    "springBootVersion": "4.1.1",
+    "ktorVersion": "3.5.2"
+  },
+  "browserClient": {
+    "npmPackage": "@woge/fallback-client",
+    "jvmAssetArtifact": "dev.woge:woge-fallback-client-assets",
+    "packageVersion": "0.1.0",
+    "patchProtocolVersion": 1,
+    "runtimeDependencies": []
+  },
+  "modules": [
+    {
+      "name": "woge-core",
+      "role": "foundation",
+      "exposure": "public",
+      "sourcePath": "modules/woge-core",
+      "artifact": "dev.woge:woge-core",
+      "concepts": ["html-dsl", "safe-html-values", "html-sinks", "css-values", "head-assets"],
+      "guide": "docs/guides/html-elements.md",
+      "example": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HtmlCssAndSinks.kt"
+    },
+    {
+      "name": "woge-ui-headless",
+      "role": "ui",
+      "exposure": "public",
+      "sourcePath": "modules/woge-ui-headless",
+      "artifact": "dev.woge:woge-ui-headless",
+      "concepts": [],
+      "guide": "docs/architecture/component-distribution.md",
+      "example": null
+    },
+    {
+      "name": "woge-protocol",
+      "role": "protocol",
+      "exposure": "public",
+      "sourcePath": "modules/woge-protocol",
+      "artifact": "dev.woge:woge-protocol",
+      "concepts": ["patch-ir", "patch-stream-codec", "page-epoch", "target-revision"],
+      "guide": "docs/guides/patch-ir.md",
+      "example": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/ProtocolAndPage.kt"
+    },
+    {
+      "name": "woge-host-spi",
+      "role": "port",
+      "exposure": "public",
+      "sourcePath": "modules/woge-host-spi",
+      "artifact": "dev.woge:woge-host-spi",
+      "concepts": ["page-use-case", "deferred-regions", "request-context", "semantic-observability"],
+      "guide": "docs/guides/server-host-spi.md",
+      "example": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/ProtocolAndPage.kt"
+    },
+    {
+      "name": "woge-server-runtime",
+      "role": "runtime",
+      "exposure": "internal",
+      "sourcePath": "modules/woge-server-runtime",
+      "artifact": null,
+      "concepts": ["shared-server-execution"],
+      "guide": "docs/architecture/module-graph.md",
+      "example": null
+    },
+    {
+      "name": "woge-fallback-client-assets",
+      "role": "integration",
+      "exposure": "public",
+      "sourcePath": "integrations/woge-fallback-client-assets",
+      "artifact": "dev.woge:woge-fallback-client-assets",
+      "concepts": ["node-free-browser-assets"],
+      "guide": "docs/guides/fallback-client-installation.md",
+      "example": "examples/reference-application/shared/build.gradle.kts"
+    },
+    {
+      "name": "woge-adapter-tck",
+      "role": "test-support",
+      "exposure": "support",
+      "sourcePath": "testing/woge-adapter-tck",
+      "artifact": null,
+      "concepts": ["server-adapter-contract"],
+      "guide": "docs/architecture/server-adapter-parity.md",
+      "example": "testing/woge-adapter-tck/src/main/kotlin/dev/woge/tck/ServerAdapterContract.kt"
+    },
+    {
+      "name": "woge-spring-mvc",
+      "role": "adapter",
+      "exposure": "public",
+      "sourcePath": "adapters/woge-spring-mvc",
+      "artifact": "dev.woge:woge-spring-mvc",
+      "concepts": ["spring-mvc-page-handler", "spring-mvc-deferred-handler"],
+      "guide": "docs/guides/spring-mvc-adapter.md",
+      "example": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt"
+    },
+    {
+      "name": "woge-spring-webflux",
+      "role": "adapter",
+      "exposure": "public",
+      "sourcePath": "adapters/woge-spring-webflux",
+      "artifact": "dev.woge:woge-spring-webflux",
+      "concepts": ["spring-webflux-page-handler", "spring-webflux-deferred-handler"],
+      "guide": "docs/guides/spring-webflux-adapter.md",
+      "example": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt"
+    },
+    {
+      "name": "woge-ktor",
+      "role": "adapter",
+      "exposure": "public",
+      "sourcePath": "adapters/woge-ktor",
+      "artifact": "dev.woge:woge-ktor",
+      "concepts": ["ktor-page-handler", "ktor-deferred-handler"],
+      "guide": "docs/guides/ktor-adapter.md",
+      "example": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt"
+    },
+    {
+      "name": "woge-spring-boot-autoconfigure",
+      "role": "integration",
+      "exposure": "public",
+      "sourcePath": "integrations/woge-spring-boot-autoconfigure",
+      "artifact": "dev.woge:woge-spring-boot-autoconfigure",
+      "concepts": ["spring-boot-auto-configuration", "explicit-adapter-selection"],
+      "guide": "docs/guides/spring-boot-starter.md",
+      "example": "examples/reference-application/spring-webflux/src/main/kotlin/dev/woge/example/WogeQuickstartApplication.kt"
+    },
+    {
+      "name": "woge-spring-boot-starter",
+      "role": "integration",
+      "exposure": "public",
+      "sourcePath": "integrations/woge-spring-boot-starter",
+      "artifact": "dev.woge:woge-spring-boot-starter",
+      "concepts": ["spring-boot-starter"],
+      "guide": "docs/guides/quickstart-spring-boot.md",
+      "example": "examples/reference-application/spring-webflux/build.gradle.kts"
+    }
+  ],
+  "examples": [
+    {
+      "id": "m1-html-css-sinks",
+      "source": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HtmlCssAndSinks.kt",
+      "concepts": ["html-dsl", "css-values", "buffered-html", "streaming-html"]
+    },
+    {
+      "id": "m1-protocol-page-deferred",
+      "source": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/ProtocolAndPage.kt",
+      "concepts": ["page-use-case", "deferred-region", "patch-ir", "patch-stream-codec"]
+    },
+    {
+      "id": "m1-host-adapters",
+      "source": "examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt",
+      "concepts": ["spring-webflux", "spring-mvc", "ktor"]
+    },
+    {
+      "id": "m1-reference-application",
+      "source": "examples/reference-application/shared/src/main/kotlin/dev/woge/example/project/ProjectPage.kt",
+      "concepts": ["executable-consumer", "host-parity", "browser-smoke"]
+    }
+  ],
+  "plannedKspDiagnosticIssues": [26, 27, 28],
+  "browserSupportPolicy": "docs/architecture/browser-support-policy.md"
+}

--- a/docs/development/build-and-test.md
+++ b/docs/development/build-and-test.md
@@ -24,10 +24,16 @@ The gate compiles the convention plugins, verifies explicit API mode, runs tests
 ./gradlew :woge-core:checkKotlinAbi
 ./gradlew :woge-protocol:checkKotlinAbi
 ./gradlew :woge-host-spi:checkKotlinAbi
+./gradlew :woge-m1-api-corpus:check
 ./gradlew :woge-core:jmh
 ```
 
 `ktlintFormat` changes source files; the other commands are checks. Test reports are written below each project's `build/test-results` and `build/reports/tests` directories. Detekt writes machine-readable XML/SARIF and an HTML report below `build/reports/detekt`.
+
+The M1 API corpus compiles complete public examples and then invokes the pinned Kotlin compiler on
+deliberately invalid HTML, URL, unsafe-value, protocol and portable-host fixtures. Its second test
+keeps the machine-readable framework index aligned with module, npm, Kotlin, Spring, Ktor and patch
+protocol metadata.
 
 The JMH command is an explicit performance measurement rather than a pass/fail check. `check` compiles
 the benchmark fixture but does not execute it. HTML sink results are written below

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,6 @@ they are executable. They use supported public APIs and compile in `./gradlew ch
 Do not copy spike packages into examples. The first maintained consumer is the
 [reference application](reference-application/README.md), whose host-neutral page and Spring Boot
 WebFlux, Spring MVC and Ktor launchers are part of the root build.
+
+The compact [M1 API corpus](m1-api-corpus/README.md) compiles complete positive examples for every M1
+boundary and verifies deliberately invalid API shapes against the pinned Kotlin compiler.

--- a/examples/m1-api-corpus/README.md
+++ b/examples/m1-api-corpus/README.md
@@ -1,0 +1,21 @@
+# M1 API corpus
+
+This small module compiles representative uses of every implemented M1 application-facing boundary.
+Each source includes all imports and the build file declares the complete dependency context.
+
+- `HtmlCssAndSinks.kt` covers the familiar HTML DSL, safe values, ordinary CSS strings and buffered
+  or streamed output.
+- `ProtocolAndPage.kt` covers the host-neutral page/deferred-region ports, Patch IR and stream codec.
+- `HostAdapters.kt` binds that unchanged page to Spring WebFlux, Spring MVC and Ktor inputs.
+- `src/test/resources/negative` contains code that must not compile. `CompilerDiagnosticsTest` invokes
+  the pinned Kotlin compiler and verifies source-located diagnostic names plus expected/received
+  concepts.
+
+Run only this corpus from the repository root:
+
+```shell
+./gradlew :woge-m1-api-corpus:check
+```
+
+The corpus is implementation evidence, not another Woge runtime module. The maintained reference
+application remains the executable end-to-end consumer.

--- a/examples/m1-api-corpus/build.gradle.kts
+++ b/examples/m1-api-corpus/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Compact compile-verified examples and negative compiler fixtures for the public M1 API."
+
+dependencies {
+    implementation(project(":woge-core"))
+    implementation(project(":woge-protocol"))
+    implementation(project(":woge-host-spi"))
+    implementation(project(":woge-spring-webflux"))
+    implementation(project(":woge-spring-mvc"))
+    implementation(project(":woge-ktor"))
+
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.kotlinCompilerEmbeddable)
+    testImplementation(libs.kotlinxSerializationJson)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.test {
+    systemProperty("woge.repository.root", rootProject.layout.projectDirectory.asFile.absolutePath)
+}

--- a/examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt
+++ b/examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HostAdapters.kt
@@ -1,0 +1,31 @@
+package dev.woge.examples.m1
+
+import dev.woge.ktor.KtorPageInput
+import dev.woge.ktor.WogeKtorHandlers
+import dev.woge.spring.mvc.SpringMvcPageInput
+import dev.woge.spring.mvc.WogeSpringMvcHandlers
+import dev.woge.spring.mvc.pathVariable
+import dev.woge.spring.webflux.WebFluxPageInput
+import dev.woge.spring.webflux.WogeWebFluxHandlers
+
+internal class HostAdapters(
+    private val page: ProjectPage = ProjectPage(),
+) {
+    fun webFlux() =
+        WogeWebFluxHandlers().let { handlers ->
+            val input = WebFluxPageInput { request -> ProjectInput(request.pathVariable("project")) }
+            handlers.page(page, input) to handlers.deferred(page, input)
+        }
+
+    fun springMvc() =
+        WogeSpringMvcHandlers().let { handlers ->
+            val input = SpringMvcPageInput { request -> ProjectInput(request.pathVariable("project")) }
+            handlers.page(page, input) to handlers.deferred(page, input)
+        }
+
+    fun ktor() =
+        WogeKtorHandlers().let { handlers ->
+            val input = KtorPageInput { call -> ProjectInput(requireNotNull(call.parameters["project"])) }
+            handlers.page(page, input) to handlers.deferred(page, input)
+        }
+}

--- a/examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HtmlCssAndSinks.kt
+++ b/examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/HtmlCssAndSinks.kt
@@ -1,0 +1,49 @@
+package dev.woge.examples.m1
+
+import dev.woge.css.CssStylesheet
+import dev.woge.css.declarations
+import dev.woge.html.HtmlSink
+import dev.woge.html.a
+import dev.woge.html.applicationUrl
+import dev.woge.html.article
+import dev.woge.html.h2
+import dev.woge.html.p
+import dev.woge.html.renderHtml
+import dev.woge.html.streamHtml
+import dev.woge.css.stylesheet as cssStylesheet
+
+internal val projectStyles: CssStylesheet =
+    cssStylesheet(
+        """
+        @layer components {
+          .project-card { container-type: inline-size; color: var(--project-accent); }
+        }
+        """.trimIndent(),
+    )
+
+internal fun renderProjectCard(projectName: String): String =
+    renderHtml {
+        article(
+            attributes = {
+                classes("project-card", "grid", "md:grid-cols-[1fr_auto]")
+                data("project-id", "woge")
+                aria("busy", "false")
+                styles(declarations("--project-accent: oklch(62% 0.2 250);"))
+            },
+        ) {
+            h2 { text(projectName) }
+            p { text("Server-rendered HTML stays useful without JavaScript.") }
+            a(attributes = { url("href", applicationUrl("/projects/woge")) }) {
+                text("Open project")
+            }
+        }
+    }
+
+internal fun streamProjectCard(
+    projectName: String,
+    writeChunk: (String) -> Unit,
+) {
+    streamHtml(HtmlSink(writeChunk), maxChunkChars = 256) {
+        article { h2 { text(projectName) } }
+    }
+}

--- a/examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/ProtocolAndPage.kt
+++ b/examples/m1-api-corpus/src/main/kotlin/dev/woge/examples/m1/ProtocolAndPage.kt
@@ -1,0 +1,78 @@
+package dev.woge.examples.m1
+
+import dev.woge.host.DeferredRegion
+import dev.woge.host.DeferredRegionFailure
+import dev.woge.host.DeferredRegionsUseCase
+import dev.woge.host.PageRequest
+import dev.woge.host.PageResult
+import dev.woge.host.PageUseCase
+import dev.woge.host.deferredRegion
+import dev.woge.host.htmlPage
+import dev.woge.host.regionPlaceholder
+import dev.woge.html.h1
+import dev.woge.html.p
+import dev.woge.protocol.InteractionSequence
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchId
+import dev.woge.protocol.PatchStreamV1
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+import dev.woge.protocol.ReplacePatch
+import dev.woge.protocol.TargetRevision
+import dev.woge.protocol.TargetRevisionStep
+import dev.woge.protocol.patchHtml
+
+internal data class ProjectInput(
+    val slug: String,
+)
+
+internal class ProjectPage :
+    PageUseCase<ProjectInput>,
+    DeferredRegionsUseCase<ProjectInput> {
+    override suspend fun open(request: PageRequest<ProjectInput>): PageResult =
+        htmlPage {
+            h1 { text("Project ${request.input.slug}") }
+            regionPlaceholder(projectSummaryRegion(request.input))
+        }
+
+    override suspend fun regions(request: PageRequest<ProjectInput>): Iterable<DeferredRegion> =
+        listOf(projectSummaryRegion(request.input))
+}
+
+internal fun encodedProjectPatch(input: ProjectInput): ByteArray {
+    val target = projectTarget(input)
+    val patch =
+        ReplacePatch(
+            patchId = PatchId.of("summary-patch"),
+            target = target,
+            interactionSequence = InteractionSequence.INITIAL,
+            revision = TargetRevisionStep.after(TargetRevision.INITIAL),
+            html = patchHtml { p { text("Ready") } },
+        )
+    return PatchStreamV1.encode(listOf(patch))
+}
+
+private fun projectSummaryRegion(input: ProjectInput): DeferredRegion =
+    deferredRegion(
+        target = projectTarget(input),
+        loading = { p { text("Loading project summary…") } },
+        onFailure = { failure ->
+            patchHtml {
+                p {
+                    text(
+                        when (failure) {
+                            DeferredRegionFailure.TIMED_OUT -> "Summary took too long"
+                            DeferredRegionFailure.FAILED -> "Summary could not be loaded"
+                        },
+                    )
+                }
+            }
+        },
+        content = { patchHtml { p { text("Project summary") } } },
+    )
+
+private fun projectTarget(input: ProjectInput): PatchTarget =
+    PatchTarget(
+        pageEpoch = PageEpoch.of("project-${input.slug}"),
+        region = RegionTargetId.of("project-summary"),
+    )

--- a/examples/m1-api-corpus/src/test/kotlin/dev/woge/examples/m1/CompilerDiagnosticsTest.kt
+++ b/examples/m1-api-corpus/src/test/kotlin/dev/woge/examples/m1/CompilerDiagnosticsTest.kt
@@ -1,0 +1,113 @@
+package dev.woge.examples.m1
+
+import dev.woge.host.PageUseCase
+import dev.woge.html.HtmlWriter
+import dev.woge.protocol.PatchTarget
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import java.nio.file.Path
+
+class CompilerDiagnosticsTest {
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @Test
+    fun `invalid public API shapes fail with source-located searchable diagnostics`() {
+        fixtures.forEachIndexed { index, fixture ->
+            val output = ByteArrayOutputStream()
+            val destination = temporaryDirectory.resolve("classes-$index").toFile().apply { mkdirs() }
+            val source = requireNotNull(javaClass.getResource("/negative/${fixture.file}"))
+            val exitCode =
+                PrintStream(output, true, Charsets.UTF_8).use { messages ->
+                    K2JVMCompiler().exec(
+                        messages,
+                        "-no-stdlib",
+                        "-no-reflect",
+                        "-Xrender-internal-diagnostic-names",
+                        "-classpath",
+                        compilationClasspath,
+                        "-d",
+                        destination.absolutePath,
+                        Path.of(source.toURI()).toString(),
+                    )
+                }
+            val diagnostics = output.toString(Charsets.UTF_8)
+
+            assertEquals(ExitCode.COMPILATION_ERROR, exitCode, fixture.id)
+            assertTrue(diagnostics.contains(fixture.file), "$fixture did not report its source file:\n$diagnostics")
+            fixture.expectedFragments.forEach { expected ->
+                assertTrue(diagnostics.contains(expected), "$fixture did not report '$expected':\n$diagnostics")
+            }
+        }
+    }
+
+    private val compilationClasspath: String =
+        listOf(
+            HtmlWriter::class.java,
+            PatchTarget::class.java,
+            PageUseCase::class.java,
+            Unit::class.java,
+            Language::class.java,
+        ).map { marker ->
+            File(
+                marker.protectionDomain.codeSource.location
+                    .toURI(),
+            ).absolutePath
+        }.distinct()
+            .joinToString(File.pathSeparator)
+
+    private data class Fixture(
+        val id: String,
+        val file: String,
+        val expectedFragments: List<String>,
+    )
+
+    private companion object {
+        val fixtures =
+            listOf(
+                Fixture(
+                    id = "WOGE-COMPILE-HTML-001",
+                    file = "html-raw-string.kt",
+                    expectedFragments = listOf("[ARGUMENT_TYPE_MISMATCH]", "String", "UnsafeHtml"),
+                ),
+                Fixture(
+                    id = "WOGE-COMPILE-HTML-002",
+                    file = "html-url-string.kt",
+                    expectedFragments = listOf("[ARGUMENT_TYPE_MISMATCH]", "String", "HtmlUrl"),
+                ),
+                Fixture(
+                    id = "WOGE-COMPILE-HTML-003",
+                    file = "unsafe-opt-in-required.kt",
+                    expectedFragments =
+                        listOf(
+                            "[OPT_IN_USAGE_ERROR]",
+                            "[WOGE-HTML-UNSAFE-001]",
+                            "Add @OptIn(UnsafeWogeHtmlApi::class) only at the reviewed boundary",
+                        ),
+                ),
+                Fixture(
+                    id = "WOGE-COMPILE-PROTOCOL-001",
+                    file = "protocol-target-shape.kt",
+                    expectedFragments =
+                        listOf(
+                            "[ARGUMENT_TYPE_MISMATCH]",
+                            "RegionTargetId",
+                            "PageEpoch",
+                        ),
+                ),
+                Fixture(
+                    id = "WOGE-COMPILE-PORT-001",
+                    file = "portable-framework-leak.kt",
+                    expectedFragments = listOf("[UNRESOLVED_REFERENCE]", "springframework", "ServerRequest"),
+                ),
+            )
+    }
+}

--- a/examples/m1-api-corpus/src/test/kotlin/dev/woge/examples/m1/FrameworkIndexTest.kt
+++ b/examples/m1-api-corpus/src/test/kotlin/dev/woge/examples/m1/FrameworkIndexTest.kt
@@ -1,0 +1,135 @@
+package dev.woge.examples.m1
+
+import dev.woge.protocol.PatchStreamV1
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readLines
+import kotlin.io.path.readText
+
+class FrameworkIndexTest {
+    private val repositoryRoot = Path.of(requireNotNull(System.getProperty("woge.repository.root")))
+    private val index =
+        Json.parseToJsonElement(repositoryRoot.resolve("docs/ai-dx/woge-framework-index.json").readText()).jsonObject
+
+    @Test
+    fun `framework index matches canonical versions and module manifest`() {
+        assertEquals(1, index.requiredInt("schemaVersion"))
+        assertEquals(gradleProperty("wogeVersion"), index.requiredString("frameworkVersion"))
+        assertEquals(catalogVersion("kotlin"), index.requiredObject("language").requiredString("kotlinVersion"))
+        assertEquals(PatchStreamV1.VERSION, index.requiredObject("protocol").requiredInt("patchStreamVersion"))
+        assertEquals(catalogVersion("springBoot"), index.requiredObject("hosts").requiredString("springBootVersion"))
+        assertEquals(catalogVersion("ktor"), index.requiredObject("hosts").requiredString("ktorVersion"))
+
+        val packageMetadata =
+            Json
+                .parseToJsonElement(repositoryRoot.resolve("client/woge-fallback-client/package.json").readText())
+                .jsonObject
+        val browser = index.requiredObject("browserClient")
+        assertEquals(packageMetadata.requiredString("name"), browser.requiredString("npmPackage"))
+        assertEquals(packageMetadata.requiredString("version"), browser.requiredString("packageVersion"))
+        assertEquals(
+            packageMetadata.requiredObject("woge").requiredInt("patchProtocolVersion"),
+            browser.requiredInt("patchProtocolVersion"),
+        )
+
+        val manifestModules = readModuleManifest()
+        val indexedModules =
+            index.requiredArray("modules").associate { module ->
+                module.jsonObject.requiredString("name") to module.jsonObject
+            }
+        assertEquals(manifestModules.keys, indexedModules.keys)
+        manifestModules.forEach { (name, manifest) ->
+            val indexed = requireNotNull(indexedModules[name])
+            assertEquals(manifest.role, indexed.requiredString("role"), name)
+            assertEquals(manifest.exposure, indexed.requiredString("exposure"), name)
+            assertEquals(manifest.path, indexed.requiredString("sourcePath"), name)
+            assertTrue(
+                indexed.requiredArray("concepts").all { concept ->
+                    concept is JsonPrimitive && concept.isString
+                },
+                name,
+            )
+            if (manifest.exposure == "public") {
+                assertEquals("dev.woge:$name", indexed.requiredString("artifact"), name)
+            }
+            indexed.optionalString("guide")?.let(::assertRepositoryPath)
+            indexed.optionalString("example")?.let(::assertRepositoryPath)
+        }
+    }
+
+    @Test
+    fun `framework index points to unique compile-verified examples and explicit future owners`() {
+        val examples = index.requiredArray("examples").map(JsonElement::jsonObject)
+        assertEquals(examples.size, examples.map { it.requiredString("id") }.distinct().size)
+        examples.forEach { example ->
+            assertRepositoryPath(example.requiredString("source"))
+            assertTrue(example.requiredArray("concepts").isNotEmpty(), example.requiredString("id"))
+        }
+        assertEquals(
+            listOf(26, 27, 28),
+            index.requiredArray("plannedKspDiagnosticIssues").map { it.jsonPrimitive.int },
+        )
+        assertRepositoryPath(index.requiredString("browserSupportPolicy"))
+    }
+
+    private fun readModuleManifest(): LinkedHashMap<String, ModuleManifestEntry> =
+        linkedMapOf<String, ModuleManifestEntry>().apply {
+            repositoryRoot
+                .resolve("config/architecture/module-boundaries.tsv")
+                .readLines()
+                .filterNot { it.isBlank() || it.startsWith("#") }
+                .forEach { row ->
+                    val columns = row.split('\t')
+                    put(columns[0], ModuleManifestEntry(columns[1], columns[2], columns[3]))
+                }
+        }
+
+    private fun gradleProperty(name: String): String =
+        repositoryRoot
+            .resolve("gradle.properties")
+            .readLines()
+            .first { it.startsWith("$name=") }
+            .substringAfter('=')
+
+    private fun catalogVersion(name: String): String =
+        requireNotNull(
+            Regex("(?m)^${Regex.escape(name)} = \\\"([^\\\"]+)\\\"")
+                .find(repositoryRoot.resolve("gradle/libs.versions.toml").readText())
+                ?.groupValues
+                ?.get(1),
+        )
+
+    private fun assertRepositoryPath(value: String) {
+        assertTrue(Files.exists(repositoryRoot.resolve(value)), "Framework index path does not exist: $value")
+    }
+
+    private fun JsonObject.requiredObject(name: String): JsonObject = requireNotNull(this[name]).jsonObject
+
+    private fun JsonObject.requiredArray(name: String): JsonArray = requireNotNull(this[name]).jsonArray
+
+    private fun JsonObject.requiredString(name: String): String = requireNotNull(this[name]).jsonPrimitive.content
+
+    private fun JsonObject.requiredInt(name: String): Int = requireNotNull(this[name]).jsonPrimitive.int
+
+    private fun JsonObject.optionalString(name: String): String? =
+        this[name]?.takeUnless { it is JsonNull }?.jsonPrimitive?.content
+
+    private data class ModuleManifestEntry(
+        val role: String,
+        val exposure: String,
+        val path: String,
+    )
+}

--- a/examples/m1-api-corpus/src/test/resources/negative/html-raw-string.kt
+++ b/examples/m1-api-corpus/src/test/resources/negative/html-raw-string.kt
@@ -1,0 +1,6 @@
+package dev.woge.invalid
+
+import dev.woge.html.renderHtml
+
+// WOGE-COMPILE-HTML-001: raw HTML requires the explicit UnsafeHtml boundary.
+internal fun invalidRawHtml(): String = renderHtml { raw("<strong>unsafe</strong>") }

--- a/examples/m1-api-corpus/src/test/resources/negative/html-url-string.kt
+++ b/examples/m1-api-corpus/src/test/resources/negative/html-url-string.kt
@@ -1,0 +1,10 @@
+package dev.woge.invalid
+
+import dev.woge.html.a
+import dev.woge.html.renderHtml
+
+// WOGE-COMPILE-HTML-002: URL attributes require a validated HtmlUrl, not a String.
+internal fun invalidUrl(): String =
+    renderHtml {
+        a(attributes = { url("href", "/projects/woge") }) { text("Open") }
+    }

--- a/examples/m1-api-corpus/src/test/resources/negative/portable-framework-leak.kt
+++ b/examples/m1-api-corpus/src/test/resources/negative/portable-framework-leak.kt
@@ -1,0 +1,6 @@
+package dev.woge.invalid
+
+import org.springframework.web.reactive.function.server.ServerRequest
+
+// WOGE-COMPILE-PORT-001: portable application code has no host-framework classpath.
+internal fun invalidPortableBoundary(request: ServerRequest): String = request.path()

--- a/examples/m1-api-corpus/src/test/resources/negative/protocol-target-shape.kt
+++ b/examples/m1-api-corpus/src/test/resources/negative/protocol-target-shape.kt
@@ -1,0 +1,12 @@
+package dev.woge.invalid
+
+import dev.woge.protocol.PageEpoch
+import dev.woge.protocol.PatchTarget
+import dev.woge.protocol.RegionTargetId
+
+// WOGE-COMPILE-PROTOCOL-001: page epochs and rendered-region IDs are distinct concepts.
+internal val invalidTarget =
+    PatchTarget(
+        pageEpoch = RegionTargetId.of("epoch"),
+        region = PageEpoch.of("region"),
+    )

--- a/examples/m1-api-corpus/src/test/resources/negative/unsafe-opt-in-required.kt
+++ b/examples/m1-api-corpus/src/test/resources/negative/unsafe-opt-in-required.kt
@@ -1,0 +1,6 @@
+package dev.woge.invalid
+
+import dev.woge.html.unsafeHtml
+
+// WOGE-COMPILE-HTML-003: unsafe conversions require an explicit audited opt-in.
+internal val invalidUnsafeConversion = unsafeHtml("<strong>not audited</strong>")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serializati
 ktorServerCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktorServerNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 ktlintGradlePlugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlintGradle" }
 reactorNettyHttp = { module = "io.projectreactor.netty:reactor-netty-http" }
 springBoot = { module = "org.springframework.boot:spring-boot" }

--- a/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlValues.kt
+++ b/modules/woge-core/src/main/kotlin/dev/woge/html/HtmlValues.kt
@@ -13,7 +13,9 @@ public annotation class WogeHtmlDsl
  * context. It does not sanitize or make untrusted input safe.
  */
 @RequiresOptIn(
-    message = "This value bypasses normal Woge HTML safety. Audit its source and browser context.",
+    message =
+        "[WOGE-HTML-UNSAFE-001] This value bypasses normal Woge HTML safety. " +
+            "Audit its source and browser context. Add @OptIn(UnsafeWogeHtmlApi::class) only at the reviewed boundary.",
     level = RequiresOptIn.Level.ERROR,
 )
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)

--- a/scripts/test-module-boundaries.sh
+++ b/scripts/test-module-boundaries.sh
@@ -16,11 +16,17 @@ prepare_fixture() {
   local fixture_root=$1
   mkdir -p "$fixture_root/scripts"
   cp "$repository_root/scripts/validate-module-boundaries.sh" "$fixture_root/scripts/"
-  cp -R "$repository_root/config" "$fixture_root/"
-  cp -R "$repository_root/modules" "$fixture_root/"
-  cp -R "$repository_root/adapters" "$fixture_root/"
-  cp -R "$repository_root/integrations" "$fixture_root/"
-  cp -R "$repository_root/testing" "$fixture_root/"
+  for source_tree in config modules adapters integrations testing; do
+    while IFS= read -r source_file; do
+      relative_path=${source_file#"$repository_root/"}
+      mkdir -p "$fixture_root/$(dirname "$relative_path")"
+      cp "$source_file" "$fixture_root/$relative_path"
+    done < <(
+      find "$repository_root/$source_tree" \
+        \( -type d \( -name build -o -name .gradle \) -prune \) \
+        -o -type f -print
+    )
+  done
 }
 
 expect_rejection() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,3 +41,6 @@ project(":woge-reference-spring-mvc").projectDir = file("examples/reference-appl
 
 include(":woge-reference-ktor")
 project(":woge-reference-ktor").projectDir = file("examples/reference-application/ktor")
+
+include(":woge-m1-api-corpus")
+project(":woge-m1-api-corpus").projectDir = file("examples/m1-api-corpus")


### PR DESCRIPTION
Closes #74

## Outcome
- compile complete M1 examples for HTML/CSS, sinks, host ports, deferred regions, Patch IR/codec and all three server adapters
- run five intentionally invalid Kotlin fixtures through the pinned K2 compiler and assert source-located diagnostic identifiers plus expected/received concepts
- add stable `WOGE-HTML-UNSAFE-001` guidance at the library-owned unsafe opt-in boundary
- validate a machine-readable framework index against module, Gradle, npm, Kotlin, Spring, Ktor, protocol and source metadata
- remove a parallel-build race from module-boundary fixture copying
- record the public DX contract in ADR 0037 and link canonical sources instead of duplicating snippets

## Verification
- `./gradlew :woge-m1-api-corpus:check`
- `./gradlew :woge-core:check`
- `bash scripts/test-module-boundaries.sh`
- `./gradlew check` (221 tasks)