### PR TITLE
Define the build-independent development lifecycle

### DIFF
--- a/config/architecture/module-boundaries.tsv
+++ b/config/architecture/module-boundaries.tsv
@@ -4,6 +4,7 @@ woge-ui-headless	ui	public	modules/woge-ui-headless	woge-core	-
 woge-protocol	protocol	public	modules/woge-protocol	woge-core	-
 woge-host-spi	port	public	modules/woge-host-spi	woge-core,woge-protocol	-
 woge-server-runtime	runtime	internal	modules/woge-server-runtime	woge-core,woge-protocol,woge-host-spi	-
+woge-dev-model	tooling-model	internal	modules/woge-dev-model	-	-
 woge-fallback-client-assets	integration	public	integrations/woge-fallback-client-assets	-	-
 woge-adapter-tck	test-support	support	testing/woge-adapter-tck	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-
 woge-spring-mvc	adapter	public	adapters/woge-spring-mvc	woge-core,woge-protocol,woge-host-spi,woge-server-runtime	-

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The documentation grows with executable product slices. Pages describing unimple
 ## Canonical architecture guidance
 
 - [M1 module and consumer graph](architecture/module-graph.md)
+- [Development lifecycle and reload model](architecture/development-lifecycle.md)
 - [Server-adapter parity matrix](architecture/server-adapter-parity.md)
 - [Spring MVC and WebFlux support model](architecture/spring-support-model.md)
 - [Browser support and progressive enhancement](architecture/browser-support-policy.md)

--- a/docs/adr/0038-build-independent-development-lifecycle.md
+++ b/docs/adr/0038-build-independent-development-lifecycle.md
@@ -1,0 +1,120 @@
+# ADR 0038: Share one build-independent development lifecycle across tool adapters
+
+- Status: Accepted
+- Date: 2026-09-06
+- Decision owners: @christian-draeger
+- Related issues: [#140](https://github.com/christian-draeger/woge/issues/140)
+
+## Context
+
+Woge needs a short edit-to-browser loop for Spring Boot first and Ktor as a peer. Gradle, application
+hosts, optional frontend tooling, browser connections and future MCP or IDE clients each observe a
+part of that loop. If one of those technologies owns the state model, other integrations must parse
+logs, emulate its lifecycle or leak host-specific types through the architecture.
+
+Fast feedback must not trade away correctness. Rapid saves can finish out of order, cancelled builds
+can report late success, and overlapping restarts can announce a server that is already obsolete.
+Compilation failure should leave the last valid application usable and expose structured diagnostics.
+
+The reload vocabulary is also commonly ambiguous. “Hot reload” may mean browser refresh, server
+restart, frontend module replacement or JVM class redefinition, although those operations have very
+different correctness and state-preservation properties.
+
+## Decision
+
+Woge owns an internal, experimental `woge-dev-model` module with no host, build-tool or transport
+dependencies. It defines:
+
+- **Live Reload** as rebuild followed by a complete document refresh.
+- **Hot Restart** as replacement of the server application generation plus browser synchronization,
+  without JVM class redefinition.
+- **HMR / Hot Update** as replacement of a proven-safe asset or frontend module without a document
+  refresh.
+- **True JVM Hot Reload** as class redefinition in a live JVM. This is outside the first release.
+
+`BuildId` and `ServerGeneration` are positive monotonic values scoped to one development session.
+The pure reducer accepts typed events for build start, success, failure and cancellation; server
+restart and readiness; CSS and frontend changes; and required/applied reloads. It returns `APPLIED`,
+`IGNORED_STALE` or `REJECTED` without mutating its input state.
+
+A newer `BuildStarted` supersedes an active older build and coalesces its known changes. Terminal
+events for lower build IDs are stale. A terminal event for the current but inactive build is rejected,
+which prevents late cancellation success. Starting a newer build invalidates pending reload/restart
+work from the older build but retains the active valid server. A failed current build retains that
+server generation and its local URLs.
+
+Restart requests coalesce toward the newest requested generation. Readiness below that generation is
+stale; readiness above it is unrequested and rejected. Only exact readiness advances the session.
+
+Reload levels are ordered by increasingly broad correctness:
+
+`HOT_ASSET → HOT_FRONTEND_MODULE → DOCUMENT_REFRESH → SERVER_RESTART → COLD_RESTART`
+
+The selected action may escalate to the right. Moving left requires positive evidence that the
+specific change is eligible. Server completion is represented by `ServerReady`, never by pretending
+that a browser reload completed a restart.
+
+`WogeDevelopmentCapabilities` is the shared structured object-capability for status, bounded
+await-build, diagnostics, reload, restart, application-manifest and development-URL access. Gradle,
+CLI, Spring, Ktor, optional Vite, browser overlay, MCP, tests and future IDE tooling adapt this same
+boundary; none parse terminal output as a protocol. The concrete manifest schema remains owned by
+issue #146 behind a minimal extension interface.
+
+Development URLs are loopback-only and exclude credentials, queries and fragments. Diagnostics carry
+stable codes, already-redacted one-line summaries and optional repository-relative positions; raw
+compiler output, exceptions, source bodies, environment values and absolute paths are excluded.
+Transport adapters bind locally by default and authenticate and authorize access before exposing the
+privileged capability, especially reload and restart commands.
+
+The development model has a dedicated `tooling-model` architecture role. Production roles cannot
+depend on it, it is not published, and production starters verify that no `woge-dev-*` artifact is on
+their runtime classpath. Production artifacts contain no dormant development endpoint or resource.
+
+True JVM class redefinition, mandatory Node/Vite and a stable public MCP API are non-goals for the
+first release.
+
+## Alternatives considered
+
+- **Make Gradle continuous build the lifecycle model:** useful as one trigger, but Gradle task output
+  and daemon behavior are not a stable capability protocol and cannot represent browser/server state.
+- **Use Spring Boot DevTools types as the core:** gives Spring a convenient restart mechanism but
+  prevents Ktor parity and leaks one host into every consumer.
+- **Start with a Vite-owned HMR graph:** mature for frontend modules, but would make Node mandatory and
+  cannot decide Kotlin server restart correctness.
+- **Parse terminal text in each client:** quick for a demo, but loses stable diagnostics, ordering,
+  authorization boundaries and reliable machine consumption.
+- **Implement JVM class redefinition first:** can preserve more state for eligible bytecode changes,
+  but has class-shape and tooling constraints. Server/document fallback is simpler and dependable.
+- **Run exploratory spikes for the event model:** the ordering rules are deterministic and directly
+  testable. Spikes are reserved for later process ownership, proxy and restart behavior that depends
+  on external systems.
+
+## Consequences
+
+### Positive
+
+- Every tool observes one deterministic state and stale-event policy.
+- Spring Boot remains first-class without becoming the portable abstraction.
+- Failed builds preserve a usable last-known-good application with structured diagnostics.
+- Hot update is an optional optimization over an explicit correctness fallback.
+- Tooling is machine-readable and suitable for humans, IDEs and coding agents without special APIs.
+- Architecture and starter checks make production isolation executable.
+
+### Negative
+
+- Adapters must translate their native events and enforce transport authorization.
+- Monotonic identifiers and exact generation matching add orchestration bookkeeping.
+- The first release may refresh or restart more often than specialized hot-reload systems.
+- The internal API remains experimental until several adapters validate its shape.
+
+## Follow-up
+
+- Validate process ownership, ports and proxy necessity in
+  [#141](https://github.com/christian-draeger/woge/issues/141).
+- Build the shared orchestrator over this reducer and capability boundary in
+  [#147](https://github.com/christian-draeger/woge/issues/147).
+- Add Spring Boot restart and browser-channel adapters in
+  [#144](https://github.com/christian-draeger/woge/issues/144) and
+  [#145](https://github.com/christian-draeger/woge/issues/145).
+- Define the concrete non-secret manifest in
+  [#146](https://github.com/christian-draeger/woge/issues/146).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,6 +64,7 @@ The check validates filenames, required sections, metadata, duplicate numbers, i
 | [0035](0035-framework-neutral-semantic-observation-port.md) | Accepted | Use a framework-neutral semantic observation port |
 | [0036](0036-dual-fallback-client-distribution.md) | Accepted | Distribute one fallback client through npm and a JVM asset adapter |
 | [0037](0037-compile-verified-m1-corpus.md) | Accepted | Verify the public M1 surface with compiler fixtures and a framework index |
+| [0038](0038-build-independent-development-lifecycle.md) | Accepted | Share one build-independent development lifecycle across tool adapters |
 
 ADRs 0001–0018 are the complete M0 decision set. ADRs beginning with 0019 record implementation-era
 decisions and supersessions. The [MVP boundary](../mvp-boundary.md) is the canonical short synthesis;

--- a/docs/ai-dx/woge-framework-index.json
+++ b/docs/ai-dx/woge-framework-index.json
@@ -79,6 +79,16 @@
       "example": null
     },
     {
+      "name": "woge-dev-model",
+      "role": "tooling-model",
+      "exposure": "internal",
+      "sourcePath": "modules/woge-dev-model",
+      "artifact": null,
+      "concepts": ["development-lifecycle", "development-capabilities", "reload-correctness"],
+      "guide": "docs/architecture/development-lifecycle.md",
+      "example": null
+    },
+    {
       "name": "woge-fallback-client-assets",
       "role": "integration",
       "exposure": "public",

--- a/docs/architecture/development-lifecycle.md
+++ b/docs/architecture/development-lifecycle.md
@@ -1,0 +1,74 @@
+# Development lifecycle and reload model
+
+Woge treats the development loop as a small state machine, not as text printed by Gradle or a server.
+That gives a browser, command-line tool, Gradle task and future IDE integration the same answer to
+questions such as “is the current build valid?” and “does this edit need a refresh or a restart?”.
+
+The implemented model lives in the internal `woge-dev-model` module. It contains no Spring, Ktor,
+Gradle, Vite, browser or MCP types. Those systems will be adapters around the model.
+
+## What happens after an edit
+
+1. A watcher reports `BuildStarted` with a new monotonic `BuildId` and semantic changes.
+2. A newer save supersedes the in-flight build. Its changes are coalesced into the newest build.
+3. `BuildSucceeded` selects the cheapest reload level that has been proven correct, or
+   `BuildFailed` publishes structured diagnostics.
+4. Browser-facing updates end with `ReloadApplied`; server-facing updates use
+   `ServerRestarting` and `ServerReady` with a new monotonic `ServerGeneration`.
+5. Events for an older build or server generation cannot mutate current state.
+
+A compile failure does not tear down the last valid application. The failed build and its diagnostics
+become visible while the previous ready server generation and URL remain available. A late success
+from a cancelled or superseded build is rejected.
+
+## Reload levels
+
+The order is a correctness fallback chain:
+
+1. `HOT_ASSET` updates an independently safe asset such as CSS.
+2. `HOT_FRONTEND_MODULE` replaces an eligible frontend module while retaining page state.
+3. `DOCUMENT_REFRESH` asks the browser for a new document.
+4. `SERVER_RESTART` starts a new application generation in the existing development host.
+5. `COLD_RESTART` recreates the complete development process boundary.
+
+Tooling may move to the right whenever a cheaper action is unsupported or uncertain. It may move to
+the left only with evidence that the edit is safe at that level. This makes reload an optimization;
+correct behavior never depends on hot updating successfully.
+
+The terms used by Woge are deliberately precise:
+
+- **Live Reload** rebuilds and then refreshes the document. Browser state may be lost.
+- **Hot Restart** replaces the running server application generation and synchronizes the browser;
+  it does not redefine loaded JVM classes.
+- **HMR / Hot Update** replaces a proven-safe asset or frontend module without a full document load.
+- **True JVM Hot Reload** redefines classes in a live JVM. It is not part of the first Woge release.
+
+## One capability boundary
+
+`WogeDevelopmentCapabilities` exposes structured operations for status, bounded await-build,
+diagnostics, reload, restart, the application manifest and local development URLs. CLI output and a
+browser overlay render this model; they do not scrape each other. Gradle, Spring Boot, Ktor, optional
+Vite, MCP, tests and future IDE support remain replaceable adapters.
+
+The application manifest has only a minimal interface here. Its concrete, versioned and non-secret
+schema belongs to [issue #146](https://github.com/christian-draeger/woge/issues/146).
+
+## Security and production isolation
+
+- Development URLs accept loopback HTTP(S) hosts only and cannot contain credentials, query values or
+  fragments.
+- Diagnostics contain stable codes, redacted one-line summaries and optional repository-relative
+  positions. Raw terminal output, exceptions, environment values and absolute workstation paths are
+  not model fields.
+- A capability implementation is privileged. Any network adapter must bind locally by default and
+  authenticate and authorize callers before exposing reads or invoking reload/restart commands.
+- `woge-dev-model` is internal and unpublished. The module graph rejects dependencies from production
+  roles, and the Spring Boot starter verifies that no `woge-dev-*` artifact reaches its runtime classpath.
+- Production packaging must contain no development endpoint, watcher, token, manifest endpoint or
+  tooling resource. A disabled runtime switch is not sufficient isolation.
+
+Node/Vite is optional, not a requirement for Kotlin-and-CSS applications. A stable public MCP API is
+also deferred until the underlying capabilities have real adapter experience.
+
+The durable decision and rejected alternatives are recorded in
+[ADR 0038](../adr/0038-build-independent-development-lifecycle.md).

--- a/docs/architecture/module-graph.md
+++ b/docs/architecture/module-graph.md
@@ -15,6 +15,7 @@ flowchart BT
     Runtime[woge-server-runtime<br/>internal] --> Core
     Runtime --> Protocol
     Runtime --> SPI
+    DevModel[woge-dev-model<br/>internal tooling model]
     TCK[woge-adapter-tck<br/>test support] --> Core
     TCK --> Protocol
     TCK --> SPI
@@ -49,6 +50,7 @@ the Spring adapters cannot depend on each other, and Ktor never wraps Spring con
 | Patch and streaming values | `woge-protocol` | Hosts share one versioned wire vocabulary |
 | Page/action/live use cases | `woge-host-spi` | Application code sees Woge-owned ports, not server requests |
 | Shared execution machinery | `woge-server-runtime` | Adapters reuse implementation without making it public API |
+| Development lifecycle semantics | `woge-dev-model` | Tool adapters share ordering and fallback rules without entering production artifacts |
 | Adapter parity fixtures | `woge-adapter-tck` | Every host proves the same observable contract |
 | Spring Boot setup | auto-configuration and starter | Spring is first-class without becoming the core abstraction |
 | Browser patch application | npm `@woge/fallback-client` | It is a small web artifact, not a JVM or component runtime |
@@ -70,7 +72,7 @@ pipelines, while the JVM artifact supplies canonical unbundled modules as classp
 
 The boundary validator fails on missing modules, unknown or cyclic edges, Gradle/manifest drift,
 forbidden host references in portable production source and MVC/WebFlux cross-dependencies. Negative
-fixtures prove that those failures remain active. Run both layers directly with
+fixtures also prove that production modules cannot depend on the isolated development model. Run both layers directly with
 `./gradlew validateModuleBoundaries testModuleBoundaries` or as part of `./gradlew check`.
 
 The executable contract and current host coverage live in the

--- a/integrations/woge-spring-boot-starter/build.gradle.kts
+++ b/integrations/woge-spring-boot-starter/build.gradle.kts
@@ -42,3 +42,23 @@ val verifyNoBundledWebStacks =
 tasks.named("check") {
     dependsOn(verifyNoBundledWebStacks)
 }
+
+val verifyNoDevelopmentTooling =
+    tasks.register("verifyNoDevelopmentTooling") {
+        group = "verification"
+        description = "Verifies that production starter dependencies contain no Woge development tooling."
+
+        val runtimeClasspath = configurations.named("runtimeClasspath")
+        inputs.files(runtimeClasspath)
+
+        doLast {
+            val bundledModules = inputs.files.files.map { it.name.removeSuffix(".jar") }
+            check(bundledModules.none { it.startsWith("woge-dev-") }) {
+                "The production starter bundled Woge development tooling"
+            }
+        }
+    }
+
+tasks.named("check") {
+    dependsOn(verifyNoDevelopmentTooling)
+}

--- a/modules/woge-dev-model/build.gradle.kts
+++ b/modules/woge-dev-model/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("dev.woge.kotlin-jvm-library")
+}
+
+description = "Internal transport- and build-tool-independent development lifecycle model."
+
+dependencies {
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentCapabilities.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentCapabilities.kt
@@ -1,0 +1,106 @@
+package dev.woge.development
+
+import kotlin.time.Duration
+
+/** Cursor and bounded wait requested by a development-tool client. */
+@ExperimentalWogeDevelopmentApi
+public data class AwaitBuildRequest(
+    public val afterBuild: BuildId?,
+    public val timeout: Duration,
+) {
+    init {
+        require(timeout.isFinite() && timeout.isPositive()) { "Await-build timeout must be finite and positive" }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public sealed interface AwaitBuildResult {
+    public data class Observed(
+        public val outcome: DevelopmentBuildTerminalEvent,
+    ) : AwaitBuildResult
+
+    public data class TimedOut(
+        public val latestRequestedBuild: BuildId?,
+    ) : AwaitBuildResult
+
+    public data object SessionStopped : AwaitBuildResult
+}
+
+/**
+ * Minimal contract implemented by the application manifest owned by its generator.
+ *
+ * The concrete schema is intentionally not part of the lifecycle model.
+ */
+@ExperimentalWogeDevelopmentApi
+public interface DevelopmentApplicationManifest {
+    public val schemaVersion: Int
+    public val buildId: BuildId
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class DevelopmentReloadCommand(
+    public val buildId: BuildId,
+    public val level: ReloadLevel,
+) {
+    init {
+        require(!level.satisfies(ReloadLevel.SERVER_RESTART)) {
+            "Reload commands support hot updates and document refresh; use restart for server levels"
+        }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class DevelopmentRestartCommand(
+    public val buildId: BuildId,
+    public val level: ReloadLevel,
+) {
+    init {
+        require(level.satisfies(ReloadLevel.SERVER_RESTART)) {
+            "Restart commands require SERVER_RESTART or COLD_RESTART"
+        }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public sealed interface DevelopmentCommandResult {
+    public data class Accepted(
+        public val buildId: BuildId,
+        public val selectedLevel: ReloadLevel,
+    ) : DevelopmentCommandResult
+
+    public data class Refused(
+        public val reason: DevelopmentCommandRefusal,
+    ) : DevelopmentCommandResult
+}
+
+@ExperimentalWogeDevelopmentApi
+public enum class DevelopmentCommandRefusal {
+    NOT_AUTHORIZED,
+    STALE_BUILD,
+    UNSUPPORTED,
+    SESSION_STOPPED,
+}
+
+/**
+ * Structured object-capability for Woge development tools.
+ *
+ * Implementations are privileged: transport adapters must authenticate and authorize callers before
+ * exposing this object or invoking its mutating methods. CLI, Gradle, browser, MCP and future IDE
+ * integrations adapt this same contract instead of parsing terminal output.
+ */
+@ExperimentalWogeDevelopmentApi
+public interface WogeDevelopmentCapabilities {
+    public suspend fun status(): DevelopmentSessionState
+
+    public suspend fun awaitBuild(request: AwaitBuildRequest): AwaitBuildResult
+
+    public suspend fun diagnostics(): List<DevelopmentDiagnostic>
+
+    public suspend fun reload(command: DevelopmentReloadCommand): DevelopmentCommandResult
+
+    public suspend fun restart(command: DevelopmentRestartCommand): DevelopmentCommandResult
+
+    public suspend fun applicationManifest(): DevelopmentApplicationManifest?
+
+    public suspend fun developmentUrls(): List<DevelopmentUrl>
+}

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentDiagnostics.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentDiagnostics.kt
@@ -1,0 +1,73 @@
+package dev.woge.development
+
+/** Stable machine-readable category for one development diagnostic. */
+@ExperimentalWogeDevelopmentApi
+@JvmInline
+public value class DevelopmentDiagnosticCode private constructor(
+    public val value: String,
+) {
+    public companion object {
+        public fun of(value: String): DevelopmentDiagnosticCode {
+            require(DIAGNOSTIC_CODE.matches(value)) {
+                "Development diagnostic code must be uppercase ASCII segments separated by '-'"
+            }
+            return DevelopmentDiagnosticCode(value)
+        }
+    }
+}
+
+/** A short already-redacted message intended for a developer or coding tool. */
+@ExperimentalWogeDevelopmentApi
+@JvmInline
+public value class DevelopmentDiagnosticSummary private constructor(
+    public val value: String,
+) {
+    override fun toString(): String = "DevelopmentDiagnosticSummary(<redacted>)"
+
+    public companion object {
+        public fun of(value: String): DevelopmentDiagnosticSummary {
+            require(value.isNotBlank() && value.length <= MAX_DIAGNOSTIC_SUMMARY_LENGTH) {
+                "Development diagnostic summary must contain 1 to $MAX_DIAGNOSTIC_SUMMARY_LENGTH characters"
+            }
+            require(value.none(Char::isISOControl)) {
+                "Development diagnostic summary must be one line without control characters"
+            }
+            return DevelopmentDiagnosticSummary(value)
+        }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public enum class DevelopmentDiagnosticSeverity {
+    INFO,
+    WARNING,
+    ERROR,
+}
+
+/** Optional exact source position. Line and column values are one-based. */
+@ExperimentalWogeDevelopmentApi
+public data class DevelopmentSourceLocation(
+    public val path: DevelopmentSourcePath,
+    public val line: Int,
+    public val column: Int,
+) {
+    init {
+        require(line > 0) { "Diagnostic line must be positive" }
+        require(column > 0) { "Diagnostic column must be positive" }
+    }
+}
+
+/** Structured, display-safe diagnostic. Raw compiler output and exceptions are intentionally absent. */
+@ExperimentalWogeDevelopmentApi
+public data class DevelopmentDiagnostic(
+    public val code: DevelopmentDiagnosticCode,
+    public val severity: DevelopmentDiagnosticSeverity,
+    public val summary: DevelopmentDiagnosticSummary,
+    public val location: DevelopmentSourceLocation? = null,
+) {
+    override fun toString(): String =
+        "DevelopmentDiagnostic(code=${code.value}, severity=$severity, location=$location, summary=<redacted>)"
+}
+
+private val DIAGNOSTIC_CODE: Regex = Regex("^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*$")
+private const val MAX_DIAGNOSTIC_SUMMARY_LENGTH: Int = 1_000

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentEvents.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentEvents.kt
@@ -1,0 +1,143 @@
+package dev.woge.development
+
+import kotlin.time.Duration
+
+@ExperimentalWogeDevelopmentApi
+public enum class DevelopmentChangeKind {
+    KOTLIN_SOURCE,
+    GENERATED_SOURCE,
+    CSS,
+    FRONTEND_MODULE,
+    BUILD_CONFIGURATION,
+    UNKNOWN,
+}
+
+/** One semantic input change. Content and absolute workstation paths are intentionally absent. */
+@ExperimentalWogeDevelopmentApi
+public data class DevelopmentChange(
+    public val kind: DevelopmentChangeKind,
+    public val path: DevelopmentSourcePath? = null,
+)
+
+@ExperimentalWogeDevelopmentApi
+public sealed interface DevelopmentEvent
+
+@ExperimentalWogeDevelopmentApi
+public sealed interface DevelopmentBuildEvent : DevelopmentEvent {
+    public val buildId: BuildId
+}
+
+@ExperimentalWogeDevelopmentApi
+public sealed interface DevelopmentBuildTerminalEvent : DevelopmentBuildEvent
+
+@ExperimentalWogeDevelopmentApi
+public data class BuildStarted(
+    override val buildId: BuildId,
+    public val changes: Set<DevelopmentChange>,
+) : DevelopmentBuildEvent
+
+@ExperimentalWogeDevelopmentApi
+public data class BuildSucceeded(
+    override val buildId: BuildId,
+    public val duration: Duration,
+    public val requiredReload: ReloadLevel,
+) : DevelopmentBuildTerminalEvent {
+    init {
+        requireValidDuration(duration)
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class BuildFailed(
+    override val buildId: BuildId,
+    public val duration: Duration,
+    public val diagnostics: List<DevelopmentDiagnostic>,
+) : DevelopmentBuildTerminalEvent {
+    init {
+        requireValidDuration(duration)
+        require(diagnostics.isNotEmpty()) { "A failed build must contain at least one structured diagnostic" }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public enum class BuildCancellationReason {
+    SUPERSEDED,
+    REQUESTED,
+    SESSION_STOPPING,
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class BuildCancelled(
+    override val buildId: BuildId,
+    public val reason: BuildCancellationReason,
+) : DevelopmentBuildTerminalEvent
+
+/** A server restart has started or a newer restart request superseded the previous request. */
+@ExperimentalWogeDevelopmentApi
+public data class ServerRestarting(
+    public val buildId: BuildId,
+    public val expectedGeneration: ServerGeneration,
+    public val level: ReloadLevel,
+) : DevelopmentEvent {
+    init {
+        require(level.satisfies(ReloadLevel.SERVER_RESTART)) {
+            "A server restart must use SERVER_RESTART or COLD_RESTART"
+        }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class ServerReady(
+    public val buildId: BuildId,
+    public val generation: ServerGeneration,
+    public val urls: List<DevelopmentUrl>,
+) : DevelopmentEvent {
+    init {
+        require(urls.isNotEmpty()) { "A ready development server must expose at least one local URL" }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class CssChanged(
+    public val buildId: BuildId,
+    public val resources: Set<DevelopmentSourcePath>,
+) : DevelopmentEvent {
+    init {
+        require(resources.isNotEmpty()) { "A CSS change must identify at least one resource" }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class FrontendChanged(
+    public val buildId: BuildId,
+    public val modules: Set<DevelopmentSourcePath>,
+) : DevelopmentEvent {
+    init {
+        require(modules.isNotEmpty()) { "A frontend change must identify at least one module" }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data class ReloadRequired(
+    public val buildId: BuildId,
+    public val minimumLevel: ReloadLevel,
+) : DevelopmentEvent
+
+@ExperimentalWogeDevelopmentApi
+public data class ReloadApplied(
+    public val buildId: BuildId,
+    public val level: ReloadLevel,
+) : DevelopmentEvent {
+    init {
+        require(!level.satisfies(ReloadLevel.SERVER_RESTART)) {
+            "Server restart completion must be reported with ServerReady"
+        }
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public data object DevelopmentSessionStopped : DevelopmentEvent
+
+private fun requireValidDuration(duration: Duration) {
+    require(duration.isFinite() && !duration.isNegative()) { "Build duration must be finite and non-negative" }
+}

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentLifecycle.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentLifecycle.kt
@@ -1,0 +1,364 @@
+package dev.woge.development
+
+/** Pure state transition function shared by all Woge development-tool adapters. */
+@ExperimentalWogeDevelopmentApi
+@Suppress("TooManyFunctions")
+public object DevelopmentLifecycle {
+    public fun reduce(
+        state: DevelopmentSessionState,
+        event: DevelopmentEvent,
+    ): DevelopmentTransition {
+        if (state.phase == DevelopmentSessionPhase.STOPPED) {
+            return rejected(state, DevelopmentTransitionReason.SESSION_STOPPED)
+        }
+        return when (event) {
+            is BuildStarted -> reduceBuildStarted(state, event)
+            is BuildSucceeded -> reduceBuildSucceeded(state, event)
+            is BuildFailed -> reduceBuildFailed(state, event)
+            is BuildCancelled -> reduceBuildCancelled(state, event)
+            is ServerRestarting -> reduceServerRestarting(state, event)
+            is ServerReady -> reduceServerReady(state, event)
+            is CssChanged -> reduceCssChanged(state, event)
+            is FrontendChanged -> reduceFrontendChanged(state, event)
+            is ReloadRequired -> reduceReloadRequired(state, event)
+            is ReloadApplied -> reduceReloadApplied(state, event)
+            DevelopmentSessionStopped -> reduceStopped(state)
+        }
+    }
+
+    private fun reduceBuildStarted(
+        state: DevelopmentSessionState,
+        event: BuildStarted,
+    ): DevelopmentTransition {
+        val latest = state.latestRequestedBuild
+        if (latest != null && event.buildId <= latest) {
+            return stale(state, DevelopmentTransitionReason.STALE_BUILD)
+        }
+        val coalescedChanges =
+            if (state.activeBuild == null) {
+                event.changes.toSet()
+            } else {
+                state.activeChanges + event.changes
+            }
+        return applied(
+            DevelopmentSessionState(
+                phase = DevelopmentSessionPhase.BUILDING,
+                latestRequestedBuild = event.buildId,
+                activeBuild = event.buildId,
+                activeChanges = coalescedChanges,
+                latestBuildOutcome = null,
+                lastSuccessfulBuild = state.lastSuccessfulBuild,
+                activeServerGeneration = state.activeServerGeneration,
+                pendingServerGeneration = null,
+                diagnostics = emptyList(),
+                pendingReload = null,
+                developmentUrls = state.developmentUrls,
+            ),
+        )
+    }
+
+    private fun reduceBuildSucceeded(
+        state: DevelopmentSessionState,
+        event: BuildSucceeded,
+    ): DevelopmentTransition =
+        withActiveBuild(state, event.buildId) {
+            applied(
+                DevelopmentSessionState(
+                    phase = DevelopmentSessionPhase.RELOAD_PENDING,
+                    latestRequestedBuild = state.latestRequestedBuild,
+                    activeBuild = null,
+                    activeChanges = emptySet(),
+                    latestBuildOutcome = event,
+                    lastSuccessfulBuild = event.buildId,
+                    activeServerGeneration = state.activeServerGeneration,
+                    pendingServerGeneration = null,
+                    diagnostics = emptyList(),
+                    pendingReload = event.requiredReload,
+                    developmentUrls = state.developmentUrls,
+                ),
+            )
+        }
+
+    private fun reduceBuildFailed(
+        state: DevelopmentSessionState,
+        event: BuildFailed,
+    ): DevelopmentTransition =
+        withActiveBuild(state, event.buildId) {
+            val stableEvent = event.copy(diagnostics = event.diagnostics.toList())
+            applied(
+                DevelopmentSessionState(
+                    phase = DevelopmentSessionPhase.BUILD_FAILED,
+                    latestRequestedBuild = state.latestRequestedBuild,
+                    activeBuild = null,
+                    activeChanges = emptySet(),
+                    latestBuildOutcome = stableEvent,
+                    lastSuccessfulBuild = state.lastSuccessfulBuild,
+                    activeServerGeneration = state.activeServerGeneration,
+                    pendingServerGeneration = null,
+                    diagnostics = stableEvent.diagnostics,
+                    pendingReload = null,
+                    developmentUrls = state.developmentUrls,
+                ),
+            )
+        }
+
+    private fun reduceBuildCancelled(
+        state: DevelopmentSessionState,
+        event: BuildCancelled,
+    ): DevelopmentTransition =
+        withActiveBuild(state, event.buildId) {
+            applied(
+                DevelopmentSessionState(
+                    phase = restingPhase(state),
+                    latestRequestedBuild = state.latestRequestedBuild,
+                    activeBuild = null,
+                    activeChanges = emptySet(),
+                    latestBuildOutcome = event,
+                    lastSuccessfulBuild = state.lastSuccessfulBuild,
+                    activeServerGeneration = state.activeServerGeneration,
+                    pendingServerGeneration = state.pendingServerGeneration,
+                    diagnostics = emptyList(),
+                    pendingReload = state.pendingReload,
+                    developmentUrls = state.developmentUrls,
+                ),
+            )
+        }
+
+    private fun reduceServerRestarting(
+        state: DevelopmentSessionState,
+        event: ServerRestarting,
+    ): DevelopmentTransition =
+        withCurrentSuccessfulBuild(state, event.buildId) {
+            val activeGeneration = state.activeServerGeneration
+            val pendingGeneration = state.pendingServerGeneration
+            if (isStaleGeneration(event.expectedGeneration, activeGeneration, pendingGeneration)) {
+                stale(state, DevelopmentTransitionReason.STALE_SERVER_GENERATION)
+            } else {
+                applied(
+                    DevelopmentSessionState(
+                        phase = DevelopmentSessionPhase.SERVER_RESTARTING,
+                        latestRequestedBuild = state.latestRequestedBuild,
+                        activeBuild = null,
+                        activeChanges = emptySet(),
+                        latestBuildOutcome = state.latestBuildOutcome,
+                        lastSuccessfulBuild = state.lastSuccessfulBuild,
+                        activeServerGeneration = state.activeServerGeneration,
+                        pendingServerGeneration = event.expectedGeneration,
+                        diagnostics = state.diagnostics,
+                        pendingReload = safest(state.pendingReload, event.level),
+                        developmentUrls = state.developmentUrls,
+                    ),
+                )
+            }
+        }
+
+    private fun reduceServerReady(
+        state: DevelopmentSessionState,
+        event: ServerReady,
+    ): DevelopmentTransition =
+        withCurrentSuccessfulBuild(state, event.buildId) {
+            val activeGeneration = state.activeServerGeneration
+            if (activeGeneration != null && event.generation <= activeGeneration) {
+                return@withCurrentSuccessfulBuild stale(
+                    state,
+                    DevelopmentTransitionReason.STALE_SERVER_GENERATION,
+                )
+            }
+            val pendingGeneration =
+                state.pendingServerGeneration
+                    ?: return@withCurrentSuccessfulBuild rejected(
+                        state,
+                        DevelopmentTransitionReason.SERVER_GENERATION_NOT_REQUESTED,
+                    )
+            when {
+                event.generation < pendingGeneration ->
+                    stale(state, DevelopmentTransitionReason.STALE_SERVER_GENERATION)
+
+                event.generation > pendingGeneration ->
+                    rejected(state, DevelopmentTransitionReason.SERVER_GENERATION_NOT_REQUESTED)
+
+                else ->
+                    applied(
+                        DevelopmentSessionState(
+                            phase = DevelopmentSessionPhase.READY,
+                            latestRequestedBuild = state.latestRequestedBuild,
+                            activeBuild = null,
+                            activeChanges = emptySet(),
+                            latestBuildOutcome = state.latestBuildOutcome,
+                            lastSuccessfulBuild = state.lastSuccessfulBuild,
+                            activeServerGeneration = event.generation,
+                            pendingServerGeneration = null,
+                            diagnostics = emptyList(),
+                            pendingReload = null,
+                            developmentUrls = event.urls.distinct(),
+                        ),
+                    )
+            }
+        }
+
+    private fun reduceCssChanged(
+        state: DevelopmentSessionState,
+        event: CssChanged,
+    ): DevelopmentTransition =
+        withCurrentSuccessfulBuild(state, event.buildId) {
+            requireReload(state, ReloadLevel.HOT_ASSET)
+        }
+
+    private fun reduceFrontendChanged(
+        state: DevelopmentSessionState,
+        event: FrontendChanged,
+    ): DevelopmentTransition =
+        withCurrentSuccessfulBuild(state, event.buildId) {
+            requireReload(state, ReloadLevel.HOT_FRONTEND_MODULE)
+        }
+
+    private fun reduceReloadRequired(
+        state: DevelopmentSessionState,
+        event: ReloadRequired,
+    ): DevelopmentTransition =
+        withCurrentSuccessfulBuild(state, event.buildId) {
+            requireReload(state, event.minimumLevel)
+        }
+
+    private fun reduceReloadApplied(
+        state: DevelopmentSessionState,
+        event: ReloadApplied,
+    ): DevelopmentTransition =
+        withCurrentSuccessfulBuild(state, event.buildId) {
+            if (state.activeServerGeneration == null) {
+                return@withCurrentSuccessfulBuild rejected(state, DevelopmentTransitionReason.SERVER_NOT_READY)
+            }
+            val pendingReload =
+                state.pendingReload
+                    ?: return@withCurrentSuccessfulBuild rejected(state, DevelopmentTransitionReason.NO_RELOAD_PENDING)
+            if (!event.level.satisfies(pendingReload)) {
+                return@withCurrentSuccessfulBuild rejected(
+                    state,
+                    DevelopmentTransitionReason.RELOAD_LEVEL_TOO_WEAK,
+                )
+            }
+            applied(
+                DevelopmentSessionState(
+                    phase = DevelopmentSessionPhase.READY,
+                    latestRequestedBuild = state.latestRequestedBuild,
+                    activeBuild = null,
+                    activeChanges = emptySet(),
+                    latestBuildOutcome = state.latestBuildOutcome,
+                    lastSuccessfulBuild = state.lastSuccessfulBuild,
+                    activeServerGeneration = state.activeServerGeneration,
+                    pendingServerGeneration = null,
+                    diagnostics = emptyList(),
+                    pendingReload = null,
+                    developmentUrls = state.developmentUrls,
+                ),
+            )
+        }
+
+    private fun reduceStopped(state: DevelopmentSessionState): DevelopmentTransition =
+        applied(
+            DevelopmentSessionState(
+                phase = DevelopmentSessionPhase.STOPPED,
+                latestRequestedBuild = state.latestRequestedBuild,
+                activeBuild = null,
+                activeChanges = emptySet(),
+                latestBuildOutcome = state.latestBuildOutcome,
+                lastSuccessfulBuild = state.lastSuccessfulBuild,
+                activeServerGeneration = null,
+                pendingServerGeneration = null,
+                diagnostics = emptyList(),
+                pendingReload = null,
+                developmentUrls = emptyList(),
+            ),
+        )
+
+    private fun requireReload(
+        state: DevelopmentSessionState,
+        level: ReloadLevel,
+    ): DevelopmentTransition =
+        applied(
+            DevelopmentSessionState(
+                phase =
+                    if (state.pendingServerGeneration == null) {
+                        DevelopmentSessionPhase.RELOAD_PENDING
+                    } else {
+                        DevelopmentSessionPhase.SERVER_RESTARTING
+                    },
+                latestRequestedBuild = state.latestRequestedBuild,
+                activeBuild = null,
+                activeChanges = emptySet(),
+                latestBuildOutcome = state.latestBuildOutcome,
+                lastSuccessfulBuild = state.lastSuccessfulBuild,
+                activeServerGeneration = state.activeServerGeneration,
+                pendingServerGeneration = state.pendingServerGeneration,
+                diagnostics = state.diagnostics,
+                pendingReload = safest(state.pendingReload, level),
+                developmentUrls = state.developmentUrls,
+            ),
+        )
+
+    private fun withActiveBuild(
+        state: DevelopmentSessionState,
+        buildId: BuildId,
+        block: () -> DevelopmentTransition,
+    ): DevelopmentTransition {
+        val latest =
+            state.latestRequestedBuild
+                ?: return rejected(state, DevelopmentTransitionReason.BUILD_NOT_REQUESTED)
+        return when {
+            buildId < latest -> stale(state, DevelopmentTransitionReason.STALE_BUILD)
+            buildId > latest -> rejected(state, DevelopmentTransitionReason.BUILD_NOT_REQUESTED)
+            state.activeBuild != buildId -> rejected(state, DevelopmentTransitionReason.BUILD_NOT_ACTIVE)
+            else -> block()
+        }
+    }
+
+    private fun withCurrentSuccessfulBuild(
+        state: DevelopmentSessionState,
+        buildId: BuildId,
+        block: () -> DevelopmentTransition,
+    ): DevelopmentTransition {
+        val latest =
+            state.latestRequestedBuild
+                ?: return rejected(state, DevelopmentTransitionReason.BUILD_NOT_REQUESTED)
+        return when {
+            buildId < latest -> stale(state, DevelopmentTransitionReason.STALE_BUILD)
+            buildId > latest -> rejected(state, DevelopmentTransitionReason.BUILD_NOT_REQUESTED)
+            state.lastSuccessfulBuild != buildId ->
+                rejected(state, DevelopmentTransitionReason.BUILD_NOT_SUCCESSFUL)
+
+            else -> block()
+        }
+    }
+
+    private fun isStaleGeneration(
+        expected: ServerGeneration,
+        active: ServerGeneration?,
+        pending: ServerGeneration?,
+    ): Boolean = listOfNotNull(active, pending).any { expected <= it }
+
+    private fun restingPhase(state: DevelopmentSessionState): DevelopmentSessionPhase =
+        when {
+            state.pendingServerGeneration != null -> DevelopmentSessionPhase.SERVER_RESTARTING
+            state.pendingReload != null -> DevelopmentSessionPhase.RELOAD_PENDING
+            state.activeServerGeneration != null -> DevelopmentSessionPhase.READY
+            else -> DevelopmentSessionPhase.IDLE
+        }
+
+    private fun safest(
+        current: ReloadLevel?,
+        requested: ReloadLevel,
+    ): ReloadLevel = current?.let { ReloadLevel.safest(it, requested) } ?: requested
+
+    private fun applied(state: DevelopmentSessionState): DevelopmentTransition =
+        DevelopmentTransition(state, DevelopmentEventDisposition.APPLIED, null)
+
+    private fun stale(
+        state: DevelopmentSessionState,
+        reason: DevelopmentTransitionReason,
+    ): DevelopmentTransition = DevelopmentTransition(state, DevelopmentEventDisposition.IGNORED_STALE, reason)
+
+    private fun rejected(
+        state: DevelopmentSessionState,
+        reason: DevelopmentTransitionReason,
+    ): DevelopmentTransition = DevelopmentTransition(state, DevelopmentEventDisposition.REJECTED, reason)
+}

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentSessionState.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentSessionState.kt
@@ -1,0 +1,94 @@
+package dev.woge.development
+
+@ExperimentalWogeDevelopmentApi
+public enum class DevelopmentSessionPhase {
+    IDLE,
+    BUILDING,
+    BUILD_FAILED,
+    RELOAD_PENDING,
+    SERVER_RESTARTING,
+    READY,
+    STOPPED,
+}
+
+/** Immutable status snapshot reduced from ordered [DevelopmentEvent] values. */
+@ExperimentalWogeDevelopmentApi
+@Suppress("LongParameterList")
+public class DevelopmentSessionState internal constructor(
+    public val phase: DevelopmentSessionPhase,
+    public val latestRequestedBuild: BuildId?,
+    public val activeBuild: BuildId?,
+    public val activeChanges: Set<DevelopmentChange>,
+    public val latestBuildOutcome: DevelopmentBuildTerminalEvent?,
+    public val lastSuccessfulBuild: BuildId?,
+    public val activeServerGeneration: ServerGeneration?,
+    public val pendingServerGeneration: ServerGeneration?,
+    public val diagnostics: List<DevelopmentDiagnostic>,
+    public val pendingReload: ReloadLevel?,
+    public val developmentUrls: List<DevelopmentUrl>,
+) {
+    /** Whether an earlier valid application remains available, including while a later build fails. */
+    public val hasLastValidApplication: Boolean
+        get() = activeServerGeneration != null && developmentUrls.isNotEmpty()
+
+    override fun toString(): String =
+        "DevelopmentSessionState(" +
+            "phase=$phase, " +
+            "latestRequestedBuild=$latestRequestedBuild, " +
+            "activeBuild=$activeBuild, " +
+            "lastSuccessfulBuild=$lastSuccessfulBuild, " +
+            "activeServerGeneration=$activeServerGeneration, " +
+            "pendingServerGeneration=$pendingServerGeneration, " +
+            "diagnosticCount=${diagnostics.size}, " +
+            "pendingReload=$pendingReload, " +
+            "developmentUrlCount=${developmentUrls.size})"
+
+    public companion object {
+        public fun initial(): DevelopmentSessionState =
+            DevelopmentSessionState(
+                phase = DevelopmentSessionPhase.IDLE,
+                latestRequestedBuild = null,
+                activeBuild = null,
+                activeChanges = emptySet(),
+                latestBuildOutcome = null,
+                lastSuccessfulBuild = null,
+                activeServerGeneration = null,
+                pendingServerGeneration = null,
+                diagnostics = emptyList(),
+                pendingReload = null,
+                developmentUrls = emptyList(),
+            )
+    }
+}
+
+@ExperimentalWogeDevelopmentApi
+public enum class DevelopmentEventDisposition {
+    APPLIED,
+    IGNORED_STALE,
+    REJECTED,
+}
+
+@ExperimentalWogeDevelopmentApi
+public enum class DevelopmentTransitionReason {
+    SESSION_STOPPED,
+    STALE_BUILD,
+    BUILD_NOT_REQUESTED,
+    BUILD_NOT_ACTIVE,
+    BUILD_NOT_SUCCESSFUL,
+    STALE_SERVER_GENERATION,
+    SERVER_GENERATION_NOT_REQUESTED,
+    SERVER_NOT_READY,
+    NO_RELOAD_PENDING,
+    RELOAD_LEVEL_TOO_WEAK,
+}
+
+/** Result of reducing one event. Rejected or stale events always retain the original state instance. */
+@ExperimentalWogeDevelopmentApi
+public class DevelopmentTransition internal constructor(
+    public val state: DevelopmentSessionState,
+    public val disposition: DevelopmentEventDisposition,
+    public val reason: DevelopmentTransitionReason?,
+) {
+    public val wasApplied: Boolean
+        get() = disposition == DevelopmentEventDisposition.APPLIED
+}

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentValues.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/DevelopmentValues.kt
@@ -1,0 +1,112 @@
+package dev.woge.development
+
+import java.net.URI
+
+/** Monotonic identity of one requested development build. */
+@ExperimentalWogeDevelopmentApi
+@JvmInline
+public value class BuildId private constructor(
+    public val value: Long,
+) : Comparable<BuildId> {
+    override fun compareTo(other: BuildId): Int = value.compareTo(other.value)
+
+    public companion object {
+        public val FIRST: BuildId = BuildId(1)
+
+        public fun of(value: Long): BuildId {
+            require(value > 0) { "Build ID must be positive" }
+            return BuildId(value)
+        }
+
+        public fun after(previous: BuildId): BuildId {
+            require(previous.value < Long.MAX_VALUE) { "Build ID overflow requires a new development session" }
+            return BuildId(previous.value + 1)
+        }
+    }
+}
+
+/** Monotonic identity of one ready server process within a development session. */
+@ExperimentalWogeDevelopmentApi
+@JvmInline
+public value class ServerGeneration private constructor(
+    public val value: Long,
+) : Comparable<ServerGeneration> {
+    override fun compareTo(other: ServerGeneration): Int = value.compareTo(other.value)
+
+    public companion object {
+        public val FIRST: ServerGeneration = ServerGeneration(1)
+
+        public fun of(value: Long): ServerGeneration {
+            require(value > 0) { "Server generation must be positive" }
+            return ServerGeneration(value)
+        }
+
+        public fun after(previous: ServerGeneration): ServerGeneration {
+            require(previous.value < Long.MAX_VALUE) {
+                "Server generation overflow requires a new development session"
+            }
+            return ServerGeneration(previous.value + 1)
+        }
+    }
+}
+
+/** A repository-relative path safe to expose in development diagnostics. */
+@ExperimentalWogeDevelopmentApi
+@JvmInline
+public value class DevelopmentSourcePath private constructor(
+    public val value: String,
+) {
+    public companion object {
+        public fun of(value: String): DevelopmentSourcePath {
+            require(value.isNotBlank() && value.length <= MAX_SOURCE_PATH_LENGTH) {
+                "Development source path must contain 1 to $MAX_SOURCE_PATH_LENGTH characters"
+            }
+            require(!value.startsWith('/') && !WINDOWS_ABSOLUTE_PATH.matches(value)) {
+                "Development source path must be repository-relative"
+            }
+            require(value.split('/', '\\').none { it == ".." }) {
+                "Development source path must not traverse parent directories"
+            }
+            require(value.none(Char::isISOControl)) { "Development source path must not contain control characters" }
+            return DevelopmentSourcePath(value)
+        }
+    }
+}
+
+/** A loopback HTTP URL exposed by a local development session. */
+@ExperimentalWogeDevelopmentApi
+@JvmInline
+public value class DevelopmentUrl private constructor(
+    public val value: String,
+) {
+    public companion object {
+        public fun local(value: String): DevelopmentUrl {
+            val uri =
+                runCatching { URI(value) }
+                    .getOrElse { throw IllegalArgumentException("Invalid development URL", it) }
+            require(uri.isAbsolute && uri.scheme.lowercase() in HTTP_SCHEMES) {
+                "Development URL must use HTTP or HTTPS"
+            }
+            require(uri.rawUserInfo == null && uri.rawQuery == null && uri.rawFragment == null) {
+                "Development URL must not contain user information, a query or a fragment"
+            }
+            val host = requireNotNull(uri.host) { "Development URL must contain a host" }.lowercase()
+            require(host == "localhost" || host.endsWith(".localhost") || host in LOOPBACK_ADDRESSES) {
+                "Development URL must use a loopback host"
+            }
+            return DevelopmentUrl(uri.toASCIIString())
+        }
+    }
+}
+
+private const val MAX_SOURCE_PATH_LENGTH: Int = 512
+private val WINDOWS_ABSOLUTE_PATH: Regex = Regex("^[A-Za-z]:[\\\\/].*")
+private val HTTP_SCHEMES: Set<String> = setOf("http", "https")
+private val LOOPBACK_ADDRESSES: Set<String> =
+    setOf(
+        "127.0.0.1",
+        "::1",
+        "[::1]",
+        "0:0:0:0:0:0:0:1",
+        "[0:0:0:0:0:0:0:1]",
+    )

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/ExperimentalWogeDevelopmentApi.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/ExperimentalWogeDevelopmentApi.kt
@@ -1,0 +1,20 @@
+package dev.woge.development
+
+/**
+ * Marks Woge's internal development-tooling contract.
+ *
+ * The contract is shared by Woge-owned tooling adapters, but it is not a stable application API and
+ * is deliberately not published as a production dependency.
+ */
+@RequiresOptIn(
+    message = "Woge development tooling is experimental and must not be used by production application code.",
+    level = RequiresOptIn.Level.WARNING,
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+)
+public annotation class ExperimentalWogeDevelopmentApi

--- a/modules/woge-dev-model/src/main/kotlin/dev/woge/development/ReloadLevel.kt
+++ b/modules/woge-dev-model/src/main/kotlin/dev/woge/development/ReloadLevel.kt
@@ -1,0 +1,28 @@
+package dev.woge.development
+
+/**
+ * Correctness-ordered ways to expose a successful change.
+ *
+ * Each following value is a more expensive but more generally correct fallback. Tooling may select
+ * a cheaper value only after proving it safe for the observed change.
+ */
+@ExperimentalWogeDevelopmentApi
+public enum class ReloadLevel {
+    HOT_ASSET,
+    HOT_FRONTEND_MODULE,
+    DOCUMENT_REFRESH,
+    SERVER_RESTART,
+    COLD_RESTART,
+    ;
+
+    public fun fallback(): ReloadLevel? = entries.getOrNull(ordinal + 1)
+
+    public fun satisfies(required: ReloadLevel): Boolean = ordinal >= required.ordinal
+
+    public companion object {
+        public fun safest(
+            first: ReloadLevel,
+            second: ReloadLevel,
+        ): ReloadLevel = if (first.satisfies(second)) first else second
+    }
+}

--- a/modules/woge-dev-model/src/test/kotlin/dev/woge/development/DevelopmentCapabilitiesTest.kt
+++ b/modules/woge-dev-model/src/test/kotlin/dev/woge/development/DevelopmentCapabilitiesTest.kt
@@ -1,0 +1,22 @@
+package dev.woge.development
+
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalWogeDevelopmentApi::class)
+class DevelopmentCapabilitiesTest {
+    @Test
+    fun `capability requests keep reload and restart commands distinct`() {
+        AwaitBuildRequest(afterBuild = BuildId.FIRST, timeout = 30.seconds)
+        DevelopmentReloadCommand(BuildId.FIRST, ReloadLevel.DOCUMENT_REFRESH)
+        DevelopmentRestartCommand(BuildId.FIRST, ReloadLevel.SERVER_RESTART)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            DevelopmentReloadCommand(BuildId.FIRST, ReloadLevel.SERVER_RESTART)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DevelopmentRestartCommand(BuildId.FIRST, ReloadLevel.DOCUMENT_REFRESH)
+        }
+    }
+}

--- a/modules/woge-dev-model/src/test/kotlin/dev/woge/development/DevelopmentLifecycleTest.kt
+++ b/modules/woge-dev-model/src/test/kotlin/dev/woge/development/DevelopmentLifecycleTest.kt
@@ -1,0 +1,216 @@
+package dev.woge.development
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalWogeDevelopmentApi::class)
+class DevelopmentLifecycleTest {
+    @Test
+    fun `rapid saves coalesce changes and stale success cannot replace the newest build`() {
+        val buildOne = BuildId.FIRST
+        val buildTwo = BuildId.after(buildOne)
+        val kotlinChange = DevelopmentChange(DevelopmentChangeKind.KOTLIN_SOURCE, source("src/main/Page.kt"))
+        val cssChange = DevelopmentChange(DevelopmentChangeKind.CSS, source("src/main/site.css"))
+
+        var state = apply(DevelopmentSessionState.initial(), BuildStarted(buildOne, setOf(kotlinChange)))
+        state = apply(state, BuildStarted(buildTwo, setOf(cssChange)))
+        assertEquals(setOf(kotlinChange, cssChange), state.activeChanges)
+
+        val stale =
+            DevelopmentLifecycle.reduce(
+                state,
+                BuildSucceeded(buildOne, 20.milliseconds, ReloadLevel.SERVER_RESTART),
+            )
+        assertEquals(DevelopmentEventDisposition.IGNORED_STALE, stale.disposition)
+        assertEquals(DevelopmentTransitionReason.STALE_BUILD, stale.reason)
+        assertSame(state, stale.state)
+
+        val outOfOrder =
+            DevelopmentLifecycle.reduce(
+                state,
+                BuildSucceeded(BuildId.after(buildTwo), 20.milliseconds, ReloadLevel.SERVER_RESTART),
+            )
+        assertEquals(DevelopmentEventDisposition.REJECTED, outOfOrder.disposition)
+        assertEquals(DevelopmentTransitionReason.BUILD_NOT_REQUESTED, outOfOrder.reason)
+        assertSame(state, outOfOrder.state)
+
+        state = apply(state, BuildSucceeded(buildTwo, 30.milliseconds, ReloadLevel.HOT_ASSET))
+        assertEquals(buildTwo, state.lastSuccessfulBuild)
+        assertEquals(ReloadLevel.HOT_ASSET, state.pendingReload)
+        assertEquals(DevelopmentSessionPhase.RELOAD_PENDING, state.phase)
+    }
+
+    @Test
+    fun `a failed replacement build keeps the last ready application and structured diagnostics`() {
+        val buildOne = BuildId.FIRST
+        val buildTwo = BuildId.after(buildOne)
+        var state = readyState(buildOne, ServerGeneration.FIRST)
+
+        state = apply(state, BuildStarted(buildTwo, setOf(DevelopmentChange(DevelopmentChangeKind.KOTLIN_SOURCE))))
+        val diagnostic = compileDiagnostic()
+        state = apply(state, BuildFailed(buildTwo, 50.milliseconds, listOf(diagnostic)))
+
+        assertEquals(DevelopmentSessionPhase.BUILD_FAILED, state.phase)
+        assertEquals(buildOne, state.lastSuccessfulBuild)
+        assertEquals(ServerGeneration.FIRST, state.activeServerGeneration)
+        assertEquals(listOf(diagnostic), state.diagnostics)
+        assertTrue(state.hasLastValidApplication)
+        assertEquals(listOf(localUrl()), state.developmentUrls)
+
+        val staleReady =
+            DevelopmentLifecycle.reduce(
+                state,
+                ServerReady(buildOne, ServerGeneration.after(ServerGeneration.FIRST), listOf(localUrl())),
+            )
+        assertEquals(DevelopmentEventDisposition.IGNORED_STALE, staleReady.disposition)
+        assertSame(state, staleReady.state)
+    }
+
+    @Test
+    fun `cancellation retains the previous application and late completion is rejected`() {
+        val buildOne = BuildId.FIRST
+        val buildTwo = BuildId.after(buildOne)
+        var state = readyState(buildOne, ServerGeneration.FIRST)
+        state = apply(state, BuildStarted(buildTwo, emptySet()))
+        state = apply(state, BuildCancelled(buildTwo, BuildCancellationReason.REQUESTED))
+
+        assertEquals(DevelopmentSessionPhase.READY, state.phase)
+        assertTrue(state.hasLastValidApplication)
+        assertEquals(buildTwo, state.latestRequestedBuild)
+
+        val lateSuccess =
+            DevelopmentLifecycle.reduce(
+                state,
+                BuildSucceeded(buildTwo, 10.milliseconds, ReloadLevel.SERVER_RESTART),
+            )
+        assertEquals(DevelopmentEventDisposition.REJECTED, lateSuccess.disposition)
+        assertEquals(DevelopmentTransitionReason.BUILD_NOT_ACTIVE, lateSuccess.reason)
+        assertSame(state, lateSuccess.state)
+    }
+
+    @Test
+    fun `restart storms keep only the newest requested generation`() {
+        val build = BuildId.FIRST
+        var state = successfulBuildState(build, ReloadLevel.SERVER_RESTART)
+        val generationOne = ServerGeneration.FIRST
+        val generationTwo = ServerGeneration.after(generationOne)
+        val generationThree = ServerGeneration.after(generationTwo)
+
+        state = apply(state, ServerRestarting(build, generationOne, ReloadLevel.SERVER_RESTART))
+        state = apply(state, ServerRestarting(build, generationTwo, ReloadLevel.SERVER_RESTART))
+        assertEquals(generationTwo, state.pendingServerGeneration)
+
+        val stale = DevelopmentLifecycle.reduce(state, ServerReady(build, generationOne, listOf(localUrl())))
+        assertEquals(DevelopmentEventDisposition.IGNORED_STALE, stale.disposition)
+        assertSame(state, stale.state)
+
+        val unrequested = DevelopmentLifecycle.reduce(state, ServerReady(build, generationThree, listOf(localUrl())))
+        assertEquals(DevelopmentEventDisposition.REJECTED, unrequested.disposition)
+        assertEquals(DevelopmentTransitionReason.SERVER_GENERATION_NOT_REQUESTED, unrequested.reason)
+        assertSame(state, unrequested.state)
+
+        state = apply(state, ServerReady(build, generationTwo, listOf(localUrl())))
+        assertEquals(DevelopmentSessionPhase.READY, state.phase)
+        assertEquals(generationTwo, state.activeServerGeneration)
+        assertNull(state.pendingServerGeneration)
+    }
+
+    @Test
+    fun `semantic frontend events escalate but never weaken a pending reload`() {
+        val build = BuildId.FIRST
+        var state = readyState(build, ServerGeneration.FIRST)
+
+        state = apply(state, CssChanged(build, setOf(source("src/main/site.css"))))
+        assertEquals(ReloadLevel.HOT_ASSET, state.pendingReload)
+        state = apply(state, FrontendChanged(build, setOf(source("src/main/app.js"))))
+        assertEquals(ReloadLevel.HOT_FRONTEND_MODULE, state.pendingReload)
+        state = apply(state, ReloadRequired(build, ReloadLevel.DOCUMENT_REFRESH))
+        assertEquals(ReloadLevel.DOCUMENT_REFRESH, state.pendingReload)
+
+        val tooWeak = DevelopmentLifecycle.reduce(state, ReloadApplied(build, ReloadLevel.HOT_FRONTEND_MODULE))
+        assertEquals(DevelopmentEventDisposition.REJECTED, tooWeak.disposition)
+        assertEquals(DevelopmentTransitionReason.RELOAD_LEVEL_TOO_WEAK, tooWeak.reason)
+        assertSame(state, tooWeak.state)
+
+        state = apply(state, ReloadApplied(build, ReloadLevel.DOCUMENT_REFRESH))
+        assertEquals(DevelopmentSessionPhase.READY, state.phase)
+        assertNull(state.pendingReload)
+    }
+
+    @Test
+    fun `asset events do not supersede a restart already in progress`() {
+        val build = BuildId.FIRST
+        val generation = ServerGeneration.FIRST
+        var state = successfulBuildState(build, ReloadLevel.SERVER_RESTART)
+        state = apply(state, ServerRestarting(build, generation, ReloadLevel.SERVER_RESTART))
+        state = apply(state, CssChanged(build, setOf(source("src/main/site.css"))))
+
+        assertEquals(DevelopmentSessionPhase.SERVER_RESTARTING, state.phase)
+        assertEquals(generation, state.pendingServerGeneration)
+        assertEquals(ReloadLevel.SERVER_RESTART, state.pendingReload)
+    }
+
+    @Test
+    fun `stopped sessions release live endpoints and reject later events`() {
+        val build = BuildId.FIRST
+        var state = readyState(build, ServerGeneration.FIRST)
+        state = apply(state, DevelopmentSessionStopped)
+
+        assertEquals(DevelopmentSessionPhase.STOPPED, state.phase)
+        assertFalse(state.hasLastValidApplication)
+        assertTrue(state.developmentUrls.isEmpty())
+
+        val later = DevelopmentLifecycle.reduce(state, BuildStarted(BuildId.after(build), emptySet()))
+        assertEquals(DevelopmentEventDisposition.REJECTED, later.disposition)
+        assertEquals(DevelopmentTransitionReason.SESSION_STOPPED, later.reason)
+        assertSame(state, later.state)
+    }
+
+    private fun successfulBuildState(
+        buildId: BuildId,
+        reloadLevel: ReloadLevel,
+    ): DevelopmentSessionState {
+        var state = apply(DevelopmentSessionState.initial(), BuildStarted(buildId, emptySet()))
+        state = apply(state, BuildSucceeded(buildId, 25.milliseconds, reloadLevel))
+        return state
+    }
+
+    private fun readyState(
+        buildId: BuildId,
+        generation: ServerGeneration,
+    ): DevelopmentSessionState {
+        var state = successfulBuildState(buildId, ReloadLevel.COLD_RESTART)
+        state = apply(state, ServerRestarting(buildId, generation, ReloadLevel.COLD_RESTART))
+        state = apply(state, ServerReady(buildId, generation, listOf(localUrl())))
+        return state
+    }
+
+    private fun apply(
+        state: DevelopmentSessionState,
+        event: DevelopmentEvent,
+    ): DevelopmentSessionState {
+        val transition = DevelopmentLifecycle.reduce(state, event)
+        assertTrue(
+            transition.wasApplied,
+            "Expected $event to apply, got ${transition.disposition}: ${transition.reason}",
+        )
+        return transition.state
+    }
+
+    private fun compileDiagnostic(): DevelopmentDiagnostic =
+        DevelopmentDiagnostic(
+            DevelopmentDiagnosticCode.of("WOGE-KOTLIN-COMPILE"),
+            DevelopmentDiagnosticSeverity.ERROR,
+            DevelopmentDiagnosticSummary.of("Type mismatch"),
+            DevelopmentSourceLocation(source("src/main/Page.kt"), 4, 12),
+        )
+
+    private fun source(value: String): DevelopmentSourcePath = DevelopmentSourcePath.of(value)
+
+    private fun localUrl(): DevelopmentUrl = DevelopmentUrl.local("http://localhost:8080/")
+}

--- a/modules/woge-dev-model/src/test/kotlin/dev/woge/development/DevelopmentValuesTest.kt
+++ b/modules/woge-dev-model/src/test/kotlin/dev/woge/development/DevelopmentValuesTest.kt
@@ -1,0 +1,74 @@
+package dev.woge.development
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalWogeDevelopmentApi::class)
+class DevelopmentValuesTest {
+    @Test
+    fun `identifiers are positive monotonic and overflow safe`() {
+        assertEquals(BuildId.of(2), BuildId.after(BuildId.FIRST))
+        assertEquals(ServerGeneration.of(2), ServerGeneration.after(ServerGeneration.FIRST))
+        assertThrows(IllegalArgumentException::class.java) { BuildId.of(0) }
+        assertThrows(IllegalArgumentException::class.java) { ServerGeneration.of(-1) }
+        assertThrows(IllegalArgumentException::class.java) { BuildId.after(BuildId.of(Long.MAX_VALUE)) }
+        assertThrows(IllegalArgumentException::class.java) {
+            ServerGeneration.after(ServerGeneration.of(Long.MAX_VALUE))
+        }
+    }
+
+    @Test
+    fun `reload levels form the complete correctness fallback chain`() {
+        assertEquals(ReloadLevel.HOT_FRONTEND_MODULE, ReloadLevel.HOT_ASSET.fallback())
+        assertEquals(ReloadLevel.DOCUMENT_REFRESH, ReloadLevel.HOT_FRONTEND_MODULE.fallback())
+        assertEquals(ReloadLevel.SERVER_RESTART, ReloadLevel.DOCUMENT_REFRESH.fallback())
+        assertEquals(ReloadLevel.COLD_RESTART, ReloadLevel.SERVER_RESTART.fallback())
+        assertNull(ReloadLevel.COLD_RESTART.fallback())
+
+        assertTrue(ReloadLevel.DOCUMENT_REFRESH.satisfies(ReloadLevel.HOT_ASSET))
+        assertFalse(ReloadLevel.HOT_ASSET.satisfies(ReloadLevel.DOCUMENT_REFRESH))
+    }
+
+    @Test
+    fun `development URLs are loopback only`() {
+        assertEquals(
+            "http://localhost:8080/app",
+            DevelopmentUrl.local("http://localhost:8080/app").value,
+        )
+        assertEquals("https://ui.localhost:8443/", DevelopmentUrl.local("https://ui.localhost:8443/").value)
+        assertEquals("http://[::1]:8080/", DevelopmentUrl.local("http://[::1]:8080/").value)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            DevelopmentUrl.local("http://192.168.1.4:8080/")
+        }
+        assertThrows(IllegalArgumentException::class.java) { DevelopmentUrl.local("http://example.com/") }
+        assertThrows(IllegalArgumentException::class.java) { DevelopmentUrl.local("file:///tmp/index.html") }
+        assertThrows(IllegalArgumentException::class.java) {
+            DevelopmentUrl.local("http://user@localhost:8080/")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DevelopmentUrl.local("http://localhost:8080/?token=secret")
+        }
+    }
+
+    @Test
+    fun `diagnostics expose structured relative locations and redact string rendering`() {
+        val diagnostic =
+            DevelopmentDiagnostic(
+                code = DevelopmentDiagnosticCode.of("WOGE-KOTLIN-COMPILE"),
+                severity = DevelopmentDiagnosticSeverity.ERROR,
+                summary = DevelopmentDiagnosticSummary.of("Type mismatch"),
+                location = DevelopmentSourceLocation(DevelopmentSourcePath.of("src/main/App.kt"), 12, 8),
+            )
+
+        assertTrue(diagnostic.toString().contains("WOGE-KOTLIN-COMPILE"))
+        assertFalse(diagnostic.toString().contains("Type mismatch"))
+        assertThrows(IllegalArgumentException::class.java) { DevelopmentSourcePath.of("/Users/me/App.kt") }
+        assertThrows(IllegalArgumentException::class.java) { DevelopmentSourcePath.of("src/../secret.txt") }
+        assertThrows(IllegalArgumentException::class.java) { DevelopmentDiagnosticSummary.of("line one\nline two") }
+    }
+}

--- a/scripts/test-module-boundaries.sh
+++ b/scripts/test-module-boundaries.sh
@@ -77,6 +77,17 @@ printf '\ndependencies {\n    testImplementation(project(":woge-spring-webflux")
   >>"$adapter_fixture/adapters/woge-spring-mvc/build.gradle.kts"
 expect_rejection "$adapter_fixture" "woge-spring-mvc must not depend on woge-spring-webflux"
 
+production_dev_fixture="$scratch_root/production-dev-dependency"
+prepare_fixture "$production_dev_fixture"
+awk -F '\t' -v OFS='\t' '
+  $1 == "woge-core" { $5 = "woge-dev-model" }
+  { print }
+' "$production_dev_fixture/config/architecture/module-boundaries.tsv" >"$production_dev_fixture/module-boundaries.next"
+mv "$production_dev_fixture/module-boundaries.next" "$production_dev_fixture/config/architecture/module-boundaries.tsv"
+printf '\ndependencies {\n    implementation(project(":woge-dev-model"))\n}\n' \
+  >>"$production_dev_fixture/modules/woge-core/build.gradle.kts"
+expect_rejection "$production_dev_fixture" "woge-core (foundation) may not depend on woge-dev-model (tooling-model)"
+
 if (( failure_count > 0 )); then
   printf 'Module-boundary tests failed with %d problem(s).\n' "$failure_count" >&2
   exit 1

--- a/scripts/validate-module-boundaries.sh
+++ b/scripts/validate-module-boundaries.sh
@@ -62,6 +62,7 @@ role_allows() {
     adapter:foundation|adapter:protocol|adapter:port|adapter:runtime) return 0 ;;
     test-support:foundation|test-support:protocol|test-support:port|test-support:runtime) return 0 ;;
     integration:foundation|integration:protocol|integration:port|integration:runtime|integration:adapter|integration:integration) return 0 ;;
+    tooling:foundation|tooling:ui|tooling:protocol|tooling:port|tooling:runtime|tooling:adapter|tooling:integration|tooling:tooling-model) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -75,7 +76,7 @@ while IFS=$'\t' read -r module role exposure source_path dependencies optional_d
   fi
 
   case "$role" in
-    foundation|ui|protocol|port|runtime|adapter|integration|test-support) ;;
+    foundation|ui|protocol|port|runtime|adapter|integration|test-support|tooling-model|tooling) ;;
     *) fail "$module has unknown role '$role'" ;;
   esac
 
@@ -149,14 +150,14 @@ if [[ -s "$edges" ]]; then
   fi
 fi
 
-for module in woge-core woge-ui-headless woge-protocol woge-host-spi woge-server-runtime; do
+for module in woge-core woge-ui-headless woge-protocol woge-host-spi woge-server-runtime woge-dev-model; do
   source_path=$(awk -F '\t' -v name="$module" '$1 == name { print $4; exit }' "$records")
   [[ -n "$source_path" ]] || continue
   [[ -d "$repository_root/$source_path" ]] || continue
   main_source_path="$repository_root/$source_path/src/main"
   [[ -d "$main_source_path" ]] || continue
 
-  forbidden_types='(org\.springframework|reactor\.|jakarta\.servlet|javax\.servlet|io\.ktor)'
+  forbidden_types='(org\.gradle|org\.springframework|reactor\.|jakarta\.servlet|javax\.servlet|io\.ktor|io\.modelcontextprotocol)'
   if command -v rg >/dev/null 2>&1; then
     matches=$(rg -n --glob '*.kt' --glob '*.java' "$forbidden_types" "$main_source_path" || true)
   else


### PR DESCRIPTION
Closes #140

## Summary
- add an internal, experimental development lifecycle model with typed events, monotonic build/generation IDs and a pure reducer
- define the reload correctness chain and structured capability port without host/build/transport types
- preserve last-known-good applications across failed builds and reject stale/out-of-order events
- enforce loopback/redaction/authorization guidance and production dependency isolation
- record ADR 0038 and web-developer-oriented lifecycle documentation

## Verification
- `./gradlew check` (240 tasks, successful)